### PR TITLE
PP-5357: database migration for rename

### DIFF
--- a/src/main/resources/migrations/00011_update_payment_details_event_name.sql
+++ b/src/main/resources/migrations/00011_update_payment_details_event_name.sql
@@ -1,0 +1,5 @@
+--liquibase formatted sql
+
+--changeset uk.gov.pay:update_payment_details_event_name
+
+UPDATE event SET event_type = 'PAYMENT_DETAILS_ENTERED' WHERE event_type = 'PAYMENT_DETAILS_EVENT';


### PR DESCRIPTION
* added a migration script that updates the name of the `PAYMENT_DETAILS_EVENT` to `PAYMENT_DETAILS_ENTERED`

**Notes**
Tested in pay local - is working

**BLOCKED** on release of https://github.com/alphagov/pay-connector/pull/1457