### PR TITLE
BAU: Disabled Pact compatibility check

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -89,7 +89,7 @@ pipeline {
         branch 'master'
       }
       steps {
-        checkPactCompatibility("ledger", gitCommit(), "test")
+        //checkPactCompatibility("ledger", gitCommit(), "test")
         deployEcs("ledger")
       }
     }


### PR DESCRIPTION
## WHAT
We don't have pact setup for ledger. So `checkPactCompatibility` can be disabled for now