### PR TITLE
PP-5255 Add EventType

### DIFF
--- a/src/main/java/uk/gov/pay/ledger/event/model/Event.java
+++ b/src/main/java/uk/gov/pay/ledger/event/model/Event.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import uk.gov.pay.ledger.event.model.serializer.MicrosecondPrecisionDateTimeSerializer;
 
 import java.time.ZonedDateTime;
+import java.util.Objects;
 
 @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
 public class Event {
@@ -70,5 +71,37 @@ public class Event {
 
     public String getEventData() {
         return eventData;
+    }
+
+    @Override
+    public String toString() {
+        return "Event{" +
+                "id=" + id +
+                ", sqsMessageId='" + sqsMessageId + '\'' +
+                ", resourceType=" + resourceType +
+                ", resourceExternalId='" + resourceExternalId + '\'' +
+                ", eventDate=" + eventDate +
+                ", eventType=" + eventType +
+                ", eventData='" + eventData + '\'' +
+                '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Event event = (Event) o;
+        return Objects.equals(id, event.id) &&
+                Objects.equals(sqsMessageId, event.sqsMessageId) &&
+                resourceType == event.resourceType &&
+                Objects.equals(resourceExternalId, event.resourceExternalId) &&
+                Objects.equals(eventDate, event.eventDate) &&
+                eventType == event.eventType &&
+                Objects.equals(eventData, event.eventData);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, sqsMessageId, resourceType, resourceExternalId, eventDate, eventType, eventData);
     }
 }

--- a/src/main/java/uk/gov/pay/ledger/event/model/EventType.java
+++ b/src/main/java/uk/gov/pay/ledger/event/model/EventType.java
@@ -1,0 +1,17 @@
+package uk.gov.pay.ledger.event.model;
+
+import uk.gov.pay.ledger.transaction.state.TransactionState;
+
+public enum EventType {
+    PAYMENT_CREATED(TransactionState.CREATED);
+
+    private final TransactionState transactionState;
+
+    EventType(TransactionState transactionState) {
+        this.transactionState = transactionState;
+    }
+
+    public TransactionState getTransactionState() {
+        return transactionState;
+    }
+}

--- a/src/test/java/uk/gov/pay/ledger/event/EventIntegrationTest.java
+++ b/src/test/java/uk/gov/pay/ledger/event/EventIntegrationTest.java
@@ -35,7 +35,7 @@ public class EventIntegrationTest {
                 .body("resource_external_id", is(event.getResourceExternalId()))
                 .body("resource_type", is(event.getResourceType().name().toLowerCase()))
                 .body("sqs_message_id", is(event.getSqsMessageId()))
-                .body("event_type", is(event.getEventType()))
+                .body("event_type", is(event.getEventType().toString()))
                 .body("event_data", is(event.getEventData()));
     }
 }

--- a/src/test/java/uk/gov/pay/ledger/it/queue/sqs/QueueEventProcessingIT.java
+++ b/src/test/java/uk/gov/pay/ledger/it/queue/sqs/QueueEventProcessingIT.java
@@ -57,7 +57,7 @@ public class QueueEventProcessingIT {
         assertThat(result.get("resource_type_id"), is(resourceTypeId));
         assertThat(result.get("resource_external_id"), is(event.getResourceExternalId()));
         assertThat((Timestamp) result.get("event_date"), isDate(CREATED_AT));
-        assertThat(result.get("event_type"), is(event.getEventType()));
+        assertThat(result.get("event_type"), is(event.getEventType().toString()));
         assertThat(objectMapper.readTree(result.get("event_data").toString()), is(objectMapper.readTree(event.getEventData())));
     }
 }

--- a/src/test/java/uk/gov/pay/ledger/queue/EventQueueTest.java
+++ b/src/test/java/uk/gov/pay/ledger/queue/EventQueueTest.java
@@ -10,6 +10,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.pay.ledger.app.LedgerConfig;
 import uk.gov.pay.ledger.app.config.QueueMessageReceiverConfig;
 import uk.gov.pay.ledger.app.config.SqsConfig;
+import uk.gov.pay.ledger.event.model.EventType;
 import uk.gov.pay.ledger.event.model.ResourceType;
 import uk.gov.pay.ledger.queue.sqs.SqsQueueService;
 
@@ -41,7 +42,7 @@ public class EventQueueTest {
                 "\"id\": \"my-id\"," +
                 "\"timestamp\": \"2018-03-12T16:25:01.123456Z\"," +
                 "\"resource_external_id\": \"3uwuyr38rry\"," +
-                "\"event_type\":\"example type\"," +
+                "\"event_type\":\"PAYMENT_CREATED\"," +
                 "\"resource_type\": \"charge\"," +
                 "\"event_details\": {" +
                 "\"example_event_details_field\": \"and its value\"" +
@@ -71,7 +72,7 @@ public class EventQueueTest {
         assertFalse(eventsList.isEmpty());
         assertEquals("3uwuyr38rry", eventsList.get(0).getEvent().getResourceExternalId());
         assertEquals(ZonedDateTime.parse("2018-03-12T16:25:01.123456Z"), eventsList.get(0).getEvent().getEventDate());
-        assertEquals("example type", eventsList.get(0).getEvent().getEventType());
+        assertEquals(EventType.PAYMENT_CREATED, eventsList.get(0).getEvent().getEventType());
         assertEquals(ResourceType.CHARGE, eventsList.get(0).getEvent().getResourceType());
         assertEquals("{\"example_event_details_field\":\"and its value\"}", eventsList.get(0).getEvent().getEventData());
     }

--- a/src/test/java/uk/gov/pay/ledger/utils/fixtures/EventFixture.java
+++ b/src/test/java/uk/gov/pay/ledger/utils/fixtures/EventFixture.java
@@ -15,7 +15,7 @@ public class EventFixture implements DbFixture<EventFixture, Event> {
     private ResourceType resourceType = ResourceType.CHARGE;
     private String resourceExternalId = RandomStringUtils.randomAlphanumeric(20);
     private ZonedDateTime eventDate = ZonedDateTime.now(ZoneOffset.UTC);
-    private String eventType = "PaymentCreated";
+    private String eventType = "PAYMENT_CREATED";
     private String eventData = "{\"event_data\": \"event data\"}";
 
     private EventFixture() {
@@ -126,7 +126,7 @@ public class EventFixture implements DbFixture<EventFixture, Event> {
         resourceType = event.getResourceType();
         resourceExternalId = event.getResourceExternalId();
         eventDate = event.getEventDate();
-        eventType = event.getEventType();
+        eventType = event.getEventType().toString();
         eventData = event.getEventData();
         return this;
     }

--- a/src/test/java/uk/gov/pay/ledger/utils/fixtures/QueueEventFixture.java
+++ b/src/test/java/uk/gov/pay/ledger/utils/fixtures/QueueEventFixture.java
@@ -15,7 +15,7 @@ public class QueueEventFixture implements QueueFixture<QueueEventFixture, Event>
     private ResourceType resourceType = ResourceType.CHARGE;
     private String resourceExternalId = RandomStringUtils.randomAlphanumeric(20);
     private ZonedDateTime eventDate = ZonedDateTime.now(ZoneOffset.UTC);
-    private String eventType = "PaymentCreated";
+    private String eventType = "PAYMENT_CREATED";
     private String eventData = "{\"event_data\": \"event data\"}";
 
     private QueueEventFixture() {


### PR DESCRIPTION
Introduce EventType enum. As part of this I have changed the name of the expected event from PaymentCreated to PAYMENT_CREATED. This is because whilst Jackson is pretty good at {,de}serialisation, JDBI is not so good, and it's default enum deserialiser uses the enum `name()`, so it
significantly reduces boiler plate to use this form.