### PR TITLE
BAU: post PR clean-up

### DIFF
--- a/src/main/java/uk/gov/pay/ledger/transaction/dao/TransactionDao.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/dao/TransactionDao.java
@@ -10,6 +10,7 @@ import uk.gov.pay.ledger.transaction.search.common.TransactionSearchParams;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.function.BiConsumer;
 
 public class TransactionDao {
 
@@ -92,14 +93,18 @@ public class TransactionDao {
     private Query getQuery(TransactionSearchParams searchParams, Handle handle, String searchCountQueryString) {
         String searchExtraFields = searchParams.generateQuery();
         Query query = handle.createQuery(searchCountQueryString.replace(":searchExtraFields", searchExtraFields));
-        searchParams.getQueryMap().forEach((k, v) -> {
-            if (v instanceof List<?>) {
-                query.bindList(k, ((List<?>) v));
-            } else {
-                query.bind(k, v);
-            }
-        });
+        searchParams.getQueryMap().forEach(bindSearchParameter(query));
         return query;
+    }
+
+    private BiConsumer<String, Object> bindSearchParameter(Query query) {
+        return (searchKey, searchValue) -> {
+            if (searchValue instanceof List<?>) {
+                query.bindList(searchKey, ((List<?>) searchValue));
+            } else {
+                query.bind(searchKey, searchValue);
+            }
+        };
     }
 
     public void upsert(TransactionEntity transaction) {

--- a/src/test/java/uk/gov/pay/ledger/transaction/service/TransactionServiceTest.java
+++ b/src/test/java/uk/gov/pay/ledger/transaction/service/TransactionServiceTest.java
@@ -1,6 +1,6 @@
 package uk.gov.pay.ledger.transaction.service;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import io.dropwizard.jackson.Jackson;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -40,7 +40,8 @@ public class TransactionServiceTest {
 
     @Before
     public void setUp() {
-        transactionService = new TransactionService(mockTransactionDao, new TransactionEntityFactory(new ObjectMapper()));
+        TransactionEntityFactory transactionEntityFactory = new TransactionEntityFactory(Jackson.newObjectMapper());
+        transactionService = new TransactionService(mockTransactionDao, transactionEntityFactory);
         searchParams = new TransactionSearchParams();
         searchParams.setAccountId(gatewayAccountId);
 


### PR DESCRIPTION
* #89 - refactor binding parameters in TransactionDao to separate method for the sake of readability
* #90 - replaced `new ObjectMapper` with `Jackson.newObjectMapper` to make test simulate closer of what happens in the actual Dropwizard application