### PR TITLE
PP-5527 Provider state for Transaction search pact

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -93,7 +93,7 @@ pipeline {
         deployEcs("ledger")
       }
     }
-    /*stage('Pact Tag') {
+    stage('Pact Tag') {
       when {
         branch 'master'
       }
@@ -101,7 +101,7 @@ pipeline {
         echo 'Tagging provider pact with "test"'
         tagPact("ledger", gitCommit(), "test")
       }
-    }*/
+    }
     /*stage('Smoke Tests') {
       when {
         branch 'master'

--- a/pom.xml
+++ b/pom.xml
@@ -15,6 +15,7 @@
         <testcontainers.version>1.11.3</testcontainers.version>
         <postgresql.version>42.2.5</postgresql.version>
         <pay-java-commons.version>1.0.20190606155120</pay-java-commons.version>
+        <surefire.version>3.0.0-M3</surefire.version>
         <guice.version>4.2.2</guice.version>
         <rest-assured.version>4.0.0</rest-assured.version>
     </properties>
@@ -103,7 +104,7 @@
             <artifactId>aws-java-sdk-sqs</artifactId>
             <version>1.11.572</version>
         </dependency>
-<!--test dependencies-->
+        <!--test dependencies-->
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>postgresql</artifactId>
@@ -213,7 +214,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.0.0-M3</version>
+                <version>${surefire.version}</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -279,4 +280,51 @@
             </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>default</id>
+            <activation>
+                <property>
+                    <name>!runContractTests</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <version>${surefire.version}</version>
+                        <configuration>
+                            <excludes>
+                                <exclude>**/*ContractTest.java</exclude>
+                                <exclude>**/*ContractTestSuite.java</exclude>
+                            </excludes>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>contract-tests</id>
+            <activation>
+                <property>
+                    <name>runContractTests</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <version>${surefire.version}</version>
+                        <configuration>
+                            <includes>
+                                <include>**/*ContractTestSuite.java</include>
+                            </includes>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -134,6 +134,18 @@
             <version>${rest-assured.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>au.com.dius</groupId>
+            <artifactId>pact-jvm-provider-junit_2.12</artifactId>
+            <version>3.6.7</version>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.commons</groupId>
+                    <artifactId>commons-lang3</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/test/java/uk/gov/pay/ledger/pact/ContractTestSuite.java
+++ b/src/test/java/uk/gov/pay/ledger/pact/ContractTestSuite.java
@@ -1,0 +1,13 @@
+package uk.gov.pay.ledger.pact;
+
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+@RunWith(Suite.class)
+
+@Suite.SuiteClasses({
+        TransactionsApiContractTest.class
+})
+public class ContractTestSuite {
+
+}

--- a/src/test/java/uk/gov/pay/ledger/pact/TransactionsApiContractTest.java
+++ b/src/test/java/uk/gov/pay/ledger/pact/TransactionsApiContractTest.java
@@ -12,13 +12,13 @@ import au.com.dius.pact.provider.junit.target.TestTarget;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.runner.RunWith;
-import uk.gov.pay.ledger.rules.AppWithPostgresAndSqsRule;
-import uk.gov.pay.ledger.utils.fixtures.TransactionFixture;
+import uk.gov.pay.ledger.rule.AppWithPostgresAndSqsRule;
+import uk.gov.pay.ledger.util.fixture.TransactionFixture;
 
 import java.time.ZonedDateTime;
 import java.util.Map;
 
-import static uk.gov.pay.ledger.utils.fixtures.TransactionFixture.aTransactionFixture;
+import static uk.gov.pay.ledger.util.fixture.TransactionFixture.aTransactionFixture;
 
 @RunWith(PactRunner.class)
 @Provider("ledger")

--- a/src/test/java/uk/gov/pay/ledger/pact/TransactionsApiContractTest.java
+++ b/src/test/java/uk/gov/pay/ledger/pact/TransactionsApiContractTest.java
@@ -1,0 +1,60 @@
+package uk.gov.pay.ledger.pact;
+
+import au.com.dius.pact.provider.junit.IgnoreNoPactsToVerify;
+import au.com.dius.pact.provider.junit.PactRunner;
+import au.com.dius.pact.provider.junit.Provider;
+import au.com.dius.pact.provider.junit.State;
+import au.com.dius.pact.provider.junit.loader.PactBroker;
+import au.com.dius.pact.provider.junit.loader.PactBrokerAuth;
+import au.com.dius.pact.provider.junit.target.HttpTarget;
+import au.com.dius.pact.provider.junit.target.Target;
+import au.com.dius.pact.provider.junit.target.TestTarget;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.runner.RunWith;
+import uk.gov.pay.ledger.rules.AppWithPostgresAndSqsRule;
+import uk.gov.pay.ledger.utils.fixtures.TransactionFixture;
+
+import java.time.ZonedDateTime;
+import java.util.Map;
+
+import static uk.gov.pay.ledger.utils.fixtures.TransactionFixture.aTransactionFixture;
+
+@RunWith(PactRunner.class)
+@Provider("ledger")
+@IgnoreNoPactsToVerify
+@PactBroker(scheme = "https", host = "pact-broker-test.cloudapps.digital", tags = {"${PACT_CONSUMER_TAG}", "test", "staging", "production"},
+        authentication = @PactBrokerAuth(username = "${PACT_BROKER_USERNAME}", password = "${PACT_BROKER_PASSWORD}"),
+        consumers = {"publicapi"})
+public class TransactionsApiContractTest {
+
+    @ClassRule
+    public static AppWithPostgresAndSqsRule app = new AppWithPostgresAndSqsRule();
+
+    @TestTarget
+    public static Target target;
+
+    @BeforeClass
+    public static void setup() {
+        target = new HttpTarget(app.getAppRule().getLocalPort());
+    }
+
+    @State("a transaction with created state exist")
+    public void createChargeWithCardDetails(Map<String, String> params) {
+        String transactionExternalId = params.get("transaction_external_id");
+        String gatewayAccountId = params.get("gateway_account_id");
+
+        TransactionFixture transactionFixture
+                = aTransactionFixture()
+                .withExternalId(transactionExternalId)
+                .withGatewayAccountId(gatewayAccountId)
+                .withAmount(1000l)
+                .withReference("aReference")
+                .withDescription("Test description")
+                .withState("created")
+                .withReturnUrl("aReturnUrl")
+                .withCreatedDate(ZonedDateTime.parse("2018-09-22T10:13:16.067Z"))
+                .insert(app.getJdbi());
+    }
+
+}


### PR DESCRIPTION
## WHAT
- Adds provider state for transaction search pact between public api and ledger (for PaymentCreated event)
- Excludes `common-lang3`(version 3.4) transitive dependency from pact-provider dependency which is causing compile error on usage of `RandomUtils.nextLong()` which is only available in latest version (commons-lang3-3.8.1)