### PR TITLE
RED-55: Enable CI deploy stage

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -84,7 +84,7 @@ pipeline {
         }
       }
     }
-    /*stage('Deploy') {
+    stage('Deploy') {
       when {
         branch 'master'
       }
@@ -92,7 +92,7 @@ pipeline {
         checkPactCompatibility("ledger", gitCommit(), "test")
         deployEcs("ledger")
       }
-    }*/
+    }
     /*stage('Pact Tag') {
       when {
         branch 'master'
@@ -110,7 +110,7 @@ pipeline {
         runDirectDebitSmokeTest()
       }
     }*/
-    /*stage('Complete') {
+    stage('Complete') {
       failFast true
       parallel {
         stage('Tag Build') {
@@ -130,7 +130,7 @@ pipeline {
           }
         }
       }
-    }*/
+    }
   }
   post {
     failure {


### PR DESCRIPTION
**What it does**
Enables the deploy and complete stages for the Jenkins build process run on CI. Currently this will only run in CI since the deploy instance has not yet been configured with the ledger service.

**How to test**
When changes are pushed to master they should be deployed to the configured environment.