### PR TITLE
PP-5403 Support non state transition events

### DIFF
--- a/src/main/java/uk/gov/pay/ledger/event/model/EventDigest.java
+++ b/src/main/java/uk/gov/pay/ledger/event/model/EventDigest.java
@@ -59,7 +59,7 @@ public class EventDigest {
         var latestSalientEventType = EventType.from(latestSalientEvent.getEventType()).get();
 
         var earliestDate = events.stream()
-                .map(event -> event.getEventDate())
+                .map(Event::getEventDate)
                 .min(ZonedDateTime::compareTo).get();
 
         return new EventDigest(

--- a/src/main/java/uk/gov/pay/ledger/event/model/EventDigest.java
+++ b/src/main/java/uk/gov/pay/ledger/event/model/EventDigest.java
@@ -1,7 +1,6 @@
 package uk.gov.pay.ledger.event.model;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import uk.gov.pay.ledger.transaction.state.TransactionState;
 
 import java.io.IOException;
 import java.time.ZonedDateTime;
@@ -16,29 +15,26 @@ public class EventDigest {
     private final ResourceType resourceType;
     private final String resourceExternalId;
     private final String parentResourceExternalId;
-    private final EventType mostRecentEventType;
-    private final String mostRecentEventState;
+    private final SalientEventType mostRecentSalientEventType;
     private Integer eventCount;
     private Map<String, Object> eventPayload;
     private final ZonedDateTime eventCreatedDate;
 
     private EventDigest(
             ZonedDateTime mostRecentEventTimestamp,
-            EventType mostRecentEventType,
+            SalientEventType mostRecentSalientEventType,
             ResourceType resourceType,
             String resourceExternalId,
             String parentResourceExternalId,
-            String mostRecentEventState,
             Integer eventCount,
             Map<String, Object> eventPayload,
             ZonedDateTime eventCreatedDate
     ) {
         this.mostRecentEventTimestamp = mostRecentEventTimestamp;
-        this.mostRecentEventType = mostRecentEventType;
+        this.mostRecentSalientEventType = mostRecentSalientEventType;
         this.resourceType = resourceType;
         this.resourceExternalId = resourceExternalId;
         this.parentResourceExternalId = parentResourceExternalId;
-        this.mostRecentEventState = mostRecentEventState;
         this.eventCount = eventCount;
         this.eventPayload = eventPayload;
         this.eventCreatedDate = eventCreatedDate;
@@ -51,12 +47,11 @@ public class EventDigest {
                 .findFirst()
                 .orElseThrow(() -> new RuntimeException("No events found"));
 
-        var latestSalientEvent = events.stream()
-                .filter(e -> EventType.from(e.getEventType()).isPresent())
+        var latestSalientEventType = events.stream()
+                .map(e -> SalientEventType.from(e.getEventType()))
+                .flatMap(Optional::stream)
                 .findFirst()
                 .orElseThrow(() -> new RuntimeException("No supported external state transition events found for digest"));
-
-        var latestSalientEventType = EventType.from(latestSalientEvent.getEventType()).get();
 
         var earliestDate = events.stream()
                 .map(Event::getEventDate)
@@ -68,7 +63,6 @@ public class EventDigest {
                 latestEvent.getResourceType(),
                 latestEvent.getResourceExternalId(),
                 latestEvent.getParentResourceExternalId(),
-                TransactionState.fromEventType(latestSalientEventType).getState(),
                 events.size(),
                 eventPayload,
                 earliestDate
@@ -107,8 +101,8 @@ public class EventDigest {
         return parentResourceExternalId;
     }
 
-    public EventType getMostRecentEventType() {
-        return mostRecentEventType;
+    public SalientEventType getMostRecentSalientEventType() {
+        return mostRecentSalientEventType;
     }
 
     public Map<String, Object> getEventPayload() {
@@ -121,9 +115,5 @@ public class EventDigest {
 
     public ZonedDateTime getEventCreatedDate() {
         return eventCreatedDate;
-    }
-
-    public String getMostRecentEventState() {
-        return mostRecentEventState;
     }
 }

--- a/src/main/java/uk/gov/pay/ledger/event/model/SalientEventType.java
+++ b/src/main/java/uk/gov/pay/ledger/event/model/SalientEventType.java
@@ -3,11 +3,10 @@ package uk.gov.pay.ledger.event.model;
 import java.util.Arrays;
 import java.util.Optional;
 
-public enum EventType {
+public enum SalientEventType {
     PAYMENT_CREATED,
     PAYMENT_STARTED,
     PAYMENT_EXPIRED,
-    PAYMENT_DETAILS_ENTERED,
     AUTHORISATION_SUCCESSFUL,
     AUTHORISATION_REJECTED,
     AUTHORISATION_SUCCEEDED,
@@ -39,8 +38,8 @@ public enum EventType {
     REFUND_SUCCEEDED,
     REFUND_ERROR;
 
-    public static Optional<EventType> from(String eventName) {
-        return Arrays.stream(EventType.values())
+    public static Optional<SalientEventType> from(String eventName) {
+        return Arrays.stream(SalientEventType.values())
                 .filter(v -> v.name().equals(eventName))
                 .findFirst();
     }

--- a/src/main/java/uk/gov/pay/ledger/event/model/TransactionEntityFactory.java
+++ b/src/main/java/uk/gov/pay/ledger/event/model/TransactionEntityFactory.java
@@ -26,7 +26,7 @@ public class TransactionEntityFactory {
         TransactionEntity entity = objectMapper.convertValue(eventDigest.getEventPayload(), TransactionEntity.class);
         entity.setTransactionDetails(transactionDetail);
         entity.setEventCount(eventDigest.getEventCount());
-        entity.setState(TransactionState.fromEventType(eventDigest.getMostRecentEventType()).getState());
+        entity.setState(eventDigest.getMostRecentEventState());
         entity.setCreatedDate(eventDigest.getEventCreatedDate());
         entity.setExternalId(eventDigest.getResourceExternalId());
         entity.setParentExternalId(eventDigest.getParentResourceExternalId());

--- a/src/main/java/uk/gov/pay/ledger/event/model/TransactionEntityFactory.java
+++ b/src/main/java/uk/gov/pay/ledger/event/model/TransactionEntityFactory.java
@@ -26,7 +26,7 @@ public class TransactionEntityFactory {
         TransactionEntity entity = objectMapper.convertValue(eventDigest.getEventPayload(), TransactionEntity.class);
         entity.setTransactionDetails(transactionDetail);
         entity.setEventCount(eventDigest.getEventCount());
-        entity.setState(eventDigest.getMostRecentEventState());
+        entity.setState(TransactionState.fromEventType(eventDigest.getMostRecentSalientEventType()).getState());
         entity.setCreatedDate(eventDigest.getEventCreatedDate());
         entity.setExternalId(eventDigest.getResourceExternalId());
         entity.setParentExternalId(eventDigest.getParentResourceExternalId());

--- a/src/main/java/uk/gov/pay/ledger/transaction/state/TransactionState.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/state/TransactionState.java
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import uk.gov.pay.ledger.event.model.EventType;
+import uk.gov.pay.ledger.event.model.SalientEventType;
 
 import java.util.Map;
 
@@ -57,44 +57,43 @@ public enum TransactionState {
         return message;
     }
 
-    private static final Map<EventType, TransactionState> EVENT_TYPE_TRANSACTION_STATE_MAP =
+    private static final Map<SalientEventType, TransactionState> EVENT_TYPE_TRANSACTION_STATE_MAP =
             Map.ofEntries(
-                    Map.entry(EventType.PAYMENT_CREATED, CREATED),
-                    Map.entry(EventType.PAYMENT_STARTED, STARTED),
-                    Map.entry(EventType.PAYMENT_EXPIRED, FAILED_EXPIRED),
-                    Map.entry(EventType.PAYMENT_DETAILS_ENTERED, STARTED),
-                    Map.entry(EventType.AUTHORISATION_SUCCESSFUL, SUBMITTED),
-                    Map.entry(EventType.AUTHORISATION_REJECTED, FAILED_REJECTED),
-                    Map.entry(EventType.AUTHORISATION_SUCCEEDED, SUCCESS),
-                    Map.entry(EventType.AUTHORISATION_CANCELLED, FAILED_CANCELLED),
-                    Map.entry(EventType.GATEWAY_ERROR_DURING_AUTHORISATION, ERROR_GATEWAY),
-                    Map.entry(EventType.GATEWAY_TIMEOUT_DURING_AUTHORISATION, ERROR_GATEWAY),
-                    Map.entry(EventType.UNEXPECTED_GATEWAY_ERROR_DURING_AUTHORISATION, ERROR_GATEWAY),
-                    Map.entry(EventType.GATEWAY_REQUIRES_3DS_AUTHORISATION, STARTED),
-                    Map.entry(EventType.CAPTURE_CONFIRMED, SUCCESS),
-                    Map.entry(EventType.CAPTURE_SUBMITTED, SUCCESS),
-                    Map.entry(EventType.CAPTURE_ERRORED, ERROR_GATEWAY),
-                    Map.entry(EventType.CAPTURE_ABANDONED_AFTER_TOO_MANY_RETRIES, ERROR_GATEWAY),
-                    Map.entry(EventType.USER_APPROVED_FOR_CAPTURE, SUCCESS),
-                    Map.entry(EventType.USER_APPROVED_FOR_CAPTURE_AWAITING_SERVICE_APPROVAL, SUBMITTED),
-                    Map.entry(EventType.SERVICE_APPROVED_FOR_CAPTURE, SUCCESS),
-                    Map.entry(EventType.CANCEL_BY_EXPIRATION_SUBMITTED, FAILED_EXPIRED),
-                    Map.entry(EventType.CANCEL_BY_EXPIRATION_FAILED, FAILED_EXPIRED),
-                    Map.entry(EventType.CANCELLED_BY_EXPIRATION, FAILED_EXPIRED),
-                    Map.entry(EventType.CANCEL_BY_EXTERNAL_SERVICE_SUBMITTED, CANCELLED),
-                    Map.entry(EventType.CANCELLED_BY_EXTERNAL_SERVICE, CANCELLED),
-                    Map.entry(EventType.CANCEL_BY_USER_SUBMITTED, FAILED_CANCELLED),
-                    Map.entry(EventType.CANCEL_BY_USER_FAILED, FAILED_CANCELLED),
-                    Map.entry(EventType.CANCELLED_BY_USER, FAILED_CANCELLED),
-                    Map.entry(EventType.REFUND_CREATED_BY_SERVICE, SUBMITTED),
-                    Map.entry(EventType.REFUND_CREATED_BY_USER, SUBMITTED),
-                    Map.entry(EventType.REFUND_SUBMITTED, SUBMITTED),
-                    Map.entry(EventType.REFUND_SUCCEEDED, SUCCESS),
-                    Map.entry(EventType.REFUND_ERROR, ERROR)
+                    Map.entry(SalientEventType.PAYMENT_CREATED, CREATED),
+                    Map.entry(SalientEventType.PAYMENT_STARTED, STARTED),
+                    Map.entry(SalientEventType.PAYMENT_EXPIRED, FAILED_EXPIRED),
+                    Map.entry(SalientEventType.AUTHORISATION_SUCCESSFUL, SUBMITTED),
+                    Map.entry(SalientEventType.AUTHORISATION_REJECTED, FAILED_REJECTED),
+                    Map.entry(SalientEventType.AUTHORISATION_SUCCEEDED, SUCCESS),
+                    Map.entry(SalientEventType.AUTHORISATION_CANCELLED, FAILED_CANCELLED),
+                    Map.entry(SalientEventType.GATEWAY_ERROR_DURING_AUTHORISATION, ERROR_GATEWAY),
+                    Map.entry(SalientEventType.GATEWAY_TIMEOUT_DURING_AUTHORISATION, ERROR_GATEWAY),
+                    Map.entry(SalientEventType.UNEXPECTED_GATEWAY_ERROR_DURING_AUTHORISATION, ERROR_GATEWAY),
+                    Map.entry(SalientEventType.GATEWAY_REQUIRES_3DS_AUTHORISATION, STARTED),
+                    Map.entry(SalientEventType.CAPTURE_CONFIRMED, SUCCESS),
+                    Map.entry(SalientEventType.CAPTURE_SUBMITTED, SUCCESS),
+                    Map.entry(SalientEventType.CAPTURE_ERRORED, ERROR_GATEWAY),
+                    Map.entry(SalientEventType.CAPTURE_ABANDONED_AFTER_TOO_MANY_RETRIES, ERROR_GATEWAY),
+                    Map.entry(SalientEventType.USER_APPROVED_FOR_CAPTURE, SUCCESS),
+                    Map.entry(SalientEventType.USER_APPROVED_FOR_CAPTURE_AWAITING_SERVICE_APPROVAL, SUBMITTED),
+                    Map.entry(SalientEventType.SERVICE_APPROVED_FOR_CAPTURE, SUCCESS),
+                    Map.entry(SalientEventType.CANCEL_BY_EXPIRATION_SUBMITTED, FAILED_EXPIRED),
+                    Map.entry(SalientEventType.CANCEL_BY_EXPIRATION_FAILED, FAILED_EXPIRED),
+                    Map.entry(SalientEventType.CANCELLED_BY_EXPIRATION, FAILED_EXPIRED),
+                    Map.entry(SalientEventType.CANCEL_BY_EXTERNAL_SERVICE_SUBMITTED, CANCELLED),
+                    Map.entry(SalientEventType.CANCELLED_BY_EXTERNAL_SERVICE, CANCELLED),
+                    Map.entry(SalientEventType.CANCEL_BY_USER_SUBMITTED, FAILED_CANCELLED),
+                    Map.entry(SalientEventType.CANCEL_BY_USER_FAILED, FAILED_CANCELLED),
+                    Map.entry(SalientEventType.CANCELLED_BY_USER, FAILED_CANCELLED),
+                    Map.entry(SalientEventType.REFUND_CREATED_BY_SERVICE, SUBMITTED),
+                    Map.entry(SalientEventType.REFUND_CREATED_BY_USER, SUBMITTED),
+                    Map.entry(SalientEventType.REFUND_SUBMITTED, SUBMITTED),
+                    Map.entry(SalientEventType.REFUND_SUCCEEDED, SUCCESS),
+                    Map.entry(SalientEventType.REFUND_ERROR, ERROR)
             );
 
-    public static TransactionState fromEventType(EventType eventType) {
-        return EVENT_TYPE_TRANSACTION_STATE_MAP.get(eventType);
+    public static TransactionState fromEventType(SalientEventType salientEventType) {
+        return EVENT_TYPE_TRANSACTION_STATE_MAP.get(salientEventType);
     }
 
     public static TransactionState from(String transactionState) {

--- a/src/test/java/uk/gov/pay/ledger/event/model/EventDigestTest.java
+++ b/src/test/java/uk/gov/pay/ledger/event/model/EventDigestTest.java
@@ -1,0 +1,31 @@
+package uk.gov.pay.ledger.event.model;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.util.List;
+
+import static uk.gov.pay.ledger.util.fixture.QueueEventFixture.aQueueEventFixture;
+
+public class EventDigestTest {
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    @Test
+    public void fromEventList_ShouldRejectEventDigestWithoutAnySalientEvents() {
+        Event firstNonSalientEvent = aQueueEventFixture()
+                .withEventType("FIRST_NON_STATE_TRANSITION_EVENT")
+                .withResourceType(ResourceType.PAYMENT)
+                .toEntity();
+
+        Event secondNonSalientEvent = aQueueEventFixture()
+                .withEventType("SECOND_NON_STATE_TRANSITION_EVENT")
+                .withResourceType(ResourceType.PAYMENT)
+                .toEntity();
+
+        thrown.expect(RuntimeException.class);
+        thrown.expectMessage("No supported external state transition events found for digest");
+        EventDigest.fromEventList(List.of(firstNonSalientEvent, secondNonSalientEvent));
+    }
+}

--- a/src/test/java/uk/gov/pay/ledger/event/model/TransactionEntityFactoryTest.java
+++ b/src/test/java/uk/gov/pay/ledger/event/model/TransactionEntityFactoryTest.java
@@ -118,24 +118,7 @@ public class TransactionEntityFactoryTest {
     }
 
     @Test
-    public void fromShouldRejectEventDigestWithoutAnySalientEvents() throws Exception {
-        Event firstNonSalientEvent = aQueueEventFixture()
-                .withEventType("FIRST_NON_STATE_TRANSITION_EVENT")
-                .withResourceType(ResourceType.PAYMENT)
-                .toEntity();
-
-        Event secondNonSalientEvent = aQueueEventFixture()
-                .withEventType("SECOND_NON_STATE_TRANSITION_EVENT")
-                .withResourceType(ResourceType.PAYMENT)
-                .toEntity();
-
-        thrown.expect(RuntimeException.class);
-        thrown.expectMessage("No supported external state transition events found for digest");
-        EventDigest.fromEventList(List.of(firstNonSalientEvent, secondNonSalientEvent));
-    }
-
-    @Test
-    public void fromShouldCorrectlySetStateForMostRecentSalientEventType() {
+    public void create_ShouldCorrectlySetStateForMostRecentSalientEventType() {
         Event paymentCreatedEvent = aQueueEventFixture().withEventType("PAYMENT_CREATED").toEntity();
         Event nonSalientEvent = aQueueEventFixture().withEventType("NON_STATE_TRANSITION_EVENT").toEntity();
         Event paymentStartedEvent = aQueueEventFixture().withEventType("PAYMENT_STARTED").toEntity();

--- a/src/test/java/uk/gov/pay/ledger/event/model/TransactionEntityFactoryTest.java
+++ b/src/test/java/uk/gov/pay/ledger/event/model/TransactionEntityFactoryTest.java
@@ -32,8 +32,8 @@ public class TransactionEntityFactoryTest {
     @Test
     public void fromShouldConvertEventDigestToTransactionEntity() {
         Event paymentCreatedEvent = aQueueEventFixture()
-                .withEventType(EventType.PAYMENT_CREATED.name())
-                .withDefaultEventDataForEventType(EventType.PAYMENT_CREATED.name())
+                .withEventType(SalientEventType.PAYMENT_CREATED.name())
+                .withDefaultEventDataForEventType(SalientEventType.PAYMENT_CREATED.name())
                 .withResourceType(ResourceType.PAYMENT)
                 .toEntity();
         Event paymentDetailsEvent = aQueueEventFixture()
@@ -118,7 +118,7 @@ public class TransactionEntityFactoryTest {
     }
 
     @Test
-    public void fromShouldRejectEventDigestWithoutStateTransitionEvents() throws Exception {
+    public void fromShouldRejectEventDigestWithoutAnySalientEvents() throws Exception {
         Event firstNonSalientEvent = aQueueEventFixture()
                 .withEventType("FIRST_NON_STATE_TRANSITION_EVENT")
                 .withResourceType(ResourceType.PAYMENT)
@@ -135,7 +135,7 @@ public class TransactionEntityFactoryTest {
     }
 
     @Test
-    public void fromShouldGetLatestEventDigestState() {
+    public void fromShouldCorrectlySetStateForMostRecentSalientEventType() {
         Event paymentCreatedEvent = aQueueEventFixture().withEventType("PAYMENT_CREATED").toEntity();
         Event nonSalientEvent = aQueueEventFixture().withEventType("NON_STATE_TRANSITION_EVENT").toEntity();
         Event paymentStartedEvent = aQueueEventFixture().withEventType("PAYMENT_STARTED").toEntity();

--- a/src/test/java/uk/gov/pay/ledger/event/service/EventServiceTest.java
+++ b/src/test/java/uk/gov/pay/ledger/event/service/EventServiceTest.java
@@ -10,7 +10,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.pay.ledger.event.dao.EventDao;
 import uk.gov.pay.ledger.event.model.Event;
 import uk.gov.pay.ledger.event.model.EventDigest;
-import uk.gov.pay.ledger.event.model.EventType;
+import uk.gov.pay.ledger.event.model.SalientEventType;
 import uk.gov.pay.ledger.event.model.response.CreateEventResponse;
 import uk.gov.pay.ledger.util.fixture.EventFixture;
 
@@ -63,7 +63,7 @@ public class EventServiceTest {
         EventDigest eventDigest = eventService.getEventDigestForResource(resourceExternalId);
 
         assertThat(eventDigest.getMostRecentEventTimestamp(), is(latestEventTime));
-        assertThat(eventDigest.getMostRecentEventType(), is(EventType.PAYMENT_CREATED));
+        assertThat(eventDigest.getMostRecentSalientEventType(), is(SalientEventType.PAYMENT_CREATED));
     }
 
     @Test
@@ -93,7 +93,7 @@ public class EventServiceTest {
 
         EventDigest eventDigest = eventService.getEventDigestForResource(resourceExternalId);
 
-        assertThat(eventDigest.getMostRecentEventType(), is(EventType.PAYMENT_CREATED));
+        assertThat(eventDigest.getMostRecentSalientEventType(), is(SalientEventType.PAYMENT_CREATED));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/ledger/queue/QueueMessageReceiverIT.java
+++ b/src/test/java/uk/gov/pay/ledger/queue/QueueMessageReceiverIT.java
@@ -2,7 +2,7 @@ package uk.gov.pay.ledger.queue;
 
 import org.junit.ClassRule;
 import org.junit.Test;
-import uk.gov.pay.ledger.event.model.EventType;
+import uk.gov.pay.ledger.event.model.SalientEventType;
 import uk.gov.pay.ledger.event.model.ResourceType;
 import uk.gov.pay.ledger.rule.AppWithPostgresAndSqsRule;
 
@@ -34,8 +34,8 @@ public class QueueMessageReceiverIT {
         aQueueEventFixture()
                 .withResourceExternalId(resourceExternalId)
                 .withEventDate(CREATED_AT.minusMinutes(1))
-                .withEventType(EventType.PAYMENT_CREATED.name())
-                .withDefaultEventDataForEventType(EventType.PAYMENT_CREATED.name())
+                .withEventType(SalientEventType.PAYMENT_CREATED.name())
+                .withDefaultEventDataForEventType(SalientEventType.PAYMENT_CREATED.name())
                 .insert(rule.getSqsClient());
 
         Thread.sleep(500);
@@ -64,8 +64,8 @@ public class QueueMessageReceiverIT {
                 .withResourceExternalId(resourceExternalId2)
                 .withResourceType(ResourceType.PAYMENT)
                 .withEventDate(CREATED_AT.minusMinutes(1))
-                .withEventType(EventType.PAYMENT_CREATED.name())
-                .withDefaultEventDataForEventType(EventType.PAYMENT_CREATED.name())
+                .withEventType(SalientEventType.PAYMENT_CREATED.name())
+                .withDefaultEventDataForEventType(SalientEventType.PAYMENT_CREATED.name())
                 .insert(rule.getSqsClient());
 
         Thread.sleep(500);


### PR DESCRIPTION
* use the most recent `s/salient/state-transitioning/g` event to determine event digest state

Implicitly this sets the standard that: 
* ledger shouldn't need to know about events that don't transition state (directly map to external states)
* any number of payload events can be related to a given digest, as long as at least one event maps to an external state ledger knows about

Question: should it be enforced that registered enum `EventType` has a map to an external state in `TransactionState`