### PR TITLE
PP-5403 Rename `parent_transaction_id`

### DIFF
--- a/src/main/resources/migrations/00017_rename_parent_transaction_id_in_transaction_table.sql
+++ b/src/main/resources/migrations/00017_rename_parent_transaction_id_in_transaction_table.sql
@@ -1,0 +1,8 @@
+--liquibase formatted sql
+
+--changeset uk.gov.pay:rename_parent_transaction_id_in_transaction_table
+
+ALTER TABLE transaction
+    rename COLUMN parent_transaction_id to parent_external_id;
+
+ALTER index transaction_parent_tx_id_idx rename to transaction_parent_external_id_idx;


### PR DESCRIPTION
## WHAT 

Rename `parent_transaction_id` to `parent_external_id` as the column is referring to `external_id` and not `id` of transaction table