### PR TITLE
PP-5469: pacts in separate files

### DIFF
--- a/src/test/java/uk/gov/pay/ledger/pact/CaptureConfirmedEventQueueContractTest.java
+++ b/src/test/java/uk/gov/pay/ledger/pact/CaptureConfirmedEventQueueContractTest.java
@@ -1,0 +1,84 @@
+package uk.gov.pay.ledger.pact;
+
+import au.com.dius.pact.consumer.MessagePactBuilder;
+import au.com.dius.pact.consumer.MessagePactProviderRule;
+import au.com.dius.pact.consumer.Pact;
+import au.com.dius.pact.consumer.PactVerification;
+import au.com.dius.pact.consumer.dsl.PactDslJsonBody;
+import au.com.dius.pact.model.v3.messaging.MessagePact;
+import org.junit.Rule;
+import org.junit.Test;
+import uk.gov.pay.ledger.rule.AppWithPostgresAndSqsRule;
+import uk.gov.pay.ledger.rule.SqsTestDocker;
+import uk.gov.pay.ledger.util.DatabaseTestHelper;
+import uk.gov.pay.ledger.util.fixture.QueueEventFixture;
+
+import java.time.ZonedDateTime;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.concurrent.TimeUnit;
+
+import static io.dropwizard.testing.ConfigOverride.config;
+import static org.awaitility.Awaitility.await;
+
+public class CaptureConfirmedEventQueueContractTest {
+    @Rule
+    public MessagePactProviderRule mockProvider = new MessagePactProviderRule(this);
+
+    @Rule
+    public AppWithPostgresAndSqsRule appRule = new AppWithPostgresAndSqsRule(
+            config("queueMessageReceiverConfig.backgroundProcessingEnabled", "true")
+    );
+
+    private byte[] currentMessage;
+    private String externalId = "externalId";
+    private ZonedDateTime eventDate = ZonedDateTime.parse("2018-03-12T16:25:01.123456Z");
+    private String gatewayAccountId = "gateway_account_id";
+
+    @Pact(provider = "connector", consumer = "ledger")
+    public MessagePact createCaptureConfirmedEventPact(MessagePactBuilder builder) {
+        String eventType = "CAPTURE_CONFIRMED";
+        QueueEventFixture captureConfirmedEvent = QueueEventFixture.aQueueEventFixture()
+                .withResourceExternalId(externalId)
+                .withEventDate(eventDate)
+                .withGatewayAccountId(gatewayAccountId)
+                .withEventType(eventType)
+                .withDefaultEventDataForEventType(eventType);
+
+        Map<String, String> metadata = new HashMap<String, String>();
+        metadata.put("contentType", "application/json");
+
+        PactDslJsonBody pactBody = captureConfirmedEvent.getAsPact();
+
+        return builder
+                .expectsToReceive("a capture confirmed message")
+                .withMetadata(metadata)
+                .withContent(pactBody)
+                .toPact();
+    }
+
+    @Test
+    @PactVerification({"connector"})
+    public void test() throws Exception {
+        appRule.getSqsClient().sendMessage(SqsTestDocker.getQueueUrl("event-queue"), new String(currentMessage));
+
+        DatabaseTestHelper dbHelper = DatabaseTestHelper.aDatabaseTestHelper(appRule.getJdbi());
+        await().atMost(1, TimeUnit.SECONDS).until(
+                () -> {
+                    Map<String, Object> event;
+                    try {
+                        event = dbHelper.getEventByExternalId("externalId");
+                        return "externalId".equals(event.get("resource_external_id"));
+
+                    } catch (NoSuchElementException e) {
+                        return false;
+                    }
+                }
+        );
+    }
+
+    public void setMessage(byte[] messageContents) {
+        currentMessage = messageContents;
+    }
+}

--- a/src/test/java/uk/gov/pay/ledger/pact/CaptureConfirmedEventQueueContractTest.java
+++ b/src/test/java/uk/gov/pay/ledger/pact/CaptureConfirmedEventQueueContractTest.java
@@ -9,11 +9,11 @@ import au.com.dius.pact.model.v3.messaging.MessagePact;
 import org.junit.Rule;
 import org.junit.Test;
 import uk.gov.pay.ledger.event.dao.EventDao;
+import uk.gov.pay.ledger.event.model.Event;
 import uk.gov.pay.ledger.rule.AppWithPostgresAndSqsRule;
 import uk.gov.pay.ledger.rule.SqsTestDocker;
 import uk.gov.pay.ledger.transaction.dao.TransactionDao;
 import uk.gov.pay.ledger.transaction.entity.TransactionEntity;
-import uk.gov.pay.ledger.util.DatabaseTestHelper;
 import uk.gov.pay.ledger.util.fixture.QueueEventFixture;
 
 import java.time.ZonedDateTime;
@@ -86,13 +86,13 @@ public class CaptureConfirmedEventQueueContractTest {
                 }
         );
 
-        var transaction = transactionDao.findTransactionByExternalId(externalId);
+        Optional<TransactionEntity> transaction = transactionDao.findTransactionByExternalId(externalId);
         assertThat(transaction.isPresent(), is(true));
         assertThat(transaction.get().getExternalId(), is(externalId));
         assertThat(transaction.get().getFee(), is(5L));
         assertThat(transaction.get().getNetAmount(), is(1069L));
 
-        var event = eventDao.getEventsByResourceExternalId(externalId).get(0);
+        Event event = eventDao.getEventsByResourceExternalId(externalId).get(0);
         assertThat(event.getEventData(), containsStringIgnoringCase("\"gateway_event_date\": \"2018-03-12T16:25:01.123456Z\""));
     }
 

--- a/src/test/java/uk/gov/pay/ledger/pact/ContractTestSuite.java
+++ b/src/test/java/uk/gov/pay/ledger/pact/ContractTestSuite.java
@@ -7,7 +7,8 @@ import org.junit.runners.Suite;
 
 @Suite.SuiteClasses({
         TransactionsApiContractTest.class,
-        EventQueueContractTest.class,
+        PaymentCreatedEventQueueContractTest.class,
+        CaptureConfirmedEventQueueContractTest.class,
         GetTransactionContractTest.class
 })
 public class ContractTestSuite {

--- a/src/test/java/uk/gov/pay/ledger/pact/PaymentCreatedEventQueueContractTest.java
+++ b/src/test/java/uk/gov/pay/ledger/pact/PaymentCreatedEventQueueContractTest.java
@@ -4,7 +4,6 @@ import au.com.dius.pact.consumer.MessagePactBuilder;
 import au.com.dius.pact.consumer.MessagePactProviderRule;
 import au.com.dius.pact.consumer.Pact;
 import au.com.dius.pact.consumer.PactVerification;
-import au.com.dius.pact.consumer.dsl.PactDslJsonBody;
 import au.com.dius.pact.model.v3.messaging.MessagePact;
 import org.junit.Rule;
 import org.junit.Test;
@@ -22,7 +21,7 @@ import java.util.concurrent.TimeUnit;
 import static io.dropwizard.testing.ConfigOverride.config;
 import static org.awaitility.Awaitility.await;
 
-public class EventQueueContractTest {
+public class PaymentCreatedEventQueueContractTest {
     @Rule
     public MessagePactProviderRule mockProvider = new MessagePactProviderRule(this);
 
@@ -50,28 +49,6 @@ public class EventQueueContractTest {
         return builder
                 .expectsToReceive("a payment created message")
                 .withContent(paymentCreatedEventFixture.getAsPact())
-                .toPact();
-    }
-
-    @Pact(provider = "connector", consumer = "ledger")
-    public MessagePact createCaptureConfirmedEventPact(MessagePactBuilder builder) {
-        String eventType = "CAPTURE_CONFIRMED";
-        QueueEventFixture captureConfirmedEvent = QueueEventFixture.aQueueEventFixture()
-                .withResourceExternalId(externalId)
-                .withEventDate(eventDate)
-                .withGatewayAccountId(gatewayAccountId)
-                .withEventType(eventType)
-                .withDefaultEventDataForEventType(eventType);
-
-        Map<String, String> metadata = new HashMap<String, String>();
-        metadata.put("contentType", "application/json");
-
-        PactDslJsonBody pactBody = captureConfirmedEvent.getAsPact();
-
-        return builder
-                .expectsToReceive("a capture confirmed message")
-                .withMetadata(metadata)
-                .withContent(pactBody)
                 .toPact();
     }
 


### PR DESCRIPTION
Moved PaymentCreated event pact to separate file and renamed EventQueueContractTest to CaptureConfirmedEventQueueContractTest (or the other way around)