### PR TITLE
PP-5255 Insert transaction on recieving event

### DIFF
--- a/src/main/java/uk/gov/pay/ledger/event/model/EventDetailsDigest.java
+++ b/src/main/java/uk/gov/pay/ledger/event/model/EventDetailsDigest.java
@@ -1,0 +1,58 @@
+package uk.gov.pay.ledger.event.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class EventDetailsDigest {
+    private String gatewayAccountId;
+    private Long amount;
+    private String reference;
+    private String description;
+    private String state;
+    private String language;
+    private String externalId;
+    private String returnUrl;
+    private String email;
+    private String paymentProvider;
+    private Boolean delayedCapture;
+    private String externalMetaData;
+
+    public String getGatewayAccountId() {
+        return gatewayAccountId;
+    }
+
+    public Long getAmount() {
+        return amount;
+    }
+
+    public String getReference() {
+        return reference;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public String getLanguage() {
+        return language;
+    }
+
+    public String getReturnUrl() {
+        return returnUrl;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public String getPaymentProvider() {
+        return paymentProvider;
+    }
+
+    public Boolean getDelayedCapture() {
+        return delayedCapture;
+    }
+}

--- a/src/main/java/uk/gov/pay/ledger/transaction/dao/TransactionDao.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/dao/TransactionDao.java
@@ -23,6 +23,17 @@ public class TransactionDao {
             "FROM transaction t " +
             "WHERE t.gateway_account_id = :account_id " +
             ":searchExtraFields ";
+
+    private static final String INSERT_STRING =
+            "INSERT INTO transaction(" +
+                "external_id,gateway_account_id, amount,description,reference,status,email,cardholder_name," +
+                "external_metadata,created_date,transaction_details" +
+            ") " +
+            "VALUES (" +
+                ":externalId,:gatewayAccountId,:amount,:description,:reference,:status,:email,:cardholderName," +
+                "CAST(:externalMetadata as jsonb),:createdDate,CAST(:transactionDetails as jsonb)" +
+            ");";
+
     private final Jdbi jdbi;
 
     @Inject
@@ -59,5 +70,12 @@ public class TransactionDao {
                     .mapTo(Long.class)
                     .findOnly();
         });
+    }
+
+    public void insert(Transaction transaction) {
+        jdbi.withHandle(handle ->
+                handle.createUpdate(INSERT_STRING)
+                .bindBean(TransactionRow.fromTransaction(transaction))
+                .execute());
     }
 }

--- a/src/main/java/uk/gov/pay/ledger/transaction/dao/TransactionRow.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/dao/TransactionRow.java
@@ -1,0 +1,118 @@
+package uk.gov.pay.ledger.transaction.dao;
+
+import com.google.gson.JsonObject;
+import uk.gov.pay.ledger.transaction.model.CardDetails;
+import uk.gov.pay.ledger.transaction.model.Transaction;
+
+import java.time.ZonedDateTime;
+import java.util.Optional;
+
+public class TransactionRow {
+    private Long id;
+    private String gatewayAccountId;
+    private Long amount;
+    private String reference;
+    private String description;
+    private String status;
+    private String language;
+    private String externalId;
+    private String returnUrl;
+    private String email;
+    private String paymentProvider;
+    private ZonedDateTime createdAt;
+    private CardDetails cardDetails;
+    private Boolean delayedCapture;
+    private String externalMetaData;
+
+    private TransactionRow(Transaction transaction) {
+        this.id = transaction.getId();
+        this.gatewayAccountId = transaction.getGatewayAccountId();
+        this.amount = transaction.getAmount();
+        this.reference = transaction.getReference();
+        this.description = transaction.getDescription();
+        this.status = transaction.getState();
+        this.language = transaction.getLanguage();
+        this.externalId = transaction.getExternalId();
+        this.returnUrl = transaction.getReturnUrl();
+        this.email = transaction.getEmail();
+        this.paymentProvider = transaction.getPaymentProvider();
+        this.createdAt = transaction.getCreatedAt();
+        this.cardDetails = transaction.getCardDetails();
+        this.delayedCapture = transaction.getDelayedCapture();
+        this.externalMetaData = transaction.getExternalMetaData();
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getGatewayAccountId() {
+        return gatewayAccountId;
+    }
+
+    public Long getAmount() {
+        return amount;
+    }
+
+    public String getReference() {
+        return reference;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public String getExternalId() {
+        return externalId;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public ZonedDateTime getCreatedDate() {
+        return createdAt;
+    }
+
+    public String getExternalMetadata() {
+        return externalMetaData;
+    }
+
+    public String getCardholderName() {
+        return Optional.ofNullable(cardDetails)
+                .map(CardDetails::getCardHolderName)
+                .orElse(null);
+    }
+
+    public String getTransactionDetails() {
+        JsonObject transactionDetail = new JsonObject();
+
+        transactionDetail.addProperty("language", language);
+        transactionDetail.addProperty("return_url", returnUrl);
+        transactionDetail.addProperty("payment_provider", paymentProvider);
+        transactionDetail.addProperty("delayed_capture", delayedCapture);
+        Optional.ofNullable(cardDetails)
+                .ifPresent(cd -> {
+                    Optional.ofNullable(cd.getBillingAddress())
+                            .ifPresent(ba -> {
+                                transactionDetail.addProperty("address_line1", ba.getAddressLine1());
+                                transactionDetail.addProperty("address_line2", ba.getAddressLine2());
+                                transactionDetail.addProperty("address_postcode", ba.getAddressPostCode());
+                                transactionDetail.addProperty("address_city", ba.getAddressCity());
+                                transactionDetail.addProperty("address_county", ba.getAddressCounty());
+                                transactionDetail.addProperty("address_country", ba.getAddressCountry());
+                            });
+
+                });
+
+        return transactionDetail.toString();
+    }
+
+    public static TransactionRow fromTransaction(Transaction transaction) {
+        return new TransactionRow(transaction);
+    }
+}

--- a/src/main/java/uk/gov/pay/ledger/transaction/model/Address.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/model/Address.java
@@ -3,6 +3,8 @@ package uk.gov.pay.ledger.transaction.model;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import java.util.Objects;
+
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class Address {
 
@@ -51,5 +53,23 @@ public class Address {
     @JsonProperty("country")
     public String getAddressCountry() {
         return addressCountry;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Address address = (Address) o;
+        return Objects.equals(addressLine1, address.addressLine1) &&
+                Objects.equals(addressLine2, address.addressLine2) &&
+                Objects.equals(addressPostCode, address.addressPostCode) &&
+                Objects.equals(addressCity, address.addressCity) &&
+                Objects.equals(addressCounty, address.addressCounty) &&
+                Objects.equals(addressCountry, address.addressCountry);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(addressLine1, addressLine2, addressPostCode, addressCity, addressCounty, addressCountry);
     }
 }

--- a/src/main/java/uk/gov/pay/ledger/transaction/model/CardDetails.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/model/CardDetails.java
@@ -4,6 +4,8 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import java.util.Objects;
+
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonFormat(shape = JsonFormat.Shape.OBJECT)
 public class CardDetails {
@@ -31,5 +33,20 @@ public class CardDetails {
     @JsonProperty("card_brand")
     public String getCardBrand() {
         return cardBrand == null ? "" : cardBrand;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        CardDetails that = (CardDetails) o;
+        return Objects.equals(cardHolderName, that.cardHolderName) &&
+                Objects.equals(billingAddress, that.billingAddress) &&
+                Objects.equals(cardBrand, that.cardBrand);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(cardHolderName, billingAddress, cardBrand);
     }
 }

--- a/src/main/java/uk/gov/pay/ledger/transaction/model/Transaction.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/model/Transaction.java
@@ -29,7 +29,7 @@ public class Transaction {
     private Boolean delayedCapture;
     private String externalMetaData;
 
-    public Transaction(){
+    public Transaction() {
 
     }
 
@@ -53,6 +53,16 @@ public class Transaction {
         this.cardDetails = cardDetails;
         this.delayedCapture = delayedCapture;
         this.externalMetaData = externalMetaData;
+    }
+
+    public Transaction(String gatewayAccountId, Long amount,
+                       String reference, String description, String state,
+                       String language, String externalId, String returnUrl,
+                       String email, String paymentProvider, ZonedDateTime createdAt,
+                       CardDetails cardDetails, Boolean delayedCapture, String externalMetaData) {
+
+        this(null, gatewayAccountId, amount, reference, description, state, language, externalId, returnUrl, email,
+                paymentProvider, createdAt, cardDetails, delayedCapture, externalMetaData);
     }
 
 

--- a/src/main/java/uk/gov/pay/ledger/transaction/service/TransactionService.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/service/TransactionService.java
@@ -61,4 +61,8 @@ public class TransactionService {
 
         return transactionView;
     }
+
+    public void insert(Transaction transaction) {
+        transactionDao.insert(transaction);
+    }
 }

--- a/src/main/resources/migrations/00005_drop_not_null_transaction_table.sql
+++ b/src/main/resources/migrations/00005_drop_not_null_transaction_table.sql
@@ -1,0 +1,8 @@
+--liquibase formatted sql
+
+--changeset uk.gov.pay:modify_transaction_table_drop_not_null_constraints
+
+ALTER TABLE transaction ALTER COLUMN gateway_account_id DROP NOT NULL;
+ALTER TABLE transaction ALTER COLUMN amount DROP NOT NULL;
+ALTER TABLE transaction ALTER COLUMN reference DROP NOT NULL;
+ALTER TABLE transaction ALTER COLUMN description DROP NOT NULL;

--- a/src/test/java/uk/gov/pay/ledger/event/service/EventServiceTest.java
+++ b/src/test/java/uk/gov/pay/ledger/event/service/EventServiceTest.java
@@ -70,8 +70,8 @@ public class EventServiceTest {
     public void laterEventsShouldOverrideEarlierEventsInEventDetailsDigest() {
         EventDigest eventDigest = eventService.getEventDigestForResource(resourceExternalId);
 
-        assertThat(eventDigest.getEventDetailsDigest().get("description"), is("a payment"));
-        assertThat(eventDigest.getEventDetailsDigest().get("amount"), is(1000));
+        assertThat(eventDigest.getEventDetailsDigest().getDescription(), is("a payment"));
+        assertThat(eventDigest.getEventDetailsDigest().getAmount(), is(1000L));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/ledger/queue/QueueMessageReceiverIT.java
+++ b/src/test/java/uk/gov/pay/ledger/queue/QueueMessageReceiverIT.java
@@ -1,25 +1,17 @@
 package uk.gov.pay.ledger.queue;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
-import uk.gov.pay.ledger.event.dao.EventDao;
-import uk.gov.pay.ledger.event.dao.ResourceTypeDao;
 import uk.gov.pay.ledger.event.model.Event;
 import uk.gov.pay.ledger.rule.AppWithPostgresAndSqsRule;
-import uk.gov.pay.ledger.util.DatabaseTestHelper;
 
 import java.io.IOException;
-import java.sql.Timestamp;
 import java.time.ZonedDateTime;
-import java.util.Map;
 
 import static io.dropwizard.testing.ConfigOverride.config;
+import static io.restassured.RestAssured.given;
+import static io.restassured.http.ContentType.JSON;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
-import static uk.gov.pay.ledger.util.DatabaseTestHelper.aDatabaseTestHelper;
-import static uk.gov.pay.ledger.util.ZonedDateTimeTimestampMatcher.isDate;
 import static uk.gov.pay.ledger.util.fixture.QueueEventFixture.aQueueEventFixture;
 
 public class QueueMessageReceiverIT {
@@ -28,18 +20,6 @@ public class QueueMessageReceiverIT {
     public static AppWithPostgresAndSqsRule rule = new AppWithPostgresAndSqsRule(config("queueMessageReceiverConfig.backgroundProcessingEnabled", "true"));
 
     private static final ZonedDateTime CREATED_AT = ZonedDateTime.parse("2019-06-07T08:46:01.123456Z");
-    private ObjectMapper objectMapper = new ObjectMapper();
-
-    private EventDao eventDao;
-    private ResourceTypeDao resourceTypeDao;
-    private DatabaseTestHelper dbHelper;
-
-    @Before
-    public void setUp() {
-        eventDao = rule.getJdbi().onDemand(EventDao.class);
-        resourceTypeDao = rule.getJdbi().onDemand(ResourceTypeDao.class);
-        dbHelper = aDatabaseTestHelper(rule.getJdbi());
-    }
 
     @Test
     public void shouldInsertEvent() throws IOException, InterruptedException {
@@ -50,13 +30,13 @@ public class QueueMessageReceiverIT {
 
         Thread.sleep(1000);
 
-        int resourceTypeId = resourceTypeDao.getResourceTypeIdByName(event.getResourceType().name());
-        Map<String, Object> result = dbHelper.getEventByExternalId(event.getResourceExternalId());
-        assertThat(result.get("sqs_message_id"), is(event.getSqsMessageId()));
-        assertThat(result.get("resource_type_id"), is(resourceTypeId));
-        assertThat(result.get("resource_external_id"), is(event.getResourceExternalId()));
-        assertThat((Timestamp) result.get("event_date"), isDate(CREATED_AT));
-        assertThat(result.get("event_type"), is(event.getEventType().toString()));
-        assertThat(objectMapper.readTree(result.get("event_data").toString()), is(objectMapper.readTree(event.getEventData())));
+        String resourceExternalId = event.getResourceExternalId();
+        given().port(rule.getAppRule().getLocalPort())
+                .contentType(JSON)
+                .get("/v1/transaction/" + resourceExternalId)
+                .then()
+                .statusCode(200)
+                .body("external_id", is(resourceExternalId))
+                .body("state", is("Created"));
     }
 }

--- a/src/test/java/uk/gov/pay/ledger/transaction/dao/TransactionDaoIT.java
+++ b/src/test/java/uk/gov/pay/ledger/transaction/dao/TransactionDaoIT.java
@@ -1,0 +1,44 @@
+package uk.gov.pay.ledger.transaction.dao;
+
+import org.junit.ClassRule;
+import org.junit.Test;
+import uk.gov.pay.ledger.rule.AppWithPostgresAndSqsRule;
+import uk.gov.pay.ledger.transaction.model.Transaction;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static uk.gov.pay.ledger.util.fixture.TransactionFixture.aTransactionFixture;
+
+public class TransactionDaoIT {
+
+    @ClassRule
+    public static AppWithPostgresAndSqsRule rule = new AppWithPostgresAndSqsRule();
+
+    private TransactionDao transactionDao = new TransactionDao(rule.getJdbi());
+
+    @Test
+    public void shouldInsertTransaction() {
+        Transaction transaction = aTransactionFixture()
+                .toEntity();
+
+        transactionDao.insert(transaction);
+
+        Transaction retrievedTransaction = transactionDao.findTransactionByExternalId(transaction.getExternalId()).get();
+
+        assertThat(retrievedTransaction.getId(), notNullValue());
+        assertThat(retrievedTransaction.getExternalId(), is(transaction.getExternalId()));
+        assertThat(retrievedTransaction.getCardDetails(), is(transaction.getCardDetails()));
+        assertThat(retrievedTransaction.getReference(), is(transaction.getReference()));
+        assertThat(retrievedTransaction.getGatewayAccountId(), is(transaction.getGatewayAccountId()));
+        assertThat(retrievedTransaction.getEmail(), is(transaction.getEmail()));
+        assertThat(retrievedTransaction.getAmount(), is(transaction.getAmount()));
+        assertThat(retrievedTransaction.getCreatedAt(), is(transaction.getCreatedAt()));
+        assertThat(retrievedTransaction.getDelayedCapture(), is(transaction.getDelayedCapture()));
+        assertThat(retrievedTransaction.getLanguage(), is(transaction.getLanguage()));
+        assertThat(retrievedTransaction.getPaymentProvider(), is(transaction.getPaymentProvider()));
+        assertThat(retrievedTransaction.getReturnUrl(), is(transaction.getReturnUrl()));
+        assertThat(retrievedTransaction.getState(), is(transaction.getState()));
+        assertThat(retrievedTransaction.getExternalMetaData(), is(transaction.getExternalMetaData()));
+    }
+}

--- a/src/test/java/uk/gov/pay/ledger/transaction/dao/TransactionDaoSearchIT.java
+++ b/src/test/java/uk/gov/pay/ledger/transaction/dao/TransactionDaoSearchIT.java
@@ -10,6 +10,7 @@ import uk.gov.pay.ledger.transaction.model.CardDetails;
 import uk.gov.pay.ledger.transaction.model.Transaction;
 import uk.gov.pay.ledger.transaction.search.common.CommaDelimitedSetParameter;
 import uk.gov.pay.ledger.transaction.search.common.TransactionSearchParams;
+import uk.gov.pay.ledger.util.DatabaseTestHelper;
 import uk.gov.pay.ledger.util.fixture.TransactionFixture;
 
 import java.time.ZonedDateTime;
@@ -30,8 +31,11 @@ public class TransactionDaoSearchIT {
     private TransactionDao transactionDao;
     private TransactionSearchParams searchParams;
 
+    private DatabaseTestHelper databaseTestHelper = DatabaseTestHelper.aDatabaseTestHelper(rule.getJdbi());
+
     @Before
     public void setUp() {
+        databaseTestHelper.truncateAllData();
         transactionDao = new TransactionDao(rule.getJdbi());
         searchParams = new TransactionSearchParams();
     }
@@ -133,7 +137,6 @@ public class TransactionDaoSearchIT {
 
         for (int i = 0; i < 2; i++) {
             aTransactionFixture()
-                    .withId((long) i)
                     .withAmount(100l + i)
                     .withGatewayAccountId(gatewayAccountId)
                     .withReference("reference " + i)


### PR DESCRIPTION
Adds the connecting logic that takes an EventDigest and creates and
inserts a transaction.

At the moment this simply inserts a transaction, so will not handle multiple
events. It also hardcodes the state of the transaction, so the mapping
logic needs writing.

In order to do this I have dropped some constraints on the transaction table.
This is because we don;t know what order we are going to recieve events,
so we may have only a minimal amount of information to create the
transaction, therefore we cannot enforce non-null constraints on things like
description, reference etc.

Another mildly controversial thing I have done is equate the event
`resourceExternalId` with the transaction externalId. I think this
is correct, as ultimately we need to be able to retrieve things from
connector and ledger with the same id.

This commit also does not contain any db transactions around
handling the event and creating transaction. I have thought about
this, but will hold off worrying about it for another commit.