### PR TITLE
PP-5256 Transaction search - resource parameter validation

### DIFF
--- a/src/main/java/uk/gov/pay/ledger/app/LedgerApp.java
+++ b/src/main/java/uk/gov/pay/ledger/app/LedgerApp.java
@@ -13,6 +13,7 @@ import org.jdbi.v3.core.Jdbi;
 import org.jdbi.v3.sqlobject.SqlObjectPlugin;
 import uk.gov.pay.commons.utils.logging.LoggingFilter;
 import uk.gov.pay.ledger.event.resources.EventResource;
+import uk.gov.pay.ledger.exception.BadRequestExceptionMapper;
 import uk.gov.pay.ledger.healthcheck.HealthCheckResource;
 import uk.gov.pay.ledger.transaction.resources.TransactionResource;
 
@@ -49,6 +50,7 @@ public class LedgerApp extends Application<LedgerConfig> {
         environment.jersey().register(injector.getInstance(HealthCheckResource.class));
         environment.servlets().addFilter("LoggingFilter", new LoggingFilter())
                 .addMappingForUrlPatterns(of(REQUEST), true, "/v1/*");
+        environment.jersey().register(new BadRequestExceptionMapper());
     }
 
     private Jdbi createJdbi(DataSourceFactory dataSourceFactory) {

--- a/src/main/java/uk/gov/pay/ledger/exception/BadRequestException.java
+++ b/src/main/java/uk/gov/pay/ledger/exception/BadRequestException.java
@@ -1,0 +1,8 @@
+package uk.gov.pay.ledger.exception;
+
+public class BadRequestException extends RuntimeException {
+
+    public BadRequestException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/uk/gov/pay/ledger/exception/BadRequestExceptionMapper.java
+++ b/src/main/java/uk/gov/pay/ledger/exception/BadRequestExceptionMapper.java
@@ -1,0 +1,22 @@
+package uk.gov.pay.ledger.exception;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.gov.pay.commons.model.ErrorIdentifier;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+
+public class BadRequestExceptionMapper implements ExceptionMapper<BadRequestException> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(BadRequestException.class);
+
+    @Override
+    public Response toResponse(BadRequestException exception) {
+        LOGGER.error(exception.getMessage());
+        ErrorResponse errorResponse = new ErrorResponse(ErrorIdentifier.GENERIC, exception.getMessage());
+        return Response.status(400).entity(errorResponse).type(APPLICATION_JSON).build();
+    }
+}

--- a/src/main/java/uk/gov/pay/ledger/exception/ErrorResponse.java
+++ b/src/main/java/uk/gov/pay/ledger/exception/ErrorResponse.java
@@ -1,0 +1,36 @@
+package uk.gov.pay.ledger.exception;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import uk.gov.pay.commons.model.ErrorIdentifier;
+
+import java.util.List;
+
+import static com.fasterxml.jackson.annotation.JsonInclude.Include;
+
+@JsonInclude(Include.NON_NULL)
+public class ErrorResponse {
+    
+    @JsonProperty("error_identifier")
+    private final ErrorIdentifier identifier;
+    
+    @JsonProperty("message")
+    private final List<String> messages;
+    
+    public ErrorResponse(ErrorIdentifier identifier, List<String> messages) {
+        this.identifier = identifier;
+        this.messages = messages;
+    }
+
+    public ErrorResponse(ErrorIdentifier identifier, String message) {
+        this(identifier, List.of(message));
+    }
+
+    public ErrorIdentifier getIdentifier() {
+        return identifier;
+    }
+
+    public List<String> getMessages() {
+        return messages;
+    }
+}

--- a/src/main/java/uk/gov/pay/ledger/exception/UnparsableDateException.java
+++ b/src/main/java/uk/gov/pay/ledger/exception/UnparsableDateException.java
@@ -1,0 +1,9 @@
+package uk.gov.pay.ledger.exception;
+
+import static java.lang.String.format;
+
+public class UnparsableDateException extends BadRequestException {
+    public UnparsableDateException(String fieldName, String value) {
+        super(format("Input %s (%s) is wrong format", fieldName, value));
+    }
+}

--- a/src/main/java/uk/gov/pay/ledger/transaction/resources/TransactionResource.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/resources/TransactionResource.java
@@ -22,6 +22,7 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
 
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+import static uk.gov.pay.ledger.transaction.search.common.TransactionSearchParamsValidator.validateSearchParams;
 
 @Path("/v1/api")
 @Produces(APPLICATION_JSON)
@@ -57,7 +58,7 @@ public class TransactionResource {
         if (searchParams == null) {
             searchParams = new TransactionSearchParams();
         }
-
+        validateSearchParams(searchParams);
         searchParams.setAccountId(accountId);
         return transactionService.searchTransactions(searchParams, uriInfo);
     }

--- a/src/main/java/uk/gov/pay/ledger/transaction/search/common/TransactionSearchParams.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/search/common/TransactionSearchParams.java
@@ -5,9 +5,11 @@ import org.slf4j.LoggerFactory;
 
 import javax.ws.rs.QueryParam;
 import java.time.ZonedDateTime;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import static java.lang.String.format;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
@@ -45,14 +47,14 @@ public class TransactionSearchParams {
     private String firstDigitsCardNumber;
     @QueryParam("payment_states")
     private CommaDelimitedSetParameter paymentStates;
-    @QueryParam("refund_staes")
+    @QueryParam("refund_states")
     private CommaDelimitedSetParameter refundStates;
     @QueryParam("card_brands")
-    private List<String> cardBrands;
+    private List<String> cardBrands = new ArrayList<>();
     @QueryParam("from_date")
-    private ZonedDateTime fromDate;
+    private String fromDate;
     @QueryParam("to_date")
-    private ZonedDateTime toDate;
+    private String toDate;
     private Long pageNumber = 1L;
     private Long displaySize = MAX_DISPLAY_SIZE;
     private Map<String, Object> queryMap;
@@ -93,11 +95,11 @@ public class TransactionSearchParams {
         this.cardBrands = cardBrands;
     }
 
-    public void setFromDate(ZonedDateTime fromDate) {
+    public void setFromDate(String fromDate) {
         this.fromDate = fromDate;
     }
 
-    public void setToDate(ZonedDateTime toDate) {
+    public void setToDate(String toDate) {
         this.toDate = toDate;
     }
 
@@ -182,10 +184,10 @@ public class TransactionSearchParams {
                 queryMap.put(CARDHOLDER_NAME_FIELD, cardHolderName);
             }
             if (fromDate != null) {
-                queryMap.put(FROM_DATE_FIELD, fromDate);
+                queryMap.put(FROM_DATE_FIELD, ZonedDateTime.parse(fromDate));
             }
             if (toDate != null) {
-                queryMap.put(TO_DATE_FIELD, toDate);
+                queryMap.put(TO_DATE_FIELD, ZonedDateTime.parse(toDate));
             }
         }
         return queryMap;
@@ -203,6 +205,14 @@ public class TransactionSearchParams {
         return displaySize;
     }
 
+    public String getFromDate() {
+        return fromDate;
+    }
+
+    public String getToDate() {
+        return toDate;
+    }
+
     private Long getOffset() {
         Long offset = 0l;
 
@@ -212,7 +222,6 @@ public class TransactionSearchParams {
 
         return offset;
     }
-
 
     private String likeClause(String rawUserInputText) {
         return "%" + rawUserInputText + "%";

--- a/src/main/java/uk/gov/pay/ledger/transaction/search/common/TransactionSearchParamsValidator.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/search/common/TransactionSearchParamsValidator.java
@@ -1,0 +1,31 @@
+package uk.gov.pay.ledger.transaction.search.common;
+
+import uk.gov.pay.ledger.exception.UnparsableDateException;
+
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeParseException;
+
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
+
+public class TransactionSearchParamsValidator {
+
+    private static final String FROM_DATE_FIELD = "from_date";
+    private static final String TO_DATE_FIELD = "to_date";
+
+    public static void validateSearchParams(TransactionSearchParams searchParams) {
+        if (isNotBlank(searchParams.getFromDate())) {
+            validateDate(FROM_DATE_FIELD, searchParams.getFromDate());
+        }
+        if (isNotBlank(searchParams.getToDate())) {
+            validateDate(TO_DATE_FIELD, searchParams.getToDate());
+        }
+    }
+
+    private static void validateDate(String fieldName, String dateToParse) {
+        try {
+            ZonedDateTime.parse(dateToParse);
+        } catch (DateTimeParseException e) {
+            throw new UnparsableDateException(fieldName, dateToParse);
+        }
+    }
+}

--- a/src/main/java/uk/gov/pay/ledger/transaction/search/model/TransactionView.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/search/model/TransactionView.java
@@ -140,11 +140,11 @@ public class TransactionView {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         TransactionView that = (TransactionView) o;
-        return id.equals(that.id);
+        return Objects.equals(externalId, that.externalId);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id);
+        return Objects.hash(externalId);
     }
 }

--- a/src/main/java/uk/gov/pay/ledger/transaction/state/TransactionState.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/state/TransactionState.java
@@ -27,6 +27,7 @@ public enum TransactionState {
         return value;
     }
 
+    @JsonProperty("finished")
     public boolean isFinished() {
         return finished;
     }

--- a/src/test/java/uk/gov/pay/ledger/it/transaction/search/TransactionDaoSearchITest.java
+++ b/src/test/java/uk/gov/pay/ledger/it/transaction/search/TransactionDaoSearchITest.java
@@ -200,7 +200,7 @@ public class TransactionDaoSearchITest {
 
         TransactionSearchParams searchParams = new TransactionSearchParams();
         searchParams.setAccountId(gatewayAccountId);
-        searchParams.setFromDate(ZonedDateTime.now().minusDays(1).minusMinutes(10));
+        searchParams.setFromDate(ZonedDateTime.now().minusDays(1).minusMinutes(10).toString());
 
         List<Transaction> transactionList = transactionDao.searchTransactions(searchParams);
 
@@ -223,7 +223,7 @@ public class TransactionDaoSearchITest {
 
         TransactionSearchParams searchParams = new TransactionSearchParams();
         searchParams.setAccountId(gatewayAccountId);
-        searchParams.setToDate(ZonedDateTime.now().minusDays(2).plusMinutes(10));
+        searchParams.setToDate(ZonedDateTime.now().minusDays(2).plusMinutes(10).toString());
 
         List<Transaction> transactionList = transactionDao.searchTransactions(searchParams);
 

--- a/src/test/java/uk/gov/pay/ledger/transaction/search/common/TransactionSearchParamsValidatorTest.java
+++ b/src/test/java/uk/gov/pay/ledger/transaction/search/common/TransactionSearchParamsValidatorTest.java
@@ -1,0 +1,38 @@
+package uk.gov.pay.ledger.transaction.search.common;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import uk.gov.pay.ledger.exception.UnparsableDateException;
+
+public class TransactionSearchParamsValidatorTest {
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    @Test
+    public void shouldThrowException_whenInvalidFromDate() {
+        TransactionSearchParams searchParams = new TransactionSearchParams();
+        searchParams.setFromDate("wrong-date");
+        thrown.expect(UnparsableDateException.class);
+        thrown.expectMessage("Input from_date (wrong-date) is wrong format");
+        TransactionSearchParamsValidator.validateSearchParams(searchParams);
+    }
+
+    @Test
+    public void shouldThrowException_whenInvalidToDate() {
+        TransactionSearchParams searchParams = new TransactionSearchParams();
+        searchParams.setToDate("wrong-date");
+        thrown.expect(UnparsableDateException.class);
+        thrown.expectMessage("Input to_date (wrong-date) is wrong format");
+        TransactionSearchParamsValidator.validateSearchParams(searchParams);
+    }
+
+    @Test
+    public void shouldNotThrowException_whenValidDateFormats() {
+        TransactionSearchParams searchParams = new TransactionSearchParams();
+        searchParams.setFromDate("2019-05-01T10:15:30Z");
+        searchParams.setToDate("2019-05-01T10:15:30Z");
+        TransactionSearchParamsValidator.validateSearchParams(searchParams);
+    }
+}

--- a/src/test/java/uk/gov/pay/ledger/transaction/service/TransactionServiceTest.java
+++ b/src/test/java/uk/gov/pay/ledger/transaction/service/TransactionServiceTest.java
@@ -107,8 +107,8 @@ public class TransactionServiceTest {
 
         searchParams.setEmail("test@email.com");
         searchParams.setCardHolderName("test");
-        searchParams.setFromDate(ZonedDateTime.parse("2019-05-01T10:15:30+00:00"));
-        searchParams.setToDate(ZonedDateTime.parse("2019-06-01T10:15:30+00:00"));
+        searchParams.setFromDate("2019-05-01T10:15:30Z");
+        searchParams.setToDate("2019-06-01T10:15:30Z");
         searchParams.setReference("ref");
         searchParams.setFirstDigitsCardNumber("4242");
         searchParams.setLastDigitsCardNumber("1234");


### PR DESCRIPTION
- Added validation for search query parameters `from_date` and `to_date`
- Adds validation with in resource endpoint method as Dropwizards query parameter validation doesn't support custom json error response
- Changes `from_date` & `to_date` to String as Dropwizard custom deserialiser (to ZonedDateTime) is not supported for query parameters
- Units tests for TransactionSearchParamsValidator
- Updated integration test `TransactionDaoSearchITest` to ensure all query params are processed

with @SandorArpa 