### PR TITLE
RED-54: Use PostgreSQL 11.1 container for tests

### DIFF
--- a/src/test/java/uk/gov/pay/ledger/rules/AppWithPostgresRule.java
+++ b/src/test/java/uk/gov/pay/ledger/rules/AppWithPostgresRule.java
@@ -18,7 +18,7 @@ public class AppWithPostgresRule extends ExternalResource {
     private DropwizardAppRule<LedgerConfig> appRule;
 
     public AppWithPostgresRule() {
-        postgres = new PostgreSQLContainer();
+        postgres = new PostgreSQLContainer("postgres:11.1");
         postgres.start();
         appRule = new DropwizardAppRule<>(
                 LedgerApp.class,


### PR DESCRIPTION
**WHAT**
This is the version of PostgreSQL provisioned for the ledger hosting environment. Tests (once written & enabled) should be run using the same version.

**HOW**
This can be tested locally by running:`mvn build verify`. This will run tests using the official postgres 11.1 image.