### PR TITLE
PP-5457 Rename origin_transaction_id to parent_transaction_id

### DIFF
--- a/src/main/resources/migrations/00014_add_fields_for_refunds.sql
+++ b/src/main/resources/migrations/00014_add_fields_for_refunds.sql
@@ -7,6 +7,6 @@ CREATE type transaction_type as enum ('PAYMENT', 'REFUND');
 ALTER TABLE transaction
     ADD COLUMN gateway_transaction_id text,
     ADD COLUMN type transaction_type ,
-    ADD COLUMN origin_transaction_id VARCHAR(26) references transaction(external_id);
+    ADD COLUMN parent_transaction_id VARCHAR(26) references transaction(external_id);
 
-CREATE index transaction_origin_id_idx on transaction(origin_transaction_id);
+CREATE index transaction_parent_tx_id_idx on transaction(parent_transaction_id);


### PR DESCRIPTION
## WHAT
- Renames `origin_transaction_id` to `parent_transcation_id`

Migrations have not been run in staging/prod, so updating sql