### PR TITLE
PP-5255 Introduce transaction_detail column

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -104,7 +104,12 @@
             <artifactId>aws-java-sdk-sqs</artifactId>
             <version>1.11.575</version>
         </dependency>
-        <!--test dependencies-->
+        <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+            <version>2.8.5</version>
+        </dependency>
+<!--test dependencies-->
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>postgresql</artifactId>

--- a/src/main/java/uk/gov/pay/ledger/transaction/search/common/TransactionSearchParams.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/search/common/TransactionSearchParams.java
@@ -9,7 +9,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 
 import static java.lang.String.format;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;

--- a/src/main/resources/migrations/00004_modify_transaction_table.sql
+++ b/src/main/resources/migrations/00004_modify_transaction_table.sql
@@ -1,0 +1,18 @@
+--liquibase formatted sql
+
+--changeset uk.gov.pay:build_table_event
+
+ALTER TABLE transaction
+
+ADD COLUMN transaction_details jsonb,
+
+DROP COLUMN return_url,
+DROP COLUMN payment_provider,
+DROP COLUMN language,
+DROP COLUMN delayed_capture,
+DROP COLUMN address_line1,
+DROP COLUMN address_line2,
+DROP COLUMN address_postcode,
+DROP COLUMN address_city,
+DROP COLUMN address_county,
+DROP COLUMN address_country;

--- a/src/test/java/uk/gov/pay/ledger/transaction/dao/TransactionDaoSearchIT.java
+++ b/src/test/java/uk/gov/pay/ledger/transaction/dao/TransactionDaoSearchIT.java
@@ -119,7 +119,7 @@ public class TransactionDaoSearchIT {
 
         List<Transaction> transactionList = transactionDao.searchTransactions(searchParams);
 
-        assertThat(transactionList.size(), Matchers.is(1));
+        assertThat(transactionList.size(), is(1));
         assertThat(transactionList.get(0).getEmail(), is("testemail1@example.org"));
 
         Long total = transactionDao.getTotalForSearch(searchParams);

--- a/src/test/java/uk/gov/pay/ledger/transaction/service/TransactionServiceTest.java
+++ b/src/test/java/uk/gov/pay/ledger/transaction/service/TransactionServiceTest.java
@@ -128,5 +128,4 @@ public class TransactionServiceTest {
         assertThat(selfLink, containsString("refund_states=created%2Crefunded"));
         assertThat(selfLink, containsString("card_brand=visa%2Cmastercard"));
     }
-
 }


### PR DESCRIPTION
  In an attempt to keep transactions relatively generic, introduce a transactio_detail jsonb column and move most things "card related" into it. Update mapping and fixtures accordingly. I have kept cardholder_name as its own column in order to ensure searching on this will continue to be performant. We cn look at making this more payment type agnostic in future.