### PR TITLE
PP-5257 Change API structure for transactions

### DIFF
--- a/src/main/java/uk/gov/pay/ledger/exception/ValidationException.java
+++ b/src/main/java/uk/gov/pay/ledger/exception/ValidationException.java
@@ -1,0 +1,8 @@
+package uk.gov.pay.ledger.exception;
+
+public class ValidationException extends BadRequestException {
+
+    public ValidationException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/uk/gov/pay/ledger/transaction/dao/TransactionDao.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/dao/TransactionDao.java
@@ -13,15 +13,15 @@ import java.util.Optional;
 public class TransactionDao {
 
     private static final String FIND_TRANSACTION_BY_EXTERNAL_ID = "SELECT * FROM transaction " +
-            "WHERE external_id = :externalId and gateway_account_id= :gatewayAccountId ";
+            "WHERE external_id = :externalId";
     private static final String SEARCH_QUERY_STRING = "SELECT * FROM transaction t " +
-            "WHERE t.gateway_account_id = :gatewayAccountExternalId " +
+            "WHERE t.gateway_account_id = :account_id " +
             ":searchExtraFields " +
             "ORDER BY t.id DESC OFFSET :offset LIMIT :limit";
 
     private static final String SEARCH_COUNT_QUERY_STRING = "SELECT count(t.id) " +
             "FROM transaction t " +
-            "WHERE t.gateway_account_id = :gatewayAccountExternalId " +
+            "WHERE t.gateway_account_id = :account_id " +
             ":searchExtraFields ";
     private final Jdbi jdbi;
 
@@ -30,10 +30,9 @@ public class TransactionDao {
         this.jdbi = jdbi;
     }
 
-    public Optional<Transaction> findTransactionByExternalId(String gatewayAccountId, String externalId) {
+    public Optional<Transaction> findTransactionByExternalId(String externalId) {
         return jdbi.withHandle(handle ->
                 handle.createQuery(FIND_TRANSACTION_BY_EXTERNAL_ID)
-                        .bind("gatewayAccountId", gatewayAccountId)
                         .bind("externalId", externalId)
                         .map(new TransactionMapper())
                         .findFirst());

--- a/src/main/java/uk/gov/pay/ledger/transaction/resources/TransactionResource.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/resources/TransactionResource.java
@@ -24,7 +24,7 @@ import javax.ws.rs.core.UriInfo;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static uk.gov.pay.ledger.transaction.search.common.TransactionSearchParamsValidator.validateSearchParams;
 
-@Path("/v1/api")
+@Path("/v1/transaction")
 @Produces(APPLICATION_JSON)
 public class TransactionResource {
 
@@ -38,28 +38,25 @@ public class TransactionResource {
         this.transactionDao = transactionDao;
     }
 
-    @Path("/accounts/{accountId}/transaction/{transactionExternalId}")
+    @Path("/{transactionExternalId}")
     @GET
     @Timed
-    public Transaction getById(@PathParam("accountId") String accountId,
-                               @PathParam("transactionExternalId") String transactionExternalId) {
+    public Transaction getById(@PathParam("transactionExternalId") String transactionExternalId) {
         LOGGER.info("Get transaction request: {}", transactionExternalId);
-        return transactionDao.findTransactionByExternalId(accountId, transactionExternalId)
+        return transactionDao.findTransactionByExternalId(transactionExternalId)
                 .orElseThrow(() -> new WebApplicationException(Response.Status.NOT_FOUND));
     }
 
-    @Path("/accounts/{accountId}/transactions")
+    @Path("/")
     @GET
     @Timed
-    public TransactionSearchResponse search(@PathParam("accountId") String accountId,
-                                            @Valid @BeanParam TransactionSearchParams searchParams,
+    public TransactionSearchResponse search(@Valid @BeanParam TransactionSearchParams searchParams,
                                             @Context UriInfo uriInfo) {
 
         if (searchParams == null) {
             searchParams = new TransactionSearchParams();
         }
         validateSearchParams(searchParams);
-        searchParams.setAccountId(accountId);
         return transactionService.searchTransactions(searchParams, uriInfo);
     }
 }

--- a/src/main/java/uk/gov/pay/ledger/transaction/search/common/TransactionSearchParams.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/search/common/TransactionSearchParams.java
@@ -18,7 +18,7 @@ public class TransactionSearchParams {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(TransactionSearchParams.class);
 
-    private static final String GATEWAY_ACCOUNT_EXTERNAL_FIELD = "gatewayAccountExternalId";
+    private static final String GATEWAY_ACCOUNT_EXTERNAL_FIELD = "account_id";
     private static final String OFFSET_FIELD = "offset";
     private static final String PAGE_SIZE_FIELD = "limit";
     private static final String CARDHOLDER_NAME_FIELD = "cardholder_name";
@@ -34,6 +34,7 @@ public class TransactionSearchParams {
     private static final long MAX_DISPLAY_SIZE = 500;
     private static final long DEFAULT_PAGE_NUMBER = 1L;
 
+    @QueryParam("account_id")
     private String accountId;
     @QueryParam("email")
     private String email;
@@ -228,7 +229,7 @@ public class TransactionSearchParams {
     }
 
     public String buildQueryParamString(Long forPage) {
-        String query = "";
+        String query = GATEWAY_ACCOUNT_EXTERNAL_FIELD + "=" + accountId;
 
         if (fromDate != null) {
             query += "&" + FROM_DATE_FIELD + "=" + fromDate;
@@ -264,7 +265,7 @@ public class TransactionSearchParams {
         }
 
         query += addPaginationParams(forPage);
-        return query.substring(1);
+        return query;
     }
 
     private String addPaginationParams(Long forPage) {

--- a/src/main/java/uk/gov/pay/ledger/transaction/search/common/TransactionSearchParamsValidator.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/search/common/TransactionSearchParamsValidator.java
@@ -1,18 +1,26 @@
 package uk.gov.pay.ledger.transaction.search.common;
 
 import uk.gov.pay.ledger.exception.UnparsableDateException;
+import uk.gov.pay.ledger.exception.ValidationException;
 
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeParseException;
+import java.util.Collections;
 
+import static java.lang.String.format;
+import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
 public class TransactionSearchParamsValidator {
 
+    private static final String GATEWAY_ACCOUNT_ID = "account_id";
     private static final String FROM_DATE_FIELD = "from_date";
     private static final String TO_DATE_FIELD = "to_date";
 
     public static void validateSearchParams(TransactionSearchParams searchParams) {
+
+        throwIfBlankFieldValue(GATEWAY_ACCOUNT_ID, searchParams.getAccountId());
+
         if (isNotBlank(searchParams.getFromDate())) {
             validateDate(FROM_DATE_FIELD, searchParams.getFromDate());
         }
@@ -27,5 +35,10 @@ public class TransactionSearchParamsValidator {
         } catch (DateTimeParseException e) {
             throw new UnparsableDateException(fieldName, dateToParse);
         }
+    }
+
+    private static void throwIfBlankFieldValue(String fieldName, String value) {
+        if (isBlank(value))
+            throw new ValidationException(format("Field [%s] cannot be empty", fieldName));
     }
 }

--- a/src/main/java/uk/gov/pay/ledger/transaction/service/TransactionService.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/service/TransactionService.java
@@ -44,19 +44,19 @@ public class TransactionService {
                                                            UriInfo uriInfo) {
         return transactionList.stream()
                 .map(transaction -> decorateWithLinks(TransactionView.from(transaction),
-                        searchParams.getAccountId(), uriInfo))
+                        uriInfo))
                 .collect(Collectors.toList());
     }
 
     private TransactionView decorateWithLinks(TransactionView transactionView,
-                                              String gatewayAccountId, UriInfo uriInfo) {
+                                              UriInfo uriInfo) {
 
-        Link selfLink = HalLinkBuilder.createSelfLink(uriInfo, "/v1/api/accounts/{accountId}/charges/{externalId}",
-                gatewayAccountId, transactionView.getExternalId());
+        Link selfLink = HalLinkBuilder.createSelfLink(uriInfo, "/v1/transaction/{externalId}",
+                transactionView.getExternalId());
         transactionView.addLink(selfLink);
 
-        Link refundsLink = HalLinkBuilder.createRefundsLink(uriInfo, "/v1/api/accounts/{accountId}/charges/{externalId}/refunds",
-                gatewayAccountId, transactionView.getExternalId());
+        Link refundsLink = HalLinkBuilder.createRefundsLink(uriInfo, "/v1/transaction/{externalId}/refunds",
+                transactionView.getExternalId());
         transactionView.addLink(refundsLink);
 
         return transactionView;

--- a/src/test/java/uk/gov/pay/ledger/it/resource/transaction/TransactionResourceIT.java
+++ b/src/test/java/uk/gov/pay/ledger/it/resource/transaction/TransactionResourceIT.java
@@ -43,7 +43,7 @@ public class TransactionResourceIT {
 
         given().port(port)
                 .contentType(JSON)
-                .get("/v1/api/accounts/" + transactionFixture.getGatewayAccountId() + "/transaction/" + transactionFixture.getExternalId())
+                .get("/v1/transaction/" + transactionFixture.getExternalId())
                 .then()
                 .statusCode(Response.Status.OK.getStatusCode())
                 .contentType(JSON)
@@ -61,9 +61,9 @@ public class TransactionResourceIT {
         given().port(port)
                 .contentType(JSON)
                 //todo: add more query params (card_brands, refund_states...) when search functionality is available
-                .get("/v1/api/accounts/" + gatewayAccountId
-                        + "/transactions?" +
-                        "page=2" +
+                .get("/v1/transaction?" +
+                        "account_id=" + gatewayAccountId +
+                        "&page=2" +
                         "&display_size=2" +
                         "&email=example.org" +
                         "&reference=reference" +
@@ -95,10 +95,10 @@ public class TransactionResourceIT {
                 .body("results[0].card_details.card_brand", is(transactionToVerify.getCardDetails().getCardBrand()))
                 .body("results[0].delayed_capture", is(transactionToVerify.getDelayedCapture()))
                 .body("results[0].charge_id", is(transactionToVerify.getExternalId()))
-                .body("results[0].links[0].href", containsString("v1/api/accounts/" + gatewayAccountId + "/charges/" + transactionToVerify.getExternalId()))
+                .body("results[0].links[0].href", containsString("v1/transaction/" + transactionToVerify.getExternalId()))
                 .body("results[0].links[0].method", is("GET"))
                 .body("results[0].links[0].rel", is("self"))
-                .body("results[0].links[1].href", containsString("v1/api/accounts/" + gatewayAccountId + "/charges/" + transactionToVerify.getExternalId() + "/refunds"))
+                .body("results[0].links[1].href", containsString("v1/transaction/" + transactionToVerify.getExternalId() + "/refunds"))
                 .body("results[0].links[1].method", is("GET"))
                 .body("results[0].links[1].rel", is("refunds"))
 
@@ -106,10 +106,10 @@ public class TransactionResourceIT {
                 .body("page", is(2))
                 .body("total", is(10))
 
-                .body("_links.self.href", containsString("v1/api/accounts/" + gatewayAccountId + "/transactions?from_date=2000-01-01T10%3A15%3A30Z&to_date=2100-01-01T10%3A15%3A30Z&email=example.org&reference=reference&page=2&display_size=2"))
-                .body("_links.first_page.href", containsString("v1/api/accounts/" + gatewayAccountId + "/transactions?from_date=2000-01-01T10%3A15%3A30Z&to_date=2100-01-01T10%3A15%3A30Z&email=example.org&reference=reference&page=1&display_size=2"))
-                .body("_links.last_page.href", containsString("v1/api/accounts/" + gatewayAccountId + "/transactions?from_date=2000-01-01T10%3A15%3A30Z&to_date=2100-01-01T10%3A15%3A30Z&email=example.org&reference=reference&page=5&display_size=2"))
-                .body("_links.prev_page.href", containsString("v1/api/accounts/" + gatewayAccountId + "/transactions?from_date=2000-01-01T10%3A15%3A30Z&to_date=2100-01-01T10%3A15%3A30Z&email=example.org&reference=reference&page=1&display_size=2"))
-                .body("_links.next_page.href", containsString("v1/api/accounts/" + gatewayAccountId + "/transactions?from_date=2000-01-01T10%3A15%3A30Z&to_date=2100-01-01T10%3A15%3A30Z&email=example.org&reference=reference&page=3&display_size=2"));
+                .body("_links.self.href", containsString("v1/transaction?account_id=" + gatewayAccountId + "&from_date=2000-01-01T10%3A15%3A30Z&to_date=2100-01-01T10%3A15%3A30Z&email=example.org&reference=reference&page=2&display_size=2"))
+                .body("_links.first_page.href", containsString("v1/transaction?account_id=" + gatewayAccountId + "&from_date=2000-01-01T10%3A15%3A30Z&to_date=2100-01-01T10%3A15%3A30Z&email=example.org&reference=reference&page=1&display_size=2"))
+                .body("_links.last_page.href", containsString("v1/transaction?account_id=" + gatewayAccountId + "&from_date=2000-01-01T10%3A15%3A30Z&to_date=2100-01-01T10%3A15%3A30Z&email=example.org&reference=reference&page=5&display_size=2"))
+                .body("_links.prev_page.href", containsString("v1/transaction?account_id=" + gatewayAccountId + "&from_date=2000-01-01T10%3A15%3A30Z&to_date=2100-01-01T10%3A15%3A30Z&email=example.org&reference=reference&page=1&display_size=2"))
+                .body("_links.next_page.href", containsString("v1/transaction?account_id=" + gatewayAccountId + "&from_date=2000-01-01T10%3A15%3A30Z&to_date=2100-01-01T10%3A15%3A30Z&email=example.org&reference=reference&page=3&display_size=2"));
     }
 }

--- a/src/test/java/uk/gov/pay/ledger/transaction/search/common/TransactionSearchParamsValidatorTest.java
+++ b/src/test/java/uk/gov/pay/ledger/transaction/search/common/TransactionSearchParamsValidatorTest.java
@@ -1,18 +1,34 @@
 package uk.gov.pay.ledger.transaction.search.common;
 
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import uk.gov.pay.ledger.exception.UnparsableDateException;
+import uk.gov.pay.ledger.exception.ValidationException;
 
 public class TransactionSearchParamsValidatorTest {
 
     @Rule
     public ExpectedException thrown = ExpectedException.none();
 
+    TransactionSearchParams searchParams;
+
+    @Before
+    public void setup(){
+        searchParams = new TransactionSearchParams();
+        searchParams.setAccountId("account_id");
+    }
+    @Test
+    public void shouldThrowException_whenAccountIdIsNull() {
+        searchParams.setAccountId(null);
+        thrown.expect(ValidationException.class);
+        thrown.expectMessage("Field [account_id] cannot be empty");
+        TransactionSearchParamsValidator.validateSearchParams(searchParams);
+    }
+
     @Test
     public void shouldThrowException_whenInvalidFromDate() {
-        TransactionSearchParams searchParams = new TransactionSearchParams();
         searchParams.setFromDate("wrong-date");
         thrown.expect(UnparsableDateException.class);
         thrown.expectMessage("Input from_date (wrong-date) is wrong format");
@@ -21,7 +37,6 @@ public class TransactionSearchParamsValidatorTest {
 
     @Test
     public void shouldThrowException_whenInvalidToDate() {
-        TransactionSearchParams searchParams = new TransactionSearchParams();
         searchParams.setToDate("wrong-date");
         thrown.expect(UnparsableDateException.class);
         thrown.expectMessage("Input to_date (wrong-date) is wrong format");
@@ -30,7 +45,6 @@ public class TransactionSearchParamsValidatorTest {
 
     @Test
     public void shouldNotThrowException_whenValidDateFormats() {
-        TransactionSearchParams searchParams = new TransactionSearchParams();
         searchParams.setFromDate("2019-05-01T10:15:30Z");
         searchParams.setToDate("2019-05-01T10:15:30Z");
         TransactionSearchParamsValidator.validateSearchParams(searchParams);

--- a/src/test/java/uk/gov/pay/ledger/transaction/search/model/PaginationBuilderTest.java
+++ b/src/test/java/uk/gov/pay/ledger/transaction/search/model/PaginationBuilderTest.java
@@ -30,7 +30,7 @@ public class PaginationBuilderTest {
     public void setUp() throws URISyntaxException {
         URI uri = new URI("http://example.org");
         when(mockedUriInfo.getBaseUriBuilder()).thenReturn(UriBuilder.fromUri(uri), UriBuilder.fromUri(uri));
-        when(mockedUriInfo.getPath()).thenReturn("/v1/api/accounts/" + gatewayAccountExternalId + "/transactions/view");
+        when(mockedUriInfo.getPath()).thenReturn("/transaction");
 
         searchParams = new TransactionSearchParams();
     }
@@ -44,9 +44,9 @@ public class PaginationBuilderTest {
                 .withTotalCount(120L);
         builder = builder.buildResponse();
         assertThat(builder.getPrevLink(), is(nullValue()));
-        assertThat(builder.getFirstLink().getHref().contains("?page=1&display_size=500"), is(true));
-        assertThat(builder.getLastLink().getHref().contains("?page=1&display_size=500"), is(true));
-        assertThat(builder.getSelfLink().getHref().contains("?page=1&display_size=500"), is(true));
+        assertThat(builder.getFirstLink().getHref().contains("page=1&display_size=500"), is(true));
+        assertThat(builder.getLastLink().getHref().contains("page=1&display_size=500"), is(true));
+        assertThat(builder.getSelfLink().getHref().contains("page=1&display_size=500"), is(true));
         assertThat(builder.getNextLink(), is(nullValue()));
     }
 
@@ -58,10 +58,10 @@ public class PaginationBuilderTest {
         PaginationBuilder builder = new PaginationBuilder(searchParams, mockedUriInfo)
                 .withTotalCount(120L);
         builder = builder.buildResponse();
-        assertThat(builder.getPrevLink().getHref().contains("?page=1&display_size=500"), is(true));
-        assertThat(builder.getFirstLink().getHref().contains("?page=1&display_size=500"), is(true));
-        assertThat(builder.getLastLink().getHref().contains("?page=1&display_size=500"), is(true));
-        assertThat(builder.getSelfLink().getHref().contains("?page=777&display_size=500"), is(true));
+        assertThat(builder.getPrevLink().getHref().contains("page=1&display_size=500"), is(true));
+        assertThat(builder.getFirstLink().getHref().contains("page=1&display_size=500"), is(true));
+        assertThat(builder.getLastLink().getHref().contains("page=1&display_size=500"), is(true));
+        assertThat(builder.getSelfLink().getHref().contains("page=777&display_size=500"), is(true));
         assertThat(builder.getNextLink(), is(nullValue()));
     }
 
@@ -72,11 +72,11 @@ public class PaginationBuilderTest {
         PaginationBuilder builder = new PaginationBuilder(searchParams, mockedUriInfo)
                 .withTotalCount(120L);
         builder = builder.buildResponse();
-        assertThat(builder.getPrevLink().getHref().contains("?page=1&display_size=50"), is(true));
-        assertThat(builder.getFirstLink().getHref().contains("?page=1&display_size=50"), is(true));
-        assertThat(builder.getLastLink().getHref().contains("?page=3&display_size=50"), is(true));
-        assertThat(builder.getNextLink().getHref().contains("?page=3&display_size=50"), is(true));
-        assertThat(builder.getSelfLink().getHref().contains("?page=2&display_size=50"), is(true));
+        assertThat(builder.getPrevLink().getHref().contains("page=1&display_size=50"), is(true));
+        assertThat(builder.getFirstLink().getHref().contains("page=1&display_size=50"), is(true));
+        assertThat(builder.getLastLink().getHref().contains("page=3&display_size=50"), is(true));
+        assertThat(builder.getNextLink().getHref().contains("page=3&display_size=50"), is(true));
+        assertThat(builder.getSelfLink().getHref().contains("page=2&display_size=50"), is(true));
     }
 
     @Test
@@ -86,10 +86,10 @@ public class PaginationBuilderTest {
         PaginationBuilder builder = new PaginationBuilder(searchParams, mockedUriInfo)
                 .withTotalCount(120L);
         builder = builder.buildResponse();
-        assertThat(builder.getFirstLink().getHref().contains("?page=1&display_size=10"), is(true));
-        assertThat(builder.getLastLink().getHref().contains("?page=12&display_size=10"), is(true));
-        assertThat(builder.getPrevLink().getHref().contains("?page=2&display_size=10"), is(true));
-        assertThat(builder.getNextLink().getHref().contains("?page=4&display_size=10"), is(true));
-        assertThat(builder.getSelfLink().getHref().contains("?page=3&display_size=10"), is(true));
+        assertThat(builder.getFirstLink().getHref().contains("page=1&display_size=10"), is(true));
+        assertThat(builder.getLastLink().getHref().contains("page=12&display_size=10"), is(true));
+        assertThat(builder.getPrevLink().getHref().contains("page=2&display_size=10"), is(true));
+        assertThat(builder.getNextLink().getHref().contains("page=4&display_size=10"), is(true));
+        assertThat(builder.getSelfLink().getHref().contains("page=3&display_size=10"), is(true));
     }
 }

--- a/src/test/java/uk/gov/pay/ledger/transaction/service/TransactionServiceTest.java
+++ b/src/test/java/uk/gov/pay/ledger/transaction/service/TransactionServiceTest.java
@@ -47,7 +47,7 @@ public class TransactionServiceTest {
 
         when(mockUriInfo.getBaseUri()).thenReturn(UriBuilder.fromUri("http://app.com").build());
         when(mockUriInfo.getBaseUriBuilder()).thenReturn(UriBuilder.fromUri("http://app.com"));
-        when(mockUriInfo.getPath()).thenReturn("/v1/api/accounts/{accountId}/charges");
+        when(mockUriInfo.getPath()).thenReturn("/v1/transaction");
     }
 
     @Test
@@ -74,11 +74,11 @@ public class TransactionServiceTest {
 
         assertThat(transactionView.getLinks().get(0).getRel(), is("self"));
         assertThat(transactionView.getLinks().get(0).getMethod(), is("GET"));
-        assertThat(transactionView.getLinks().get(0).getHref(), is("http://app.com/v1/api/accounts/gateway_account_id/charges/" + transactionView.getExternalId()));
+        assertThat(transactionView.getLinks().get(0).getHref(), is("http://app.com/v1/transaction/" + transactionView.getExternalId()));
 
         assertThat(transactionView.getLinks().get(1).getRel(), is("refunds"));
         assertThat(transactionView.getLinks().get(1).getMethod(), is("GET"));
-        assertThat(transactionView.getLinks().get(1).getHref(), is("http://app.com/v1/api/accounts/gateway_account_id/charges/" + transactionView.getExternalId() + "/refunds"));
+        assertThat(transactionView.getLinks().get(1).getHref(), is("http://app.com/v1/transaction/" + transactionView.getExternalId() + "/refunds"));
     }
 
     @Test
@@ -92,11 +92,11 @@ public class TransactionServiceTest {
         TransactionSearchResponse transactionSearchResponse = transactionService.searchTransactions(searchParams, mockUriInfo);
         PaginationBuilder paginationBuilder = transactionSearchResponse.getPaginationBuilder();
 
-        assertThat(paginationBuilder.getFirstLink().getHref(), is("http://app.com/v1/api/accounts/gateway_account_id/charges?page=1&display_size=10"));
-        assertThat(paginationBuilder.getPrevLink().getHref(), is("http://app.com/v1/api/accounts/gateway_account_id/charges?page=2&display_size=10"));
-        assertThat(paginationBuilder.getSelfLink().getHref(), is("http://app.com/v1/api/accounts/gateway_account_id/charges?page=3&display_size=10"));
-        assertThat(paginationBuilder.getNextLink().getHref(), is("http://app.com/v1/api/accounts/gateway_account_id/charges?page=4&display_size=10"));
-        assertThat(paginationBuilder.getLastLink().getHref(), is("http://app.com/v1/api/accounts/gateway_account_id/charges?page=10&display_size=10"));
+        assertThat(paginationBuilder.getFirstLink().getHref(), is("http://app.com/v1/transaction?account_id=gateway_account_id&page=1&display_size=10"));
+        assertThat(paginationBuilder.getPrevLink().getHref(), is("http://app.com/v1/transaction?account_id=gateway_account_id&page=2&display_size=10"));
+        assertThat(paginationBuilder.getSelfLink().getHref(), is("http://app.com/v1/transaction?account_id=gateway_account_id&page=3&display_size=10"));
+        assertThat(paginationBuilder.getNextLink().getHref(), is("http://app.com/v1/transaction?account_id=gateway_account_id&page=4&display_size=10"));
+        assertThat(paginationBuilder.getLastLink().getHref(), is("http://app.com/v1/transaction?account_id=gateway_account_id&page=10&display_size=10"));
     }
 
     @Test


### PR DESCRIPTION
## WHAT
- Transaction API endpoints changed from `/v1/api/accounts/{accountId}....` to
        `/v1/transaction/{transactionExternalId}` - to find a single transaction
        `/v1/transaction?query_params` - to search transactions
- Validation for `accound_id` which is now a query parameter for transaction search endpoint
- Updates relevents DAO queries, methods, and tests to reflect above changes