### PR TITLE
PP-5257 Unignore pacts to verify

### DIFF
--- a/src/test/java/uk/gov/pay/ledger/pact/TransactionsApiContractTest.java
+++ b/src/test/java/uk/gov/pay/ledger/pact/TransactionsApiContractTest.java
@@ -1,6 +1,5 @@
 package uk.gov.pay.ledger.pact;
 
-import au.com.dius.pact.provider.junit.IgnoreNoPactsToVerify;
 import au.com.dius.pact.provider.junit.PactRunner;
 import au.com.dius.pact.provider.junit.Provider;
 import au.com.dius.pact.provider.junit.State;
@@ -15,7 +14,6 @@ import org.junit.ClassRule;
 import org.junit.runner.RunWith;
 import uk.gov.pay.ledger.rule.AppWithPostgresAndSqsRule;
 import uk.gov.pay.ledger.util.DatabaseTestHelper;
-import uk.gov.pay.ledger.util.fixture.TransactionFixture;
 
 import java.time.ZonedDateTime;
 import java.util.Map;
@@ -25,7 +23,6 @@ import static uk.gov.pay.ledger.util.fixture.TransactionFixture.aTransactionFixt
 
 @RunWith(PactRunner.class)
 @Provider("ledger")
-@IgnoreNoPactsToVerify
 @PactBroker(scheme = "https", host = "pact-broker-test.cloudapps.digital", tags = {"${PACT_CONSUMER_TAG}", "test", "staging", "production"},
         authentication = @PactBrokerAuth(username = "${PACT_BROKER_USERNAME}", password = "${PACT_BROKER_PASSWORD}"),
         consumers = {"publicapi"})


### PR DESCRIPTION
## WHAT 
- Removes annotation `IgnoreNoPactsToVerify` from contract tests as consumer pacts (publicapi) are now published to pact-broker and pacts are available to verify