### PR TITLE
BAU - Add httpclient as direct dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,6 +62,11 @@
             <artifactId>dropwizard-client</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>4.5.9</version>
+        </dependency>
+        <dependency>
             <groupId>io.dropwizard</groupId>
             <artifactId>dropwizard-db</artifactId>
         </dependency>
@@ -119,7 +124,7 @@
             <artifactId>gson</artifactId>
             <version>2.8.5</version>
         </dependency>
-<!--test dependencies-->
+        <!--test dependencies-->
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>postgresql</artifactId>


### PR DESCRIPTION
## WHAT 
`org.apache.httpcomponents:httpclient` is a transitive dependency of `io.dropwizard:dropwizard-client` but is also used by AWS core.

As the transitive dependency of dropwizard-client is adding `httpclient 4.5.7`, AWS core which expects latest library (>4.5.8) started logging warning messages and adding noise to logs.

`"level":"WARN","logger":"com.amazonaws.http.apache.utils.ApacheUtils","thread":"dw-22 - GET /healthcheck","message":"NoSuchMethodError was thrown when disabling normalizeUri. This indicates you are using an old version (< 4.5.8) of Apache http client. It is recommended to use http client version >= 4.5.9 to avoid the breaking change introduced in apache client 4.5.7 and the latency in exception handling. See https://github.com/aws/aws-sdk-java/issues/1919 for more information`

Although there is no functional impact, this change will reduce logs noise.