### PR TITLE
PP-5249 Add healthcheeck and db config

### DIFF
--- a/docker-startup.sh
+++ b/docker-startup.sh
@@ -18,7 +18,6 @@ fi
 #java $JAVA_OPTS -jar *-allinone.jar waitOnDependencies *.yaml
 
 if [ "$RUN_MIGRATION" == "true" ]; then
-  java $JAVA_OPTS -jar *-allinone.jar migrateToInitialDbState *.yaml
   java $JAVA_OPTS -jar *-allinone.jar db migrate *.yaml
 fi
 

--- a/src/main/java/uk/gov/pay/ledger/app/LedgerApp.java
+++ b/src/main/java/uk/gov/pay/ledger/app/LedgerApp.java
@@ -14,6 +14,7 @@ import org.jdbi.v3.core.Jdbi;
 import org.jdbi.v3.sqlobject.SqlObjectPlugin;
 import uk.gov.pay.commons.utils.logging.LoggingFilter;
 import uk.gov.pay.ledger.event.EventResource;
+import uk.gov.pay.ledger.healthcheck.HealthCheckResource;
 
 import static java.util.EnumSet.of;
 import static javax.servlet.DispatcherType.REQUEST;
@@ -44,12 +45,7 @@ public class LedgerApp extends Application<LedgerConfig> {
         final Injector injector = Guice.createInjector(new LedgerModule(config, environment, createJdbi(config.getDataSourceFactory())));
 
         environment.jersey().register(injector.getInstance(EventResource.class));
-        environment.healthChecks().register("default", new HealthCheck() {
-            @Override
-            protected Result check() {
-                return Result.healthy();
-            }
-        });
+        environment.jersey().register(injector.getInstance(HealthCheckResource.class));
         environment.servlets().addFilter("LoggingFilter", new LoggingFilter())
                 .addMappingForUrlPatterns(of(REQUEST), true, "/v1/*");
     }

--- a/src/main/java/uk/gov/pay/ledger/healthcheck/HealthCheckResource.java
+++ b/src/main/java/uk/gov/pay/ledger/healthcheck/HealthCheckResource.java
@@ -1,0 +1,32 @@
+package uk.gov.pay.ledger.healthcheck;
+
+import com.codahale.metrics.health.HealthCheck;
+import com.google.inject.Inject;
+import io.dropwizard.setup.Environment;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import java.util.Map;
+import java.util.Set;
+
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+
+@Path("/")
+public class HealthCheckResource {
+
+    private Environment environment;
+
+    @Inject
+    public HealthCheckResource(Environment environment) {
+        this.environment = environment;
+    }
+
+    @GET
+    @Path("healthcheck")
+    @Produces(APPLICATION_JSON)
+    public Set<Map.Entry<String, HealthCheck.Result>> healthCheck() {
+        return environment.healthChecks().runHealthChecks().entrySet();
+
+    }
+}

--- a/src/main/resources/config/config.yaml
+++ b/src/main/resources/config/config.yaml
@@ -1,3 +1,42 @@
+server:
+  applicationConnectors:
+    - type: http
+      port: ${PORT}
+
+database:
+  driverClass: org.postgresql.Driver
+  user: ${DB_USER}
+  password: ${DB_PASSWORD}
+  url: jdbc:postgresql://${DB_HOST}/${DB_NAME:-ledger}?${DB_SSL_OPTION}
+
+  # the maximum amount of time to wait on an empty pool before throwing an maception
+  maxWaitForConnection: 1s
+
+  # the SQL query to run when validating a connection's liveness
+  validationQuery: "SELECT '1'"
+
+  # the timeout before a connection validation queries fail
+  validationQueryTimeout: 2s
+
+  # The initial size of the connection pool
+  initialSize: 4
+
+  # the minimum number of connections to keep open
+  minSize: 4
+
+  # the maximum number of connections to keep open
+  maxSize: 8
+
+  # whether or not idle connections should be validated
+  checkConnectionWhileIdle: false
+
+  # the amount of time to sleep between runs of the idle connection validation, abandoned cleaner and idle pool resizing
+  evictionInterval: 10s
+
+  # the minimum amount of time an connection must sit idle in the pool before it is eligible for eviction
+  minIdleTime: 1 minute
+
+
 logging:
   level: INFO
   appenders:

--- a/src/test/resources/config/test-config.yaml
+++ b/src/test/resources/config/test-config.yaml
@@ -1,8 +1,8 @@
 database:
   driverClass: org.postgresql.Driver
-  user: postgres
-  password: mysecretpassword
-  url: whatever.url:8080
+  user: ${DB_USER}
+  password: ${DB_PASSWORD}
+  url: jdbc:postgresql://${DB_HOST}:5432/ledger?sslfactory=org.postgresql.ssl.DefaultJavaSSLFactory&${DB_SSL_OPTION}
 
   # the maximum amount of time to wait on an empty pool before throwing an exception
   maxWaitForConnection: 1s


### PR DESCRIPTION
Adds healthcheck on 'normal' port rather than the
dropwizard default of admin port.

Adds necessary server + db config to get things moving
and working inpay local.