### PR TITLE
BAU - Remove @IgnoreNoPactsToVerify

### DIFF
--- a/src/test/java/uk/gov/pay/ledger/pact/GetTransactionContractTest.java
+++ b/src/test/java/uk/gov/pay/ledger/pact/GetTransactionContractTest.java
@@ -1,6 +1,5 @@
 package uk.gov.pay.ledger.pact;
 
-import au.com.dius.pact.provider.junit.IgnoreNoPactsToVerify;
 import au.com.dius.pact.provider.junit.PactRunner;
 import au.com.dius.pact.provider.junit.Provider;
 import au.com.dius.pact.provider.junit.State;
@@ -35,7 +34,6 @@ import static uk.gov.pay.ledger.util.fixture.TransactionFixture.aTransactionFixt
         "a transaction with fee and net_amount exists",
         "a transaction with a gateway transaction id exists",
         "a transaction with metadata exists"})
-@IgnoreNoPactsToVerify
 public class GetTransactionContractTest {
     @ClassRule
     public static AppWithPostgresAndSqsRule app = new AppWithPostgresAndSqsRule();


### PR DESCRIPTION
- Removes @IgnoreNoPactsToVerify as publicapi has got pacts for states in `GetTransactionContractTest`