### PR TITLE
PP-5389 Index `created_date` for transactions

### DIFF
--- a/src/main/resources/migrations/00021_index_created_date_for_order_by.sql
+++ b/src/main/resources/migrations/00021_index_created_date_for_order_by.sql
@@ -1,0 +1,5 @@
+--liquibase formatted sql
+
+--changeset uk.gov.pay:index_created_date_for_order_by runInTransaction:false
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS created_date_idx ON transaction USING btree(created_date);


### PR DESCRIPTION
* looking up the latest transactions in ledger is taking ages
* _leverage_ Index Scan Backward, make them instant

This could also be done for events themselves however the number of events we will be interested in should normally be limited by the scope of the resource ID.