### PR TITLE
PP-5357: renamed Payment details event

### DIFF
--- a/src/main/java/uk/gov/pay/ledger/event/model/SalientEventType.java
+++ b/src/main/java/uk/gov/pay/ledger/event/model/SalientEventType.java
@@ -5,7 +5,7 @@ import java.util.Optional;
 
 public enum SalientEventType {
     PAYMENT_CREATED,
-    PAYMENT_DETAILS_EVENT;
+    AUTHORISATION_SUCCESSFUL; //might require renaming after the work in connector to publish all the events is finished
 
     public static Optional<SalientEventType> from(String eventName) {
         return Arrays.stream(SalientEventType.values())

--- a/src/main/java/uk/gov/pay/ledger/transaction/state/TransactionState.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/state/TransactionState.java
@@ -5,9 +5,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import uk.gov.pay.ledger.event.model.SalientEventType;
 
-import java.util.Arrays;
 import java.util.Map;
-import java.util.Optional;
 
 import static java.util.Arrays.stream;
 
@@ -50,7 +48,7 @@ public enum TransactionState {
 
     private static final Map<SalientEventType, TransactionState> EVENT_TYPE_TRANSACTION_STATE_MAP = Map.of(
             SalientEventType.PAYMENT_CREATED, CREATED,
-            SalientEventType.PAYMENT_DETAILS_EVENT, SUBMITTED
+            SalientEventType.AUTHORISATION_SUCCESSFUL, SUBMITTED
     );
 
     public static TransactionState fromSalientEventType(SalientEventType salientEventType) {

--- a/src/test/java/uk/gov/pay/ledger/event/model/TransactionEntityFactoryTest.java
+++ b/src/test/java/uk/gov/pay/ledger/event/model/TransactionEntityFactoryTest.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.Before;
 import org.junit.Test;
 import uk.gov.pay.ledger.transaction.entity.TransactionEntity;
-import uk.gov.pay.ledger.transaction.state.TransactionState;
 
 import java.util.List;
 
@@ -25,18 +24,18 @@ public class TransactionEntityFactoryTest {
     public void fromShouldConvertEventDigestToTransactionEntity() {
         Event paymentCreatedEvent = aQueueEventFixture()
                 .withEventType(SalientEventType.PAYMENT_CREATED.name())
-                .withDefaultEventDataForEventType(SalientEventType.PAYMENT_CREATED)
+                .withDefaultEventDataForEventType(SalientEventType.PAYMENT_CREATED.name())
                 .toEntity();
         Event paymentDetailsEvent = aQueueEventFixture()
-                .withEventType(SalientEventType.PAYMENT_DETAILS_EVENT.name())
-                .withDefaultEventDataForEventType(SalientEventType.PAYMENT_DETAILS_EVENT)
+                .withEventType("PAYMENT_DETAILS_ENTERED")
+                .withDefaultEventDataForEventType("PAYMENT_DETAILS_ENTERED")
                 .toEntity();
         EventDigest eventDigest = EventDigest.fromEventList(List.of(paymentCreatedEvent, paymentDetailsEvent));
 
         TransactionEntity transactionEntity = transactionEntityFactory.from(eventDigest);
 
         assertThat(transactionEntity.getExternalId(), is(eventDigest.getResourceExternalId()));
-        assertThat(transactionEntity.getState(), is(TransactionState.fromSalientEventType(eventDigest.getMostRecentSalientEventType()).getState()));
+        assertThat(transactionEntity.getState(), is("created"));
         assertThat(transactionEntity.getCreatedDate(), is(paymentCreatedEvent.getEventDate()));
         assertThat(transactionEntity.getEventCount(), is(eventDigest.getEventCount()));
         assertThat(transactionEntity.getReference(), is(eventDigest.getEventPayload().get("reference")));

--- a/src/test/java/uk/gov/pay/ledger/queue/QueueMessageReceiverIT.java
+++ b/src/test/java/uk/gov/pay/ledger/queue/QueueMessageReceiverIT.java
@@ -26,15 +26,15 @@ public class QueueMessageReceiverIT {
         aQueueEventFixture()
                 .withResourceExternalId(resourceExternalId)
                 .withEventDate(CREATED_AT)
-                .withEventType("PAYMENT_DETAILS_EVENT")
-                .withDefaultEventDataForEventType(SalientEventType.PAYMENT_DETAILS_EVENT)
+                .withEventType("AUTHORISATION_SUCCESSFUL")
                 .insert(rule.getSqsClient());
 
         // A created event with an earlier timestamp, sent later
         aQueueEventFixture()
                 .withResourceExternalId(resourceExternalId)
                 .withEventDate(CREATED_AT.minusMinutes(1))
-                .withDefaultEventDataForEventType(SalientEventType.PAYMENT_CREATED)
+                .withEventType(SalientEventType.PAYMENT_CREATED.name())
+                .withDefaultEventDataForEventType(SalientEventType.PAYMENT_CREATED.name())
                 .insert(rule.getSqsClient());
 
         Thread.sleep(500);

--- a/src/test/java/uk/gov/pay/ledger/util/fixture/QueueEventFixture.java
+++ b/src/test/java/uk/gov/pay/ledger/util/fixture/QueueEventFixture.java
@@ -7,7 +7,6 @@ import com.google.gson.GsonBuilder;
 import org.apache.commons.lang3.RandomStringUtils;
 import uk.gov.pay.ledger.event.model.Event;
 import uk.gov.pay.ledger.event.model.ResourceType;
-import uk.gov.pay.ledger.event.model.SalientEventType;
 import uk.gov.pay.ledger.rule.SqsTestDocker;
 
 import java.time.ZoneOffset;
@@ -49,7 +48,7 @@ public class QueueEventFixture implements QueueFixture<QueueEventFixture, Event>
         return this;
     }
 
-    public QueueEventFixture withDefaultEventDataForEventType(String eventData) {
+    public QueueEventFixture withEventData(String eventData) {
         this.eventData = eventData;
         return this;
     }
@@ -59,9 +58,9 @@ public class QueueEventFixture implements QueueFixture<QueueEventFixture, Event>
         return this;
     }
 
-    public QueueEventFixture withDefaultEventDataForEventType(SalientEventType eventType) {
+    public QueueEventFixture withDefaultEventDataForEventType(String eventType) {
         switch (eventType) {
-            case PAYMENT_CREATED:
+            case "PAYMENT_CREATED":
                 eventData = new GsonBuilder().create()
                         .toJson(ImmutableMap.builder()
                                 .put("amount", 1000)
@@ -72,7 +71,7 @@ public class QueueEventFixture implements QueueFixture<QueueEventFixture, Event>
                                 .put("payment_provider", "sandbox")
                                 .build());
                 break;
-            case PAYMENT_DETAILS_EVENT:
+            case "PAYMENT_DETAILS_ENTERED":
                 eventData = new GsonBuilder().create()
                         .toJson(ImmutableMap.builder()
                                 .put("email", "j.doe@example.org")


### PR DESCRIPTION
* Changed the SalientEventType back to have `AUTHORISATION_SUCCESSFUL` event (for the purpose of test: src/test/java/uk/gov/pay/ledger/event/model/TransactionEntityFactoryTest.java) - it might be required to rename it to something else as part of PP-5388