### PR TITLE
BAU: fix flaky tests

### DIFF
--- a/src/main/java/uk/gov/pay/ledger/app/LedgerApp.java
+++ b/src/main/java/uk/gov/pay/ledger/app/LedgerApp.java
@@ -53,7 +53,9 @@ public class LedgerApp extends Application<LedgerConfig> {
                 .addMappingForUrlPatterns(of(REQUEST), true, "/v1/*");
         environment.jersey().register(new BadRequestExceptionMapper());
 
-        environment.lifecycle().manage(injector.getInstance(QueueMessageReceiver.class));
+        if(config.getQueueMessageReceiverConfig().isBackgroundProcessingEnabled()) {
+            environment.lifecycle().manage(injector.getInstance(QueueMessageReceiver.class));
+        }
     }
 
     private Jdbi createJdbi(DataSourceFactory dataSourceFactory) {

--- a/src/main/java/uk/gov/pay/ledger/app/config/QueueMessageReceiverConfig.java
+++ b/src/main/java/uk/gov/pay/ledger/app/config/QueueMessageReceiverConfig.java
@@ -8,6 +8,9 @@ import javax.validation.constraints.NotNull;
 public class QueueMessageReceiverConfig extends Configuration {
 
     @Valid
+    private boolean backgroundProcessingEnabled;
+
+    @Valid
     @NotNull
     private int threadDelayInMilliseconds;
 
@@ -30,4 +33,6 @@ public class QueueMessageReceiverConfig extends Configuration {
     public int getMessageRetryDelayInSeconds() {
         return messageRetryDelayInSeconds;
     }
+
+    public boolean isBackgroundProcessingEnabled() { return backgroundProcessingEnabled; }
 }

--- a/src/main/resources/config/config.yaml
+++ b/src/main/resources/config/config.yaml
@@ -68,6 +68,7 @@ sqsConfig:
   messageMaximumBatchSize: ${AWS_SQS_MESSAGE_MAXIMUM_BATCH_SIZE:-10}
 
 queueMessageReceiverConfig:
+  backgroundProcessingEnabled: ${BACKGROUND_PROCESSING_ENABLED:-true}
   threadDelayInMilliseconds: ${QUEUE_MESSAGE_RECEIVER_THREAD_DELAY_IN_MILLISECONDS:-1}
   numberOfThreads: ${QUEUE_MESSAGE_RECEIVER_NUMBER_OF_THREADS:-1}
   messageRetryDelayInSeconds: ${QUEUE_MESSAGE_RETRY_DELAY_IN_SECONDS:-900}

--- a/src/test/java/uk/gov/pay/ledger/it/queue/sqs/EventQueueIT.java
+++ b/src/test/java/uk/gov/pay/ledger/it/queue/sqs/EventQueueIT.java
@@ -2,8 +2,11 @@ package uk.gov.pay.ledger.it.queue.sqs;
 
 import com.amazonaws.services.sqs.AmazonSQS;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.pay.ledger.app.LedgerConfig;
 import uk.gov.pay.ledger.app.config.QueueMessageReceiverConfig;
 import uk.gov.pay.ledger.app.config.SqsConfig;
@@ -25,12 +28,18 @@ import static org.mockito.Mockito.when;
 import static uk.gov.pay.ledger.util.fixture.QueueEventFixture.aQueueEventFixture;
 
 @Ignore
+@RunWith(MockitoJUnitRunner.class)
 public class EventQueueIT {
+
+    private AmazonSQS client;
+
+    @Before
+    public void setUp() {
+        client = SqsTestDocker.initialise("event-queue");
+    }
 
     @Test
     public void shouldGetEventMessageDtoFromTheQueue() throws QueueException {
-        AmazonSQS client = SqsTestDocker.initialise("event-queue");
-
         Event event = aQueueEventFixture()
                 .insert(client)
                 .toEntity();
@@ -49,8 +58,6 @@ public class EventQueueIT {
 
     @Test
     public void shouldGetEventMessageFromTheQueue() throws QueueException {
-        AmazonSQS client = SqsTestDocker.initialise("event-queue");
-
         Event event = aQueueEventFixture()
                 .insert(client)
                 .toEntity();

--- a/src/test/java/uk/gov/pay/ledger/it/queue/sqs/QueueEventProcessingIT.java
+++ b/src/test/java/uk/gov/pay/ledger/it/queue/sqs/QueueEventProcessingIT.java
@@ -16,6 +16,7 @@ import java.sql.Timestamp;
 import java.time.ZonedDateTime;
 import java.util.Map;
 
+import static io.dropwizard.testing.ConfigOverride.config;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 import static uk.gov.pay.ledger.util.DatabaseTestHelper.aDatabaseTestHelper;
@@ -26,7 +27,7 @@ import static uk.gov.pay.ledger.util.fixture.QueueEventFixture.aQueueEventFixtur
 public class QueueEventProcessingIT {
 
     @ClassRule
-    public static AppWithPostgresAndSqsRule rule = new AppWithPostgresAndSqsRule(true);
+    public static AppWithPostgresAndSqsRule rule = new AppWithPostgresAndSqsRule(config("queueMessageReceiverConfig.backgroundProcessingEnabled", "true"));
 
     private static final ZonedDateTime CREATED_AT = ZonedDateTime.parse("2019-06-07T08:46:01.123456Z");
     private ObjectMapper objectMapper = new ObjectMapper();

--- a/src/test/java/uk/gov/pay/ledger/it/queue/sqs/QueueEventProcessingIT.java
+++ b/src/test/java/uk/gov/pay/ledger/it/queue/sqs/QueueEventProcessingIT.java
@@ -26,7 +26,7 @@ import static uk.gov.pay.ledger.util.fixture.QueueEventFixture.aQueueEventFixtur
 public class QueueEventProcessingIT {
 
     @ClassRule
-    public static AppWithPostgresAndSqsRule rule = new AppWithPostgresAndSqsRule();
+    public static AppWithPostgresAndSqsRule rule = new AppWithPostgresAndSqsRule(true);
 
     private static final ZonedDateTime CREATED_AT = ZonedDateTime.parse("2019-06-07T08:46:01.123456Z");
     private ObjectMapper objectMapper = new ObjectMapper();

--- a/src/test/java/uk/gov/pay/ledger/rule/AppWithPostgresAndSqsRule.java
+++ b/src/test/java/uk/gov/pay/ledger/rule/AppWithPostgresAndSqsRule.java
@@ -1,6 +1,7 @@
 package uk.gov.pay.ledger.rule;
 
 import com.amazonaws.services.sqs.AmazonSQS;
+import io.dropwizard.testing.ConfigOverride;
 import io.dropwizard.testing.junit.DropwizardAppRule;
 import org.jdbi.v3.core.Jdbi;
 import org.jdbi.v3.sqlobject.SqlObjectPlugin;
@@ -12,6 +13,9 @@ import org.testcontainers.containers.PostgreSQLContainer;
 import uk.gov.pay.ledger.app.LedgerApp;
 import uk.gov.pay.ledger.app.LedgerConfig;
 
+import java.util.List;
+
+import static com.google.common.collect.Lists.newArrayList;
 import static io.dropwizard.testing.ConfigOverride.config;
 import static io.dropwizard.testing.ResourceHelpers.resourceFilePath;
 
@@ -22,26 +26,19 @@ public class AppWithPostgresAndSqsRule extends ExternalResource {
     private PostgreSQLContainer postgres;
     private DropwizardAppRule<LedgerConfig> appRule;
 
-    public AppWithPostgresAndSqsRule() {
-        this(false);
-    }
-
-    public AppWithPostgresAndSqsRule(boolean enableBackgroundProcessing) {
+    public AppWithPostgresAndSqsRule(ConfigOverride... configOverrides) {
         postgres = new PostgreSQLContainer("postgres:11.1");
         postgres.start();
 
         sqsClient = SqsTestDocker.initialise("event-queue");
-        String eventQueueUrl = SqsTestDocker.getQueueUrl("event-queue");
-        String endpoint = SqsTestDocker.getEndpoint();
+
+        ConfigOverride[] newConfigOverrides = overrideDatabaseConfig(configOverrides, postgres);
+        newConfigOverrides = overrideSqsConfig(newConfigOverrides);
+
         appRule = new DropwizardAppRule<>(
                 LedgerApp.class,
                 CONFIG_PATH,
-                config("database.url", postgres.getJdbcUrl()),
-                config("database.user", postgres.getUsername()),
-                config("database.password", postgres.getPassword()),
-                config("queueMessageReceiverConfig.backgroundProcessingEnabled", String.valueOf(enableBackgroundProcessing)),
-                config("sqsConfig.eventQueueUrl", eventQueueUrl),
-                config("sqsConfig.endpoint", endpoint)
+                newConfigOverrides
         );
 
         jdbi = Jdbi.create(postgres.getJdbcUrl(), postgres.getUsername(), postgres.getPassword());
@@ -59,6 +56,21 @@ public class AppWithPostgresAndSqsRule extends ExternalResource {
                         base.evaluate();
                     }
                 }, description);
+    }
+
+    private ConfigOverride[] overrideDatabaseConfig(ConfigOverride[] configOverrides, PostgreSQLContainer postgreSQLContainer) {
+        List<ConfigOverride> newConfigOverride = newArrayList(configOverrides);
+        newConfigOverride.add(config("database.url", postgreSQLContainer.getJdbcUrl()));
+        newConfigOverride.add(config("database.user", postgreSQLContainer.getUsername()));
+        newConfigOverride.add(config("database.password", postgreSQLContainer.getPassword()));
+        return newConfigOverride.toArray(new ConfigOverride[0]);
+    }
+
+    private ConfigOverride[] overrideSqsConfig(ConfigOverride[] configOverrides) {
+        List<ConfigOverride> newConfigOverride = newArrayList(configOverrides);
+        newConfigOverride.add(config("sqsConfig.eventQueueUrl", SqsTestDocker.getQueueUrl("event-queue")));
+        newConfigOverride.add(config("sqsConfig.endpoint", SqsTestDocker.getEndpoint()));
+        return newConfigOverride.toArray(new ConfigOverride[0]);
     }
 
     public DropwizardAppRule<LedgerConfig> getAppRule() {

--- a/src/test/resources/config/test-config.yaml
+++ b/src/test/resources/config/test-config.yaml
@@ -67,6 +67,7 @@ sqsConfig:
   messageMaximumBatchSize: ${AWS_SQS_MESSAGE_MAXIMUM_BATCH_SIZE:-10}
 
 queueMessageReceiverConfig:
+  backgroundProcessingEnabled: ${BACKGROUND_PROCESSING_ENABLED:-false}
   threadDelayInMilliseconds: ${QUEUE_MESSAGE_RECEIVER_THREAD_DELAY_IN_MILLISECONDS:-1}
   numberOfThreads: ${QUEUE_MESSAGE_RECEIVER_NUMBER_OF_THREADS:-1}
   messageRetryDelayInSeconds: ${QUEUE_MESSAGE_RETRY_DELAY_IN_SECONDS:-900}


### PR DESCRIPTION
* There was some sort of interference between the tests that caused sqs integration tests to fail when run with all of them
* Introduced `backgroundProcessingEnabled` configuration variable which is turned off for all the tests but selected one
* small cleanup in `EventQueueIT` test