### PR TITLE
BAU: clean up transaction_details

### DIFF
--- a/src/main/java/uk/gov/pay/ledger/transaction/model/PaymentFactory.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/model/PaymentFactory.java
@@ -53,8 +53,8 @@ public class PaymentFactory {
                     TransactionState.from(entity.getState()), safeGetAsString(transactionDetails, "language"),
                     entity.getExternalId(), safeGetAsString(transactionDetails, "return_url"), entity.getEmail(),
                     safeGetAsString(transactionDetails, "payment_provider"), entity.getCreatedDate(),
-                    cardDetails, Boolean.valueOf(safeGetAsString(transactionDetails, "delayed_capture")),
-                    metadata, entity.getEventCount(), safeGetAsString(transactionDetails, "gateway_transaction_id"),
+                    cardDetails, safeGetAsBoolean(transactionDetails, "delayed_capture", false), metadata,
+                    entity.getEventCount(), safeGetAsString(transactionDetails, "gateway_transaction_id"),
                     safeGetAsLong(transactionDetails, "corporate_surcharge"), entity.getFee(),
                     entity.getNetAmount(), refundSummary, entity.getTotalAmount(), settlementSummary);
         } catch (IOException e) {
@@ -66,13 +66,19 @@ public class PaymentFactory {
 
     private static Long safeGetAsLong(JsonNode object, String propertyName) {
         return safeGetJsonElement(object, propertyName)
-                .map(JsonNode::asLong)
+                .map(JsonNode::longValue)
                 .orElse(null);
+    }
+
+    private static Boolean safeGetAsBoolean(JsonNode object, String propertyName, Boolean defaultValue) {
+        return safeGetJsonElement(object, propertyName)
+                .map(JsonNode::booleanValue)
+                .orElse(defaultValue);
     }
 
     private static String safeGetAsString(JsonNode object, String propertyName) {
         return safeGetJsonElement(object, propertyName)
-                .map(JsonNode::asText)
+                .map(JsonNode::textValue)
                 .orElse(null);
     }
 

--- a/src/main/java/uk/gov/pay/ledger/transaction/search/model/ConvertedTransactionDetails.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/search/model/ConvertedTransactionDetails.java
@@ -1,9 +1,11 @@
 package uk.gov.pay.ledger.transaction.search.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class ConvertedTransactionDetails {
 
     public ConvertedTransactionDetails() {}

--- a/src/test/java/uk/gov/pay/ledger/event/model/TransactionEntityFactoryTest.java
+++ b/src/test/java/uk/gov/pay/ledger/event/model/TransactionEntityFactoryTest.java
@@ -65,12 +65,9 @@ public class TransactionEntityFactoryTest {
                         "\"payment_provider\":\"sandbox\"," +
                         "\"expiry_date\":\"11/21\"," +
                         "\"address_line1\":\"12 Rouge Avenue\"," +
-                        "\"address_line2\":null," +
                         "\"address_postcode\":\"N1 3QU\"," +
                         "\"address_city\":\"London\"," +
-                        "\"address_county\":null," +
                         "\"address_country\":\"GB\"," +
-                        "\"wallet\":null," +
                         "\"delayed_capture\":false," +
                         "\"return_url\":\"https://example.org\"," +
                         "\"gateway_transaction_id\":\"%s\"," +


### PR DESCRIPTION
* put json properties in transaction_details only if they have value (JSON annotation)
* chaged `as<type>` to `<type>Value` to retrieve value insted of making conversions (null won't be treated as "null")
* updated tests to reflect changes in the behaviour