### PR TITLE
PP-5403 Map refund to external states

### DIFF
--- a/src/main/java/uk/gov/pay/ledger/event/model/EventDigest.java
+++ b/src/main/java/uk/gov/pay/ledger/event/model/EventDigest.java
@@ -51,7 +51,7 @@ public class EventDigest {
                 .map(e -> EventType.from(e.getEventType()))
                 .flatMap(Optional::stream)
                 .findFirst()
-                .orElse(EventType.PAYMENT_CREATED);
+                .orElseThrow(() -> new RuntimeException("No supported event types found"));
 
         var earliestDate = events.stream()
                 .map(event -> event.getEventDate())

--- a/src/main/java/uk/gov/pay/ledger/event/model/EventType.java
+++ b/src/main/java/uk/gov/pay/ledger/event/model/EventType.java
@@ -30,7 +30,13 @@ public enum EventType {
     CANCELLED_BY_EXTERNAL_SERVICE,
     CANCEL_BY_USER_SUBMITTED,
     CANCEL_BY_USER_FAILED,
-    CANCELLED_BY_USER;
+    CANCELLED_BY_USER,
+
+    REFUND_CREATED_BY_USER,
+    REFUND_CREATED_BY_SERVICE,
+    REFUND_SUBMITTED,
+    REFUND_SUCCEEDED,
+    REFUND_ERROR;
 
     public static Optional<EventType> from(String eventName) {
         return Arrays.stream(EventType.values())

--- a/src/main/java/uk/gov/pay/ledger/event/model/TransactionEntityFactory.java
+++ b/src/main/java/uk/gov/pay/ledger/event/model/TransactionEntityFactory.java
@@ -26,7 +26,7 @@ public class TransactionEntityFactory {
         TransactionEntity entity = objectMapper.convertValue(eventDigest.getEventPayload(), TransactionEntity.class);
         entity.setTransactionDetails(transactionDetail);
         entity.setEventCount(eventDigest.getEventCount());
-        entity.setState(TransactionState.fromSalientEventType(eventDigest.getMostRecentEventType()).getState());
+        entity.setState(TransactionState.fromEventType(eventDigest.getMostRecentEventType()).getState());
         entity.setCreatedDate(eventDigest.getEventCreatedDate());
         entity.setExternalId(eventDigest.getResourceExternalId());
         entity.setParentExternalId(eventDigest.getParentResourceExternalId());

--- a/src/main/java/uk/gov/pay/ledger/transaction/state/TransactionState.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/state/TransactionState.java
@@ -23,7 +23,8 @@ public enum TransactionState {
     FAILED_EXPIRED("timedout", true),
     FAILED_CANCELLED("cancelled", true),
     CANCELLED("cancelled", true),
-    ERROR_GATEWAY("error", true);
+    ERROR_GATEWAY("error", true),
+    ERROR("error", true);
 
     private final String value;
     private final boolean finished;
@@ -83,8 +84,11 @@ public enum TransactionState {
                     Map.entry(EventType.CANCEL_BY_USER_SUBMITTED, FAILED_CANCELLED),
                     Map.entry(EventType.CANCEL_BY_USER_FAILED, FAILED_CANCELLED),
                     Map.entry(EventType.CANCELLED_BY_USER, FAILED_CANCELLED),
-                    Map.entry(EventType.REFUND_CREATED_BY_SERVICE, CREATED),
-                    Map.entry(EventType.REFUND_CREATED_BY_USER, CREATED)
+                    Map.entry(EventType.REFUND_CREATED_BY_SERVICE, SUBMITTED),
+                    Map.entry(EventType.REFUND_CREATED_BY_USER, SUBMITTED),
+                    Map.entry(EventType.REFUND_SUBMITTED, SUBMITTED),
+                    Map.entry(EventType.REFUND_SUCCEEDED, SUCCESS),
+                    Map.entry(EventType.REFUND_ERROR, ERROR)
             );
 
     public static TransactionState fromEventType(EventType eventType) {

--- a/src/main/java/uk/gov/pay/ledger/transaction/state/TransactionState.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/state/TransactionState.java
@@ -82,10 +82,12 @@ public enum TransactionState {
                     Map.entry(EventType.CANCELLED_BY_EXTERNAL_SERVICE, CANCELLED),
                     Map.entry(EventType.CANCEL_BY_USER_SUBMITTED, FAILED_CANCELLED),
                     Map.entry(EventType.CANCEL_BY_USER_FAILED, FAILED_CANCELLED),
-                    Map.entry(EventType.CANCELLED_BY_USER, FAILED_CANCELLED)
+                    Map.entry(EventType.CANCELLED_BY_USER, FAILED_CANCELLED),
+                    Map.entry(EventType.REFUND_CREATED_BY_SERVICE, CREATED),
+                    Map.entry(EventType.REFUND_CREATED_BY_USER, CREATED)
             );
 
-    public static TransactionState fromSalientEventType(EventType eventType) {
+    public static TransactionState fromEventType(EventType eventType) {
         return EVENT_TYPE_TRANSACTION_STATE_MAP.get(eventType);
     }
 

--- a/src/test/java/uk/gov/pay/ledger/event/model/TransactionEntityFactoryTest.java
+++ b/src/test/java/uk/gov/pay/ledger/event/model/TransactionEntityFactoryTest.java
@@ -77,4 +77,29 @@ public class TransactionEntityFactoryTest {
 
         assertThat(transactionEntity.getTransactionDetails(), is(expectedTransactionDetails));
     }
+
+    @Test
+    public void fromShouldConvertEventDigestToTransactionForChildResource() {
+        String parentResourceExternalId = "parent-resource-external-id";
+        Event refundCreatedEvent = aQueueEventFixture()
+                .withEventType("REFUND_CREATED_BY_USER")
+                .withResourceExternalId("resource-external-id")
+                .withParentResourceExternalId(parentResourceExternalId)
+                .withResourceType(ResourceType.REFUND)
+                .toEntity();
+        Event refundSubmittedEvent = aQueueEventFixture()
+                .withEventType("REFUND_SUBMITTED")
+                .withResourceExternalId("resource-external-id")
+                .withParentResourceExternalId(parentResourceExternalId)
+                .withResourceType(ResourceType.REFUND)
+                .toEntity();
+        EventDigest eventDigest = EventDigest.fromEventList(List.of(refundCreatedEvent, refundSubmittedEvent));
+
+        TransactionEntity transactionEntity = transactionEntityFactory.create(eventDigest);
+
+        assertThat(transactionEntity.getTransactionType(), is(eventDigest.getResourceType().toString()));
+        assertThat(transactionEntity.getTransactionType(), is("REFUND"));
+        assertThat(transactionEntity.getParentExternalId(), is(eventDigest.getParentResourceExternalId()));
+        assertThat(transactionEntity.getParentExternalId(), is(parentResourceExternalId));
+    }
 }

--- a/src/test/java/uk/gov/pay/ledger/event/model/TransactionEntityFactoryTest.java
+++ b/src/test/java/uk/gov/pay/ledger/event/model/TransactionEntityFactoryTest.java
@@ -101,5 +101,6 @@ public class TransactionEntityFactoryTest {
         assertThat(transactionEntity.getTransactionType(), is("REFUND"));
         assertThat(transactionEntity.getParentExternalId(), is(eventDigest.getParentResourceExternalId()));
         assertThat(transactionEntity.getParentExternalId(), is(parentResourceExternalId));
+        assertThat(transactionEntity.getState(), is("submitted"));
     }
 }


### PR DESCRIPTION
* introduce refund event types 
* map types to external states (respecting connector maps)
* make sure transaction projection wires cross correctly 