### PR TITLE
PP-5251 Tidy ups

### DIFF
--- a/src/main/java/uk/gov/pay/ledger/transaction/dao/TransactionDao.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/dao/TransactionDao.java
@@ -6,11 +6,11 @@ import org.jdbi.v3.sqlobject.statement.SqlQuery;
 import uk.gov.pay.ledger.transaction.dao.mapper.TransactionMapper;
 import uk.gov.pay.ledger.transaction.model.Transaction;
 
-import java.util.List;
+import java.util.Optional;
 
 @RegisterRowMapper(TransactionMapper.class)
 public interface TransactionDao {
 
-    @SqlQuery("SELECT * FROM transaction WHERE gateway_account_id = :gatewayAccountId")
-    List<Transaction> getByGatewayAccountId(@Bind("gatewayAccountId") String gatewayAccountId);
+    @SqlQuery("SELECT * FROM transaction WHERE external_id = :transaction_id")
+    Optional<Transaction> getById(@Bind("transaction_id") String transactionId);
 }

--- a/src/main/java/uk/gov/pay/ledger/transaction/model/Transaction.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/model/Transaction.java
@@ -2,43 +2,32 @@ package uk.gov.pay.ledger.transaction.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import uk.gov.pay.commons.api.json.ApiResponseDateTimeSerializer;
 
 import java.time.ZonedDateTime;
 
+@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
 public class Transaction {
 
     @JsonIgnore
     private Long id;
-    @JsonIgnore
     private String gatewayAccountId;
-    @JsonProperty
     private Long amount;
-    @JsonProperty
     private String reference;
-    @JsonProperty
     private String description;
-    @JsonProperty("state")
-    private String status;
-    @JsonProperty
+    private String state;
     private String language;
-    @JsonProperty("charge_id")
     private String externalId;
-    @JsonProperty("return_url")
     private String returnUrl;
-    @JsonProperty
     private String email;
-    @JsonProperty("payment_provider")
     private String paymentProvider;
-    @JsonProperty("created_date")
     @JsonSerialize(using = ApiResponseDateTimeSerializer.class)
     private ZonedDateTime createdAt;
-    @JsonProperty("card_details")
     private CardDetails cardDetails;
-    @JsonProperty("delayed_capture")
     private Boolean delayedCapture;
-    @JsonProperty("external_metadata")
     private String externalMetaData;
 
     public Transaction(){
@@ -55,7 +44,7 @@ public class Transaction {
         this.amount = amount;
         this.reference = reference;
         this.description = description;
-        this.status = status;
+        this.state = status;
         this.language = language;
         this.externalId = externalId;
         this.returnUrl = returnUrl;
@@ -88,8 +77,8 @@ public class Transaction {
         return description;
     }
 
-    public String getStatus() {
-        return status;
+    public String getState() {
+        return state;
     }
 
     public String getLanguage() {

--- a/src/main/java/uk/gov/pay/ledger/transaction/resources/TransactionResource.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/resources/TransactionResource.java
@@ -11,7 +11,8 @@ import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
-import java.util.List;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.Response;
 
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 
@@ -27,11 +28,12 @@ public class TransactionResource {
         this.transactionDao = transactionDao;
     }
 
-    @Path("/{gatewayAccountId}")
+    @Path("/{transactionId}")
     @GET
     @Timed
-    public List<Transaction> getByGatewayAccountId(@PathParam("gatewayAccountId") String gatewayAccountId) {
-        LOGGER.info("Get transaction request: {}", gatewayAccountId);
-        return transactionDao.getByGatewayAccountId(gatewayAccountId);
+    public Transaction getById(@PathParam("transactionId") String transactionId) {
+        LOGGER.info("Get transaction request: {}", transactionId);
+        return transactionDao.getById(transactionId)
+                .orElseThrow(() -> new WebApplicationException(Response.Status.NOT_FOUND));
     }
 }

--- a/src/test/java/uk/gov/pay/ledger/transaction/TransactionIntegrationTest.java
+++ b/src/test/java/uk/gov/pay/ledger/transaction/TransactionIntegrationTest.java
@@ -1,19 +1,16 @@
 package uk.gov.pay.ledger.transaction;
 
-import io.restassured.specification.RequestSpecification;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
 import uk.gov.pay.ledger.rules.AppWithPostgresRule;
 import uk.gov.pay.ledger.utils.fixtures.TransactionFixture;
 
-import javax.ws.rs.client.Client;
 import javax.ws.rs.core.Response;
 
 import static io.restassured.RestAssured.given;
 import static io.restassured.http.ContentType.JSON;
 import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.Matchers.hasSize;
 import static uk.gov.pay.ledger.utils.fixtures.TransactionFixture.aTransactionFixture;
 
 public class TransactionIntegrationTest {
@@ -21,7 +18,6 @@ public class TransactionIntegrationTest {
     @ClassRule
     public static AppWithPostgresRule rule = new AppWithPostgresRule();
 
-    private Client client = rule.getAppRule().client();
     private Integer port = rule.getAppRule().getLocalPort();
 
     private TransactionFixture transactionFixture;
@@ -37,19 +33,14 @@ public class TransactionIntegrationTest {
         transactionFixture = aTransactionFixture();
         transactionFixture.insert(rule.getJdbi());
 
-        givenSetup()
-                .get("/v1/transaction/" + transactionFixture.getGatewayAccountId())
+        given().port(port)
+                .contentType(JSON)
+                .get("/v1/transaction/" + transactionFixture.getExternalId())
                 .then()
                 .statusCode(Response.Status.OK.getStatusCode())
                 .contentType(JSON)
-                .body("", hasSize(1))
-                .body("[0].charge_id", is(transactionFixture.getExternalId()))
-                .body("[0].card_details.cardholder_name", is(transactionFixture.getCardDetails().getCardHolderName()))
-                .body("[0].card_details.billing_address.line1", is(transactionFixture.getCardDetails().getBillingAddress().getAddressLine1()));
-    }
-
-    private RequestSpecification givenSetup() {
-        return given().port(port)
-                .contentType(JSON);
+                .body("external_id", is(transactionFixture.getExternalId()))
+                .body("card_details.cardholder_name", is(transactionFixture.getCardDetails().getCardHolderName()))
+                .body("card_details.billing_address.line1", is(transactionFixture.getCardDetails().getBillingAddress().getAddressLine1()));
     }
 }

--- a/src/test/java/uk/gov/pay/ledger/transaction/TransactionResourceTest.java
+++ b/src/test/java/uk/gov/pay/ledger/transaction/TransactionResourceTest.java
@@ -25,7 +25,7 @@ public class TransactionResourceTest {
 
     @Test
     public void shouldReturn404IfTransactionDoesNotExist() {
-        Response response = resources.target("/v1/event/non-existent-id").request().get();
+        Response response = resources.target("/v1/transaction/non-existent-id").request().get();
         assertThat(response.getStatus(), is(404));
     }
 }


### PR DESCRIPTION
- Rename charge_id to external id in Transaction model
- For transactions, change example endpoint and test
to be getById - it was confusing for
GET /v1/transaction/{id}
to return a list filtered by gateway account id
- Use snake case naming strategy in transaction model