### PR TITLE
PP-5460: add pact test for CaptureConfirmed event

### DIFF
--- a/src/test/java/uk/gov/pay/ledger/util/fixture/QueueEventFixture.java
+++ b/src/test/java/uk/gov/pay/ledger/util/fixture/QueueEventFixture.java
@@ -101,6 +101,14 @@ public class QueueEventFixture implements QueueFixture<QueueEventFixture, Event>
                                 .put("gateway_transaction_id", gatewayAccountId)
                                 .build());
                 break;
+            case "CAPTURE_CONFIRMED":
+                eventData = new GsonBuilder().create()
+                        .toJson(ImmutableMap.builder()
+                                .put("gateway_event_date", eventDate.toString())
+                                .put("fee", 5)
+                                .put("net_amount", 1069)
+                                .build());
+                break;
             default:
                 eventData = new GsonBuilder().create()
                         .toJson(ImmutableMap.of("event_data", "event_data"));


### PR DESCRIPTION
I tried to add date format verification:
* at the top level, but given you specify the name (not path) to the checked property it wasn't possible (unless there is a special way I haven't found)
* by lambda Consumer function - but it didn't seem to work

Giving up for now - can be picked up later or by somebody else.