### PR TITLE
BAU Publish pact results

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -39,7 +39,7 @@ pipeline {
           ) {
               sh 'mvn -version'
               sh "mvn clean package pact:publish -DrunContractTests=true -DPACT_BROKER_URL=https://pact-broker-test.cloudapps.digital -DPACT_CONSUMER_VERSION=${commit}" +
-                      " -DPACT_BROKER_USERNAME=${PACT_BROKER_USERNAME} -DPACT_BROKER_PASSWORD=${PACT_BROKER_PASSWORD} -DPACT_CONSUMER_TAG=${branchName}"
+                      " -DPACT_BROKER_USERNAME=${PACT_BROKER_USERNAME} -DPACT_BROKER_PASSWORD=${PACT_BROKER_PASSWORD} -DPACT_CONSUMER_TAG=${branchName} -Dpact.verifier.publishResults=true"
           }
           postSuccessfulMetrics("ledger.maven-build", stepBuildTime)
         }


### PR DESCRIPTION
When we run contract tests against ledger on master we should publish
the results. This will mean verifications of contracts with upstream
services (in this case publicapi) will be published on ledger master
builds, which is what we want.