### PR TITLE
PP-5342 - Enable Integration tests in CI

### DIFF
--- a/src/test/java/uk/gov/pay/ledger/event/dao/EventDaoIT.java
+++ b/src/test/java/uk/gov/pay/ledger/event/dao/EventDaoIT.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.Before;
 import org.junit.ClassRule;
-import org.junit.Ignore;
 import org.junit.Test;
 import uk.gov.pay.ledger.event.model.Event;
 import uk.gov.pay.ledger.rule.AppWithPostgresAndSqsRule;
@@ -24,7 +23,6 @@ import static uk.gov.pay.ledger.util.DatabaseTestHelper.aDatabaseTestHelper;
 import static uk.gov.pay.ledger.util.ZonedDateTimeTimestampMatcher.isDate;
 import static uk.gov.pay.ledger.util.fixture.EventFixture.anEventFixture;
 
-@Ignore
 public class EventDaoIT {
 
     @ClassRule

--- a/src/test/java/uk/gov/pay/ledger/event/dao/EventDaoIT.java
+++ b/src/test/java/uk/gov/pay/ledger/event/dao/EventDaoIT.java
@@ -6,8 +6,6 @@ import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Ignore;
 import org.junit.Test;
-import uk.gov.pay.ledger.event.dao.EventDao;
-import uk.gov.pay.ledger.event.dao.ResourceTypeDao;
 import uk.gov.pay.ledger.event.model.Event;
 import uk.gov.pay.ledger.rule.AppWithPostgresAndSqsRule;
 import uk.gov.pay.ledger.util.DatabaseTestHelper;

--- a/src/test/java/uk/gov/pay/ledger/event/resource/EventResourceIT.java
+++ b/src/test/java/uk/gov/pay/ledger/event/resource/EventResourceIT.java
@@ -1,7 +1,6 @@
 package uk.gov.pay.ledger.event.resource;
 
 import org.junit.ClassRule;
-import org.junit.Ignore;
 import org.junit.Test;
 import uk.gov.pay.ledger.event.model.Event;
 import uk.gov.pay.ledger.rule.AppWithPostgresAndSqsRule;
@@ -13,7 +12,6 @@ import static io.restassured.http.ContentType.JSON;
 import static org.hamcrest.CoreMatchers.is;
 import static uk.gov.pay.ledger.util.fixture.EventFixture.anEventFixture;
 
-@Ignore
 public class EventResourceIT {
     @ClassRule
     public static AppWithPostgresAndSqsRule rule = new AppWithPostgresAndSqsRule();

--- a/src/test/java/uk/gov/pay/ledger/queue/QueueMessageReceiverIT.java
+++ b/src/test/java/uk/gov/pay/ledger/queue/QueueMessageReceiverIT.java
@@ -3,7 +3,6 @@ package uk.gov.pay.ledger.queue;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.Before;
 import org.junit.ClassRule;
-import org.junit.Ignore;
 import org.junit.Test;
 import uk.gov.pay.ledger.event.dao.EventDao;
 import uk.gov.pay.ledger.event.dao.ResourceTypeDao;
@@ -23,7 +22,6 @@ import static uk.gov.pay.ledger.util.DatabaseTestHelper.aDatabaseTestHelper;
 import static uk.gov.pay.ledger.util.ZonedDateTimeTimestampMatcher.isDate;
 import static uk.gov.pay.ledger.util.fixture.QueueEventFixture.aQueueEventFixture;
 
-@Ignore
 public class QueueMessageReceiverIT {
 
     @ClassRule

--- a/src/test/java/uk/gov/pay/ledger/queue/sqs/EventQueueIT.java
+++ b/src/test/java/uk/gov/pay/ledger/queue/sqs/EventQueueIT.java
@@ -4,7 +4,6 @@ import com.amazonaws.services.sqs.AmazonSQS;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.Before;
 import org.junit.ClassRule;
-import org.junit.Ignore;
 import org.junit.Test;
 import uk.gov.pay.ledger.app.LedgerConfig;
 import uk.gov.pay.ledger.app.config.QueueMessageReceiverConfig;
@@ -26,7 +25,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static uk.gov.pay.ledger.util.fixture.QueueEventFixture.aQueueEventFixture;
 
-@Ignore
 public class EventQueueIT {
 
     @ClassRule

--- a/src/test/java/uk/gov/pay/ledger/queue/sqs/EventQueueIT.java
+++ b/src/test/java/uk/gov/pay/ledger/queue/sqs/EventQueueIT.java
@@ -3,10 +3,9 @@ package uk.gov.pay.ledger.queue.sqs;
 import com.amazonaws.services.sqs.AmazonSQS;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Ignore;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.pay.ledger.app.LedgerConfig;
 import uk.gov.pay.ledger.app.config.QueueMessageReceiverConfig;
 import uk.gov.pay.ledger.app.config.SqsConfig;
@@ -15,7 +14,7 @@ import uk.gov.pay.ledger.queue.EventMessage;
 import uk.gov.pay.ledger.queue.EventQueue;
 import uk.gov.pay.ledger.queue.QueueException;
 import uk.gov.pay.ledger.queue.QueueMessage;
-import uk.gov.pay.ledger.queue.sqs.SqsQueueService;
+import uk.gov.pay.ledger.rule.AppWithPostgresAndSqsRule;
 import uk.gov.pay.ledger.rule.SqsTestDocker;
 
 import java.util.List;
@@ -28,14 +27,15 @@ import static org.mockito.Mockito.when;
 import static uk.gov.pay.ledger.util.fixture.QueueEventFixture.aQueueEventFixture;
 
 @Ignore
-@RunWith(MockitoJUnitRunner.class)
 public class EventQueueIT {
 
+    @ClassRule
+    public static AppWithPostgresAndSqsRule rule = new AppWithPostgresAndSqsRule();
     private AmazonSQS client;
 
     @Before
     public void setUp() {
-        client = SqsTestDocker.initialise("event-queue");
+        client = rule.getSqsClient();
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/ledger/queue/sqs/EventQueueIT.java
+++ b/src/test/java/uk/gov/pay/ledger/queue/sqs/EventQueueIT.java
@@ -4,6 +4,7 @@ import com.amazonaws.services.sqs.AmazonSQS;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.Before;
 import org.junit.ClassRule;
+import org.junit.Ignore;
 import org.junit.Test;
 import uk.gov.pay.ledger.app.LedgerConfig;
 import uk.gov.pay.ledger.app.config.QueueMessageReceiverConfig;
@@ -25,6 +26,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static uk.gov.pay.ledger.util.fixture.QueueEventFixture.aQueueEventFixture;
 
+@Ignore
 public class EventQueueIT {
 
     @ClassRule
@@ -48,9 +50,9 @@ public class EventQueueIT {
         LedgerConfig mockConfig = mock(LedgerConfig.class);
         when(mockConfig.getSqsConfig()).thenReturn(sqsConfig);
 
-        SqsQueueService x = new SqsQueueService(client, mockConfig);
+        SqsQueueService sqsQueueService = new SqsQueueService(client, mockConfig);
 
-        List<QueueMessage> result = x.receiveMessages(SqsTestDocker.getQueueUrl("event-queue"), "All");
+        List<QueueMessage> result = sqsQueueService.receiveMessages(SqsTestDocker.getQueueUrl("event-queue"), "All");
         assertFalse(result.isEmpty());
     }
 
@@ -70,10 +72,10 @@ public class EventQueueIT {
         when(mockConfig.getSqsConfig()).thenReturn(sqsConfig);
         when(mockConfig.getQueueMessageReceiverConfig()).thenReturn(queueReceiverConfig);
 
-        SqsQueueService x = new SqsQueueService(client, mockConfig);
-        EventQueue y = new EventQueue(x, mockConfig, new ObjectMapper());
+        SqsQueueService sqsQueueService = new SqsQueueService(client, mockConfig);
+        EventQueue eventQueue = new EventQueue(sqsQueueService, mockConfig, new ObjectMapper());
 
-        List<EventMessage> result = y.retrieveEvents();
+        List<EventMessage> result = eventQueue.retrieveEvents();
         assertFalse(result.isEmpty());
         assertThat(result.get(0).getId(), is(event.getResourceExternalId()));
     }

--- a/src/test/java/uk/gov/pay/ledger/rule/PostgresTestDocker.java
+++ b/src/test/java/uk/gov/pay/ledger/rule/PostgresTestDocker.java
@@ -1,0 +1,58 @@
+package uk.gov.pay.ledger.rule;
+
+import org.testcontainers.containers.PostgreSQLContainer;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+
+import static java.sql.DriverManager.getConnection;
+
+public class PostgresTestDocker {
+    private static final String DB_NAME = "ledger_test";
+    private static PostgreSQLContainer container;
+
+    static void getOrCreate() {
+        try {
+            if (container == null) {
+                container = (PostgreSQLContainer) new PostgreSQLContainer("postgres:11.1")
+                        .withUsername("test")
+                        .withPassword("test");
+                container.start();
+                createDatabase(DB_NAME);
+            }
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static String getConnectionUrl() {
+        return container.getJdbcUrl();
+    }
+
+    private static void createDatabase(final String dbName) {
+        final String dbUser = getDbUsername();
+
+        try (Connection connection = getConnection(getDbRootUri(), dbUser, getDbPassword())) {
+            connection.createStatement().execute("CREATE DATABASE " + dbName + " WITH owner=" + dbUser + " TEMPLATE postgres");
+            connection.createStatement().execute("GRANT ALL PRIVILEGES ON DATABASE " + dbName + " TO " + dbUser);
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static String getDbRootUri() {
+        return container.getJdbcUrl();
+    }
+
+    static String getDbUri() {
+        return getDbRootUri() + DB_NAME;
+    }
+
+    static String getDbPassword() {
+        return container.getPassword();
+    }
+
+    static String getDbUsername() {
+        return container.getUsername();
+    }
+}

--- a/src/test/java/uk/gov/pay/ledger/transaction/dao/TransactionDaoSearchIT.java
+++ b/src/test/java/uk/gov/pay/ledger/transaction/dao/TransactionDaoSearchIT.java
@@ -7,7 +7,6 @@ import org.junit.ClassRule;
 import org.junit.Ignore;
 import org.junit.Test;
 import uk.gov.pay.ledger.rule.AppWithPostgresAndSqsRule;
-import uk.gov.pay.ledger.transaction.dao.TransactionDao;
 import uk.gov.pay.ledger.transaction.model.CardDetails;
 import uk.gov.pay.ledger.transaction.model.Transaction;
 import uk.gov.pay.ledger.transaction.search.common.CommaDelimitedSetParameter;
@@ -23,7 +22,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 import static uk.gov.pay.ledger.util.fixture.TransactionFixture.aTransactionFixture;
 
-@Ignore
+//@Ignore
 public class TransactionDaoSearchIT {
 
     @ClassRule

--- a/src/test/java/uk/gov/pay/ledger/transaction/dao/TransactionDaoSearchIT.java
+++ b/src/test/java/uk/gov/pay/ledger/transaction/dao/TransactionDaoSearchIT.java
@@ -4,7 +4,6 @@ package uk.gov.pay.ledger.transaction.dao;
 import org.hamcrest.Matchers;
 import org.junit.Before;
 import org.junit.ClassRule;
-import org.junit.Ignore;
 import org.junit.Test;
 import uk.gov.pay.ledger.rule.AppWithPostgresAndSqsRule;
 import uk.gov.pay.ledger.transaction.model.CardDetails;
@@ -22,7 +21,6 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 import static uk.gov.pay.ledger.util.fixture.TransactionFixture.aTransactionFixture;
 
-//@Ignore
 public class TransactionDaoSearchIT {
 
     @ClassRule

--- a/src/test/java/uk/gov/pay/ledger/transaction/resource/TransactionResourceIT.java
+++ b/src/test/java/uk/gov/pay/ledger/transaction/resource/TransactionResourceIT.java
@@ -2,7 +2,6 @@ package uk.gov.pay.ledger.transaction.resource;
 
 import org.junit.Before;
 import org.junit.ClassRule;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.testcontainers.shaded.org.apache.commons.lang.RandomStringUtils;
 import uk.gov.pay.ledger.rule.AppWithPostgresAndSqsRule;
@@ -20,7 +19,6 @@ import static uk.gov.pay.commons.model.ApiResponseDateTimeFormatter.ISO_INSTANT_
 import static uk.gov.pay.ledger.util.fixture.TransactionFixture.aPersistedTransactionList;
 import static uk.gov.pay.ledger.util.fixture.TransactionFixture.aTransactionFixture;
 
-@Ignore
 public class TransactionResourceIT {
 
     @ClassRule


### PR DESCRIPTION
## WHAT
- Enables all integration tests except `EventQueueIT` as it is flaky in CI but works fine in local dev environment
- Uses single docker container (postgres, sqs) for all tests
- Uses GenericContainer for postgres DB instead of test containers `PostgreSQLContainer`

## HOW
- CI should pass
- Only one container for postgres/sqs should be started for all tests (can check with tests run locally and monitor docker containers)

