### PR TITLE
Pp 5255 event digest

### DIFF
--- a/src/main/java/uk/gov/pay/ledger/event/dao/EventDao.java
+++ b/src/main/java/uk/gov/pay/ledger/event/dao/EventDao.java
@@ -11,6 +11,7 @@ import org.jdbi.v3.sqlobject.transaction.Transaction;
 import uk.gov.pay.ledger.event.dao.mapper.EventMapper;
 import uk.gov.pay.ledger.event.model.Event;
 
+import java.util.List;
 import java.util.Optional;
 
 @RegisterRowMapper(EventMapper.class)
@@ -54,4 +55,9 @@ public interface EventDao {
         int resourceTypeId = getResourceTypeDao().getResourceTypeIdByName(event.getResourceType().name());
         return insertIfDoesNotExist(event, resourceTypeId);
     }
+
+    @SqlQuery("SELECT  e.id, e.sqs_message_id, rt.name AS resource_type_name, e.resource_external_id, e.event_date," +
+            "e.event_type, e.event_data FROM event e, resource_type rt WHERE e.resource_external_id = :resourceExternalId" +
+            " AND e.resource_type_id = rt.id ORDER BY e.event_date DESC")
+    List<Event> getEventsByResourceExternalId(@Bind("resourceExternalId") String resourceExternalId);
 }

--- a/src/main/java/uk/gov/pay/ledger/event/model/Event.java
+++ b/src/main/java/uk/gov/pay/ledger/event/model/Event.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import uk.gov.pay.ledger.event.model.serializer.MicrosecondPrecisionDateTimeSerializer;
 
 import java.time.ZonedDateTime;
+import java.util.Objects;
 
 @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
 public class Event {
@@ -70,5 +71,37 @@ public class Event {
 
     public String getEventData() {
         return eventData;
+    }
+
+    @Override
+    public String toString() {
+        return "Event{" +
+                "id=" + id +
+                ", sqsMessageId='" + sqsMessageId + '\'' +
+                ", resourceType=" + resourceType +
+                ", resourceExternalId='" + resourceExternalId + '\'' +
+                ", eventDate=" + eventDate +
+                ", eventType=" + eventType +
+                ", eventData='" + eventData + '\'' +
+                '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Event event = (Event) o;
+        return Objects.equals(id, event.id) &&
+                Objects.equals(sqsMessageId, event.sqsMessageId) &&
+                resourceType == event.resourceType &&
+                Objects.equals(resourceExternalId, event.resourceExternalId) &&
+                Objects.equals(eventDate, event.eventDate) &&
+                eventType == event.eventType &&
+                Objects.equals(eventData, event.eventData);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, sqsMessageId, resourceType, resourceExternalId, eventDate, eventType, eventData);
     }
 }

--- a/src/main/java/uk/gov/pay/ledger/event/model/Event.java
+++ b/src/main/java/uk/gov/pay/ledger/event/model/Event.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
 import uk.gov.pay.ledger.event.model.serializer.MicrosecondPrecisionDateTimeSerializer;
 
 import java.time.ZonedDateTime;
@@ -19,30 +20,25 @@ public class Event {
     private String resourceExternalId;
     @JsonSerialize(using = MicrosecondPrecisionDateTimeSerializer.class)
     private ZonedDateTime eventDate;
-    private String eventType;
+    private EventType eventType;
     private String eventData;
 
     public Event() { }
 
     public Event(Long id, String sqsMessageId, ResourceType resourceType, String resourceExternalId,
-                 ZonedDateTime eventDate, String eventType, String eventData) {
+                 ZonedDateTime eventDate, String eventName, String eventData) {
         this.id = id;
         this.sqsMessageId = sqsMessageId;
         this.resourceType = resourceType;
         this.resourceExternalId = resourceExternalId;
         this.eventDate = eventDate;
-        this.eventType = eventType;
+        this.eventType = EventType.valueOf(eventName);
         this.eventData = eventData;
     }
 
     public Event(String queueMessageId, ResourceType resourceType, String resourceExternalId, ZonedDateTime eventDate,
                  String eventType, String eventData) {
-        this.sqsMessageId = queueMessageId;
-        this.resourceType = resourceType;
-        this.resourceExternalId = resourceExternalId;
-        this.eventDate = eventDate;
-        this.eventType = eventType;
-        this.eventData = eventData;
+        this(null, queueMessageId, resourceType, resourceExternalId, eventDate, eventType, eventData);
     }
 
     public Long getId() {
@@ -65,7 +61,8 @@ public class Event {
         return eventDate;
     }
 
-    public String getEventType() {
+    @JsonSerialize(using = ToStringSerializer.class)
+    public EventType getEventType() {
         return eventType;
     }
 

--- a/src/main/java/uk/gov/pay/ledger/event/model/EventDigest.java
+++ b/src/main/java/uk/gov/pay/ledger/event/model/EventDigest.java
@@ -1,0 +1,80 @@
+package uk.gov.pay.ledger.event.model;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.io.IOException;
+import java.time.ZonedDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public class EventDigest {
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+    private final ZonedDateTime mostRecentEventTimestamp;
+    private final EventType mostRecentEventType;
+    private final ResourceType resourceType;
+    private final String resourceExternalId;
+    private final Map<String, Object> eventDetailsDigest;
+
+    private EventDigest(ZonedDateTime mostRecentEventTimestamp, EventType mostRecentEventType, ResourceType resourceType, String resourceExternalId, Map<String, Object> eventDetailsDigest) {
+        this.mostRecentEventTimestamp = mostRecentEventTimestamp;
+        this.mostRecentEventType = mostRecentEventType;
+        this.resourceType = resourceType;
+        this.resourceExternalId = resourceExternalId;
+        this.eventDetailsDigest = eventDetailsDigest;
+    }
+
+    public static EventDigest fromEventList(List<Event> events) {
+        Map<String, Object> eventDetailsDigest = getEventDetailsDigest(events);
+        return events.stream()
+                .findFirst()
+                .map(e -> EventDigest.from(e, eventDetailsDigest))
+                .orElseThrow(() -> new RuntimeException("No events found"));
+    }
+
+    private static EventDigest from(Event latestEvent, Map<String, Object> eventDetailsDigest) {
+        return new EventDigest(
+                latestEvent.getEventDate(),
+                latestEvent.getEventType(),
+                latestEvent.getResourceType(),
+                latestEvent.getResourceExternalId(),
+                eventDetailsDigest
+        );
+    }
+
+    private static Map<String, Object> getEventDetailsDigest(List<Event> events) {
+        return events.stream()
+                .map(Event::getEventData)
+                .map(EventDigest::eventDetailsJsonStringToMap)
+                .flatMap(m -> m.entrySet().stream())
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue, (later, earlier) -> later));
+    }
+
+    private static Map<String, Object> eventDetailsJsonStringToMap(String eventDetails) {
+        try {
+            return (Map<String, Object>) objectMapper.readValue(eventDetails, Map.class);
+        } catch (IOException | ClassCastException e) {
+            throw new RuntimeException("Error converting event Json to Map");
+        }
+    }
+
+    public ZonedDateTime getMostRecentEventTimestamp() {
+        return mostRecentEventTimestamp;
+    }
+
+    public ResourceType getResourceType() {
+        return resourceType;
+    }
+
+    public String getResourceExternalId() {
+        return resourceExternalId;
+    }
+
+    public Map<String, Object> getEventDetailsDigest() {
+        return eventDetailsDigest;
+    }
+
+    public EventType getMostRecentEventType() {
+        return mostRecentEventType;
+    }
+}

--- a/src/main/java/uk/gov/pay/ledger/event/model/EventType.java
+++ b/src/main/java/uk/gov/pay/ledger/event/model/EventType.java
@@ -1,17 +1,5 @@
 package uk.gov.pay.ledger.event.model;
 
-import uk.gov.pay.ledger.transaction.state.TransactionState;
-
 public enum EventType {
-    PAYMENT_CREATED(TransactionState.CREATED);
-
-    private final TransactionState transactionState;
-
-    EventType(TransactionState transactionState) {
-        this.transactionState = transactionState;
-    }
-
-    public TransactionState getTransactionState() {
-        return transactionState;
-    }
+    PAYMENT_CREATED
 }

--- a/src/main/java/uk/gov/pay/ledger/event/model/EventType.java
+++ b/src/main/java/uk/gov/pay/ledger/event/model/EventType.java
@@ -1,0 +1,17 @@
+package uk.gov.pay.ledger.event.model;
+
+import uk.gov.pay.ledger.transaction.state.TransactionState;
+
+public enum EventType {
+    PAYMENT_CREATED(TransactionState.CREATED);
+
+    private final TransactionState transactionState;
+
+    EventType(TransactionState transactionState) {
+        this.transactionState = transactionState;
+    }
+
+    public TransactionState getTransactionState() {
+        return transactionState;
+    }
+}

--- a/src/main/java/uk/gov/pay/ledger/event/model/response/CreateEventResponse.java
+++ b/src/main/java/uk/gov/pay/ledger/event/model/response/CreateEventResponse.java
@@ -1,4 +1,4 @@
-package uk.gov.pay.ledger.event.service.model.response;
+package uk.gov.pay.ledger.event.model.response;
 
 import java.util.Optional;
 

--- a/src/main/java/uk/gov/pay/ledger/event/service/EventService.java
+++ b/src/main/java/uk/gov/pay/ledger/event/service/EventService.java
@@ -3,17 +3,23 @@ package uk.gov.pay.ledger.event.service;
 import com.google.inject.Inject;
 import uk.gov.pay.ledger.event.dao.EventDao;
 import uk.gov.pay.ledger.event.model.Event;
-import uk.gov.pay.ledger.event.service.model.response.CreateEventResponse;
+import uk.gov.pay.ledger.event.model.EventDigest;
+import uk.gov.pay.ledger.event.model.response.CreateEventResponse;
 
+import java.util.List;
 import java.util.Optional;
 
 public class EventService {
-
     private EventDao eventDao;
 
     @Inject
     public EventService(EventDao eventDao) {
         this.eventDao = eventDao;
+    }
+
+    public EventDigest getEventDigestForResource(String resourceExternalId) {
+        List<Event> events = eventDao.getEventsByResourceExternalId(resourceExternalId);
+        return EventDigest.fromEventList(events);
     }
 
     public CreateEventResponse createIfDoesNotExist(Event event) {
@@ -25,4 +31,3 @@ public class EventService {
         }
     }
 }
-

--- a/src/main/java/uk/gov/pay/ledger/queue/EventMessageHandler.java
+++ b/src/main/java/uk/gov/pay/ledger/queue/EventMessageHandler.java
@@ -4,7 +4,7 @@ import com.google.inject.Inject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.pay.ledger.event.service.EventService;
-import uk.gov.pay.ledger.event.service.model.response.CreateEventResponse;
+import uk.gov.pay.ledger.event.model.response.CreateEventResponse;
 
 import java.util.List;
 

--- a/src/test/java/uk/gov/pay/ledger/event/resource/EventResourceIT.java
+++ b/src/test/java/uk/gov/pay/ledger/event/resource/EventResourceIT.java
@@ -35,7 +35,7 @@ public class EventResourceIT {
                 .body("resource_external_id", is(event.getResourceExternalId()))
                 .body("resource_type", is(event.getResourceType().name().toLowerCase()))
                 .body("sqs_message_id", is(event.getSqsMessageId()))
-                .body("event_type", is(event.getEventType()))
+                .body("event_type", is(event.getEventType().toString()))
                 .body("event_data", is(event.getEventData()));
     }
 }

--- a/src/test/java/uk/gov/pay/ledger/event/service/EventServiceTest.java
+++ b/src/test/java/uk/gov/pay/ledger/event/service/EventServiceTest.java
@@ -1,5 +1,7 @@
 package uk.gov.pay.ledger.event.service;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.dropwizard.jackson.Jackson;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -7,8 +9,13 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.pay.ledger.event.dao.EventDao;
 import uk.gov.pay.ledger.event.model.Event;
-import uk.gov.pay.ledger.event.service.model.response.CreateEventResponse;
+import uk.gov.pay.ledger.event.model.EventDigest;
+import uk.gov.pay.ledger.event.model.EventType;
+import uk.gov.pay.ledger.event.model.response.CreateEventResponse;
+import uk.gov.pay.ledger.util.fixture.EventFixture;
 
+import java.time.ZonedDateTime;
+import java.util.List;
 import java.util.Optional;
 
 import static org.hamcrest.core.Is.is;
@@ -19,17 +26,52 @@ import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class EventServiceTest {
-
     @Mock
-    private EventDao mockEventDao;
+    EventDao mockEventDao;
+
+    private static ObjectMapper objectMapper = Jackson.newObjectMapper();
 
     private EventService eventService;
 
     private Event event;
 
+    private ZonedDateTime latestEventTime;
+    private final String resourceExternalId = "resource_external_id";
+
     @Before
     public void setUp() {
         eventService = new EventService(mockEventDao);
+
+        latestEventTime = ZonedDateTime.now().minusHours(1L);
+        String eventDetails1 = "{ \"amount\": 1000}";
+        Event event1 = EventFixture.anEventFixture()
+                .withEventData(eventDetails1)
+                .withResourceExternalId(resourceExternalId)
+                .withEventDate(latestEventTime)
+                .toEntity();
+        String eventDetails2 = "{ \"amount\": 2000, \"description\": \"a payment\"}";
+        Event event2 = EventFixture.anEventFixture()
+                .withEventData(eventDetails2)
+                .withResourceExternalId(resourceExternalId)
+                .withEventDate(ZonedDateTime.now().minusHours(2L))
+                .toEntity();
+        when(mockEventDao.getEventsByResourceExternalId(resourceExternalId)).thenReturn(List.of(event1, event2));
+    }
+
+    @Test
+    public void getEventDigestForResource_shouldUseFirstEventInListToPopulateEventDigestMetadata() {
+        EventDigest eventDigest = eventService.getEventDigestForResource(resourceExternalId);
+
+        assertThat(eventDigest.getMostRecentEventTimestamp(), is(latestEventTime));
+        assertThat(eventDigest.getMostRecentEventType(), is(EventType.PAYMENT_CREATED));
+    }
+
+    @Test
+    public void laterEventsShouldOverrideEarlierEventsInEventDetailsDigest() {
+        EventDigest eventDigest = eventService.getEventDigestForResource(resourceExternalId);
+
+        assertThat(eventDigest.getEventDetailsDigest().get("description"), is("a payment"));
+        assertThat(eventDigest.getEventDetailsDigest().get("amount"), is(1000));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/ledger/queue/EventMessageHandlerTest.java
+++ b/src/test/java/uk/gov/pay/ledger/queue/EventMessageHandlerTest.java
@@ -6,7 +6,7 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.pay.ledger.event.service.EventService;
-import uk.gov.pay.ledger.event.service.model.response.CreateEventResponse;
+import uk.gov.pay.ledger.event.model.response.CreateEventResponse;
 
 import java.util.List;
 

--- a/src/test/java/uk/gov/pay/ledger/queue/EventQueueTest.java
+++ b/src/test/java/uk/gov/pay/ledger/queue/EventQueueTest.java
@@ -10,6 +10,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.pay.ledger.app.LedgerConfig;
 import uk.gov.pay.ledger.app.config.QueueMessageReceiverConfig;
 import uk.gov.pay.ledger.app.config.SqsConfig;
+import uk.gov.pay.ledger.event.model.EventType;
 import uk.gov.pay.ledger.event.model.ResourceType;
 import uk.gov.pay.ledger.queue.sqs.SqsQueueService;
 
@@ -41,7 +42,7 @@ public class EventQueueTest {
                 "\"id\": \"my-id\"," +
                 "\"timestamp\": \"2018-03-12T16:25:01.123456Z\"," +
                 "\"resource_external_id\": \"3uwuyr38rry\"," +
-                "\"event_type\":\"example type\"," +
+                "\"event_type\":\"PAYMENT_CREATED\"," +
                 "\"resource_type\": \"charge\"," +
                 "\"event_details\": {" +
                 "\"example_event_details_field\": \"and its value\"" +
@@ -71,7 +72,7 @@ public class EventQueueTest {
         assertFalse(eventsList.isEmpty());
         assertEquals("3uwuyr38rry", eventsList.get(0).getEvent().getResourceExternalId());
         assertEquals(ZonedDateTime.parse("2018-03-12T16:25:01.123456Z"), eventsList.get(0).getEvent().getEventDate());
-        assertEquals("example type", eventsList.get(0).getEvent().getEventType());
+        assertEquals(EventType.PAYMENT_CREATED, eventsList.get(0).getEvent().getEventType());
         assertEquals(ResourceType.CHARGE, eventsList.get(0).getEvent().getResourceType());
         assertEquals("{\"example_event_details_field\":\"and its value\"}", eventsList.get(0).getEvent().getEventData());
     }

--- a/src/test/java/uk/gov/pay/ledger/queue/QueueMessageReceiverIT.java
+++ b/src/test/java/uk/gov/pay/ledger/queue/QueueMessageReceiverIT.java
@@ -58,7 +58,7 @@ public class QueueMessageReceiverIT {
         assertThat(result.get("resource_type_id"), is(resourceTypeId));
         assertThat(result.get("resource_external_id"), is(event.getResourceExternalId()));
         assertThat((Timestamp) result.get("event_date"), isDate(CREATED_AT));
-        assertThat(result.get("event_type"), is(event.getEventType()));
+        assertThat(result.get("event_type"), is(event.getEventType().toString()));
         assertThat(objectMapper.readTree(result.get("event_data").toString()), is(objectMapper.readTree(event.getEventData())));
     }
 }

--- a/src/test/java/uk/gov/pay/ledger/util/fixture/EventFixture.java
+++ b/src/test/java/uk/gov/pay/ledger/util/fixture/EventFixture.java
@@ -15,7 +15,7 @@ public class EventFixture implements DbFixture<EventFixture, Event> {
     private ResourceType resourceType = ResourceType.CHARGE;
     private String resourceExternalId = RandomStringUtils.randomAlphanumeric(20);
     private ZonedDateTime eventDate = ZonedDateTime.now(ZoneOffset.UTC);
-    private String eventType = "PaymentCreated";
+    private String eventType = "PAYMENT_CREATED";
     private String eventData = "{\"event_data\": \"event data\"}";
 
     private EventFixture() {
@@ -126,7 +126,7 @@ public class EventFixture implements DbFixture<EventFixture, Event> {
         resourceType = event.getResourceType();
         resourceExternalId = event.getResourceExternalId();
         eventDate = event.getEventDate();
-        eventType = event.getEventType();
+        eventType = event.getEventType().toString();
         eventData = event.getEventData();
         return this;
     }

--- a/src/test/java/uk/gov/pay/ledger/util/fixture/QueueEventFixture.java
+++ b/src/test/java/uk/gov/pay/ledger/util/fixture/QueueEventFixture.java
@@ -15,7 +15,7 @@ public class QueueEventFixture implements QueueFixture<QueueEventFixture, Event>
     private ResourceType resourceType = ResourceType.CHARGE;
     private String resourceExternalId = RandomStringUtils.randomAlphanumeric(20);
     private ZonedDateTime eventDate = ZonedDateTime.now(ZoneOffset.UTC);
-    private String eventType = "PaymentCreated";
+    private String eventType = "PAYMENT_CREATED";
     private String eventData = "{\"event_data\": \"event data\"}";
 
     private QueueEventFixture() {


### PR DESCRIPTION
First step in going from receiving an event to writing a transaction. The main idea is the event digest, 
that is used to make sense of the event history for a given resource_external_id.

The EventDigest is an object that represents the summary of a list of events pertinent to the further processing of those events. Basically that amounts to the timestamp and event type of the latest event by timestamp, as well as a compressed digest of the event details attached to each event. The idea is that this EventDigest is easily convertible into a Transaction. The way event details are compressed, if two event_detail objects both contain an attribute then the later event will overwrite the earlier one.  

This PR also introduces EventType enum. As part of this I have changed the name of the expected event from PaymentCreated to PAYMENT_CREATED. This is because whilst Jackson is pretty good at {,de}serialisation, JDBI is not so good, and it's default enum deserialiser uses the enum `name()`, so it significantly reduces boiler plate to use this form.