### PR TITLE
Add surefire and failsafe plugins for unit & integration tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -177,6 +177,24 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.0.0-M3</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <version>3.0.0-M3</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
                 <version>3.2.1</version>
                 <configuration>

--- a/src/test/java/uk/gov/pay/ledger/event/EventIT.java
+++ b/src/test/java/uk/gov/pay/ledger/event/EventIT.java
@@ -10,7 +10,7 @@ import javax.ws.rs.core.Response;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 
-public class EventIntegrationTest {
+public class EventIT {
     @ClassRule
     public static AppWithPostgresRule rule = new AppWithPostgresRule();
 


### PR DESCRIPTION
Split the unit & integration tests and name integration tests to match the
default inclusion rules for the failsafe plugin.