### PR TITLE
PP-5355 Example message consumer pact test

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -24,12 +24,23 @@ pipeline {
 
   stages {
     stage('Maven Build') {
+      when {
+        branch 'master'
+      }
       steps {
         script {
-          long stepBuildTime = System.currentTimeMillis()
-          sh 'mvn -version'
-          sh 'mvn clean verify'
-          runProviderContractTests()
+          def stepBuildTime = System.currentTimeMillis()
+          def commit = gitCommit()
+          def branchName = 'master'
+
+          withCredentials([
+                  string(credentialsId: 'pact_broker_username', variable: 'PACT_BROKER_USERNAME'),
+                  string(credentialsId: 'pact_broker_password', variable: 'PACT_BROKER_PASSWORD')]
+          ) {
+              sh 'mvn -version'
+              sh "mvn clean package pact:publish -DPACT_BROKER_URL=https://pact-broker-test.cloudapps.digital -DPACT_CONSUMER_VERSION=${commit}" +
+                      " -DPACT_BROKER_USERNAME=${PACT_BROKER_USERNAME} -DPACT_BROKER_PASSWORD=${PACT_BROKER_PASSWORD} -DPACT_CONSUMER_TAG=${branchName}"
+          }
           postSuccessfulMetrics("ledger.maven-build", stepBuildTime)
         }
       }
@@ -37,6 +48,35 @@ pipeline {
         failure {
           postMetric("ledger.maven-build.failure", 1)
         }
+      }
+    }
+    stage('Maven Build Branch') {
+      when {
+        not {
+          branch 'master'
+        }
+      }
+      steps {
+        script {
+          def stepBuildTime = System.currentTimeMillis()
+          def commit = gitCommit()
+          def branchName = gitBranchName()
+
+          withCredentials([
+                  string(credentialsId: 'pact_broker_username', variable: 'PACT_BROKER_USERNAME'),
+                  string(credentialsId: 'pact_broker_password', variable: 'PACT_BROKER_PASSWORD')]
+          ) {
+              sh 'mvn -version'
+              sh "mvn clean package pact:publish -DrunContractTests -DPACT_BROKER_URL=https://pact-broker-test.cloudapps.digital -DPACT_CONSUMER_VERSION=${commit}" +
+                      " -DPACT_BROKER_USERNAME=${PACT_BROKER_USERNAME} -DPACT_BROKER_PASSWORD=${PACT_BROKER_PASSWORD} -DPACT_CONSUMER_TAG=${branchName}"
+          }
+          postSuccessfulMetrics("ledger.maven-build", stepBuildTime)
+      }
+      }
+      post {
+          failure {
+              postMetric("ledger.maven-build.failure", 1)
+          }
       }
     }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -23,7 +23,7 @@ pipeline {
   }
 
   stages {
-    stage('Maven Build') {
+    stage('Maven Build Master') {
       when {
         branch 'master'
       }
@@ -67,7 +67,7 @@ pipeline {
                   string(credentialsId: 'pact_broker_password', variable: 'PACT_BROKER_PASSWORD')]
           ) {
               sh 'mvn -version'
-              sh "mvn clean package pact:publish -DrunContractTests -DPACT_BROKER_URL=https://pact-broker-test.cloudapps.digital -DPACT_CONSUMER_VERSION=${commit}" +
+              sh "mvn clean package pact:publish -DPACT_BROKER_URL=https://pact-broker-test.cloudapps.digital -DPACT_CONSUMER_VERSION=${commit}" +
                       " -DPACT_BROKER_USERNAME=${PACT_BROKER_USERNAME} -DPACT_BROKER_PASSWORD=${PACT_BROKER_PASSWORD} -DPACT_CONSUMER_TAG=${branchName}"
           }
           postSuccessfulMetrics("ledger.maven-build", stepBuildTime)
@@ -79,7 +79,6 @@ pipeline {
           }
       }
     }
-
     stage('Docker Build') {
       steps {
         script {

--- a/pom.xml
+++ b/pom.xml
@@ -179,6 +179,12 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <version>3.1.6</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,11 @@
         <surefire.version>3.0.0-M3</surefire.version>
         <guice.version>4.2.2</guice.version>
         <rest-assured.version>4.0.0</rest-assured.version>
+        <PACT_BROKER_URL/>
+        <PACT_BROKER_USERNAME/>
+        <PACT_BROKER_PASSWORD/>
+        <PACT_CONSUMER_VERSION/>
+        <PACT_CONSUMER_TAG/>
     </properties>
 
     <repositories>
@@ -162,11 +167,38 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <dependency>
+            <groupId>au.com.dius</groupId>
+            <artifactId>pact-jvm-consumer-junit_2.12</artifactId>
+            <version>3.6.10</version>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.commons</groupId>
+                    <artifactId>commons-lang3</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
     </dependencies>
 
     <build>
         <plugins>
-
+            <plugin>
+                <groupId>au.com.dius</groupId>
+                <artifactId>pact-jvm-provider-maven_2.12</artifactId>
+                <version>3.6.2</version>
+                <configuration>
+                    <pactDirectory>target/pacts</pactDirectory>
+                    <pactBrokerUrl>${PACT_BROKER_URL}</pactBrokerUrl>
+                    <pactBrokerUsername>${PACT_BROKER_USERNAME}</pactBrokerUsername>
+                    <pactBrokerPassword>${PACT_BROKER_PASSWORD}</pactBrokerPassword>
+                    <projectVersion>${PACT_CONSUMER_VERSION}</projectVersion>
+                    <tags>
+                        <tag>${PACT_CONSUMER_TAG}</tag>
+                    </tags>
+                    <trimSnapshot>true</trimSnapshot>
+                </configuration>
+            </plugin>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.8.1</version>

--- a/src/test/java/uk/gov/pay/ledger/pact/ContractTestSuite.java
+++ b/src/test/java/uk/gov/pay/ledger/pact/ContractTestSuite.java
@@ -6,7 +6,8 @@ import org.junit.runners.Suite;
 @RunWith(Suite.class)
 
 @Suite.SuiteClasses({
-        TransactionsApiContractTest.class
+        TransactionsApiContractTest.class,
+        EventQueueContractTest.class
 })
 public class ContractTestSuite {
 

--- a/src/test/java/uk/gov/pay/ledger/pact/EventQueueContractTest.java
+++ b/src/test/java/uk/gov/pay/ledger/pact/EventQueueContractTest.java
@@ -1,0 +1,76 @@
+package uk.gov.pay.ledger.pact;
+
+import au.com.dius.pact.consumer.MessagePactBuilder;
+import au.com.dius.pact.consumer.MessagePactProviderRule;
+import au.com.dius.pact.consumer.Pact;
+import au.com.dius.pact.consumer.PactVerification;
+import au.com.dius.pact.consumer.dsl.PactDslJsonBody;
+import au.com.dius.pact.model.v3.messaging.MessagePact;
+import org.junit.Rule;
+import org.junit.Test;
+import uk.gov.pay.ledger.rule.AppWithPostgresAndSqsRule;
+import uk.gov.pay.ledger.rule.SqsTestDocker;
+import uk.gov.pay.ledger.util.DatabaseTestHelper;
+
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.util.HashMap;
+import java.util.Map;
+
+import static io.dropwizard.testing.ConfigOverride.config;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class EventQueueContractTest {
+    @Rule
+    public MessagePactProviderRule mockProvider = new MessagePactProviderRule(this);
+
+    @Rule
+    public AppWithPostgresAndSqsRule appRule = new AppWithPostgresAndSqsRule(
+            config("queueMessageReceiverConfig.backgroundProcessingEnabled", "true")
+    );
+
+    private byte[] currentMessage;
+
+    @Pact(provider = "connector", consumer = "ledger")
+    public MessagePact createPaymentCreatedEventPact(MessagePactBuilder builder) {
+        PactDslJsonBody body = new PactDslJsonBody();
+
+        PactDslJsonBody paymentCreatedEventDetails = new PactDslJsonBody();
+        paymentCreatedEventDetails.numberType("amount", 1000);
+        paymentCreatedEventDetails.stringType("description", "payment description");
+        paymentCreatedEventDetails.stringType("reference", "payment reference");
+        paymentCreatedEventDetails.stringType("return_url", "https://example.com");
+        paymentCreatedEventDetails.stringType("payment_provider", "stripe");
+
+        body.stringType("event_type", "PAYMENT_CREATED");
+        body.stringType("timestamp", ZonedDateTime.now(ZoneOffset.UTC).toString());
+        body.stringType("resource_external_id", "externalId");
+        body.stringType("resource_type", "payment");
+        body.object("event_details", paymentCreatedEventDetails);
+
+        Map<String, String> metadata = new HashMap<String, String>();
+        metadata.put("contentType", "application/json");
+
+        return builder
+                .expectsToReceive("a payment created message")
+                .withContent(body)
+                .toPact();
+    }
+
+    @Test
+    @PactVerification({"connector"})
+    public void test() throws Exception {
+        appRule.getSqsClient().sendMessage(SqsTestDocker.getQueueUrl("event-queue"), new String(currentMessage));
+
+        DatabaseTestHelper dbHelper = DatabaseTestHelper.aDatabaseTestHelper(appRule.getJdbi());
+        Thread.sleep(1000L);
+
+        var event = dbHelper.getEventByExternalId("externalId");
+        assertThat(event.get("resource_external_id"), is("externalId"));
+    }
+
+    public void setMessage(byte[] messageContents) {
+        currentMessage = messageContents;
+    }
+}

--- a/src/test/java/uk/gov/pay/ledger/pact/EventQueueContractTest.java
+++ b/src/test/java/uk/gov/pay/ledger/pact/EventQueueContractTest.java
@@ -4,22 +4,22 @@ import au.com.dius.pact.consumer.MessagePactBuilder;
 import au.com.dius.pact.consumer.MessagePactProviderRule;
 import au.com.dius.pact.consumer.Pact;
 import au.com.dius.pact.consumer.PactVerification;
-import au.com.dius.pact.consumer.dsl.PactDslJsonBody;
 import au.com.dius.pact.model.v3.messaging.MessagePact;
 import org.junit.Rule;
 import org.junit.Test;
+import uk.gov.pay.ledger.event.model.SalientEventType;
 import uk.gov.pay.ledger.rule.AppWithPostgresAndSqsRule;
 import uk.gov.pay.ledger.rule.SqsTestDocker;
 import uk.gov.pay.ledger.util.DatabaseTestHelper;
+import uk.gov.pay.ledger.util.fixture.QueueEventFixture;
 
-import java.time.ZoneOffset;
-import java.time.ZonedDateTime;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.concurrent.TimeUnit;
 
 import static io.dropwizard.testing.ConfigOverride.config;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.awaitility.Awaitility.await;
 
 public class EventQueueContractTest {
     @Rule
@@ -34,27 +34,16 @@ public class EventQueueContractTest {
 
     @Pact(provider = "connector", consumer = "ledger")
     public MessagePact createPaymentCreatedEventPact(MessagePactBuilder builder) {
-        PactDslJsonBody body = new PactDslJsonBody();
-
-        PactDslJsonBody paymentCreatedEventDetails = new PactDslJsonBody();
-        paymentCreatedEventDetails.numberType("amount", 1000);
-        paymentCreatedEventDetails.stringType("description", "payment description");
-        paymentCreatedEventDetails.stringType("reference", "payment reference");
-        paymentCreatedEventDetails.stringType("return_url", "https://example.com");
-        paymentCreatedEventDetails.stringType("payment_provider", "stripe");
-
-        body.stringType("event_type", "PAYMENT_CREATED");
-        body.stringType("timestamp", ZonedDateTime.now(ZoneOffset.UTC).toString());
-        body.stringType("resource_external_id", "externalId");
-        body.stringType("resource_type", "payment");
-        body.object("event_details", paymentCreatedEventDetails);
+        QueueEventFixture paymentCreatedEventFixture = QueueEventFixture.aQueueEventFixture()
+                .withResourceExternalId("externalId")
+                .withDefaultEventDataForEventType("PAYMENT_CREATED");
 
         Map<String, String> metadata = new HashMap<String, String>();
         metadata.put("contentType", "application/json");
 
         return builder
                 .expectsToReceive("a payment created message")
-                .withContent(body)
+                .withContent(paymentCreatedEventFixture.getAsPact())
                 .toPact();
     }
 
@@ -64,10 +53,18 @@ public class EventQueueContractTest {
         appRule.getSqsClient().sendMessage(SqsTestDocker.getQueueUrl("event-queue"), new String(currentMessage));
 
         DatabaseTestHelper dbHelper = DatabaseTestHelper.aDatabaseTestHelper(appRule.getJdbi());
-        Thread.sleep(1000L);
+        await().atMost(1, TimeUnit.SECONDS).until(
+                () -> {
+                    Map<String, Object> event;
+                    try {
+                        event = dbHelper.getEventByExternalId("externalId");
+                        return "externalId".equals(event.get("resource_external_id"));
 
-        var event = dbHelper.getEventByExternalId("externalId");
-        assertThat(event.get("resource_external_id"), is("externalId"));
+                    } catch (NoSuchElementException e) {
+                        return false;
+                    }
+                }
+        );
     }
 
     public void setMessage(byte[] messageContents) {


### PR DESCRIPTION
Example of how Ledger can generate a message pact for a particular event type. I think this can be improved, but this shows the basic idea of how to generate and verify a message pact for the `PAYMENT_CREATED` event.
At the moment the verification step checks that the event has been persisted to the database. I think this might be the right point to verify. We would then rely on the pacts and test fixtures being generated from a shared source to ensure end to end compatibility.