### PR TITLE
PP-5115: Add ledger Jenkinsfile build configuration

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,143 @@
+#!/usr/bin/env groovy
+
+pipeline {
+  agent any
+
+  parameters {
+    booleanParam(defaultValue: false, description: '', name: 'runEndToEndTestsOnPR')
+  }
+
+  options {
+    ansiColor('xterm')
+    timestamps()
+  }
+
+  libraries {
+    lib("pay-jenkins-library@master")
+  }
+
+  environment {
+    DOCKER_HOST = "unix:///var/run/docker.sock"
+    RUN_END_TO_END_ON_PR = "${params.runEndToEndTestsOnPR}"
+    JAVA_HOME="/usr/lib/jvm/java-1.11.0-openjdk-amd64"
+  }
+
+  stages {
+    stage('Maven Build') {
+      steps {
+        script {
+          long stepBuildTime = System.currentTimeMillis()
+          sh 'mvn -version'
+          sh 'mvn clean verify'
+          runProviderContractTests()
+          postSuccessfulMetrics("ledger.maven-build", stepBuildTime)
+        }
+      }
+      post {
+        failure {
+          postMetric("ledger.maven-build.failure", 1)
+        }
+      }
+    }
+
+    stage('Docker Build') {
+      steps {
+        script {
+          buildAppWithMetrics{
+            app = "ledger"
+          }
+        }
+      }
+      post {
+        failure {
+          postMetric("ledger.docker-build.failure", 1)
+        }
+      }
+    }
+    stage('Tests') {
+      failFast true
+      parallel {
+        stage('Card Payment End-to-End Tests') {
+            when {
+                anyOf {
+                  branch 'master'
+                  environment name: 'RUN_END_TO_END_ON_PR', value: 'true'
+                }
+            }
+            steps {
+                runCardPaymentsE2E("ledger")
+            }
+        }
+      }
+    }
+    stage('Docker Tag') {
+      steps {
+        script {
+          dockerTagWithMetrics {
+            app = "ledger"
+          }
+        }
+      }
+      post {
+        failure {
+          postMetric("ledger.docker-tag.failure", 1)
+        }
+      }
+    }
+    stage('Deploy') {
+      when {
+        branch 'master'
+      }
+      steps {
+        checkPactCompatibility("ledger", gitCommit(), "test")
+        deployEcs("ledger")
+      }
+    }
+    stage('Pact Tag') {
+      when {
+        branch 'master'
+      }
+      steps {
+        echo 'Tagging provider pact with "test"'
+        tagPact("ledger", gitCommit(), "test")
+      }
+    }
+    stage('Smoke Tests') {
+      when {
+        branch 'master'
+      }
+      steps {
+        runDirectDebitSmokeTest()
+      }
+    }
+    stage('Complete') {
+      failFast true
+      parallel {
+        stage('Tag Build') {
+          when {
+            branch 'master'
+          }
+          steps {
+            tagDeployment("ledger")
+          }
+        }
+        stage('Trigger Deploy Notification') {
+          when {
+            branch 'ledger'
+          }
+          steps {
+            triggerGraphiteDeployEvent("ledger")
+          }
+        }
+      }
+    }
+  }
+  post {
+    failure {
+      postMetric(appendBranchSuffix("ledger") + ".failure", 1)
+    }
+    success {
+      postSuccessfulMetrics(appendBranchSuffix("ledger"))
+    }
+  }
+}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -54,7 +54,7 @@ pipeline {
         }
       }
     }
-    stage('Tests') {
+    /*stage('Tests') {
       failFast true
       parallel {
         stage('Card Payment End-to-End Tests') {
@@ -69,7 +69,7 @@ pipeline {
             }
         }
       }
-    }
+    }*/
     stage('Docker Tag') {
       steps {
         script {
@@ -84,7 +84,7 @@ pipeline {
         }
       }
     }
-    stage('Deploy') {
+    /*stage('Deploy') {
       when {
         branch 'master'
       }
@@ -92,8 +92,8 @@ pipeline {
         checkPactCompatibility("ledger", gitCommit(), "test")
         deployEcs("ledger")
       }
-    }
-    stage('Pact Tag') {
+    }*/
+    /*stage('Pact Tag') {
       when {
         branch 'master'
       }
@@ -101,15 +101,15 @@ pipeline {
         echo 'Tagging provider pact with "test"'
         tagPact("ledger", gitCommit(), "test")
       }
-    }
-    stage('Smoke Tests') {
+    }*/
+    /*stage('Smoke Tests') {
       when {
         branch 'master'
       }
       steps {
         runDirectDebitSmokeTest()
       }
-    }
+    }*/
     stage('Complete') {
       failFast true
       parallel {
@@ -118,15 +118,15 @@ pipeline {
             branch 'master'
           }
           steps {
-            tagDeployment("ledger")
+            //tagDeployment("ledger")
           }
         }
         stage('Trigger Deploy Notification') {
           when {
-            branch 'ledger'
+            branch 'master'
           }
           steps {
-            triggerGraphiteDeployEvent("ledger")
+            //triggerGraphiteDeployEvent("ledger")
           }
         }
       }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -110,7 +110,7 @@ pipeline {
         runDirectDebitSmokeTest()
       }
     }*/
-    stage('Complete') {
+    /*stage('Complete') {
       failFast true
       parallel {
         stage('Tag Build') {
@@ -118,7 +118,7 @@ pipeline {
             branch 'master'
           }
           steps {
-            //tagDeployment("ledger")
+            tagDeployment("ledger")
           }
         }
         stage('Trigger Deploy Notification') {
@@ -126,11 +126,11 @@ pipeline {
             branch 'master'
           }
           steps {
-            //triggerGraphiteDeployEvent("ledger")
+            triggerGraphiteDeployEvent("ledger")
           }
         }
       }
-    }
+    }*/
   }
   post {
     failure {


### PR DESCRIPTION
### WHAT:
Adds a Jenkinsfile to build, test and (later) deploy the ledger service.

### How to test & deploy:
The Jenkins CI configuration must be updated in alphagov/pay-chef to scan and build this repository. Once this has been deployed to CI, this application may be built.

