### PR TITLE
PP-5457 Add columns to support refunds

### DIFF
--- a/src/main/resources/migrations/00014_add_fields_for_refunds.sql
+++ b/src/main/resources/migrations/00014_add_fields_for_refunds.sql
@@ -1,0 +1,12 @@
+--liquibase formatted sql
+
+--changeset uk.gov.pay:add_refund_related_fields_to_transaction_table
+
+CREATE type transaction_type as enum ('PAYMENT', 'REFUND');
+
+ALTER TABLE transaction
+    ADD COLUMN gateway_transaction_id text,
+    ADD COLUMN type transaction_type ,
+    ADD COLUMN origin_transaction_id VARCHAR(26) references transaction(external_id);
+
+CREATE index transaction_origin_id_idx on transaction(origin_transaction_id);


### PR DESCRIPTION
## WHAT
- Added columns `gateway_transaction_id`, `origin_transaction_id`, `transaction_type` to support refund related endpoints
- Transaction type is currently set to nullable.
    Todo:
       - Update code to always populate transaction_type
       - Update transactoion_type to not null

Co-authored-by: @sfount 