### PR TITLE
PP-5391 add refund events contract tests

### DIFF
--- a/src/test/java/uk/gov/pay/ledger/event/model/EventDigestTest.java
+++ b/src/test/java/uk/gov/pay/ledger/event/model/EventDigestTest.java
@@ -6,7 +6,7 @@ import org.junit.rules.ExpectedException;
 
 import java.util.List;
 
-import static uk.gov.pay.ledger.util.fixture.QueueEventFixture.aQueueEventFixture;
+import static uk.gov.pay.ledger.util.fixture.QueuePaymentEventFixture.aQueuePaymentEventFixture;
 
 public class EventDigestTest {
     @Rule
@@ -14,12 +14,12 @@ public class EventDigestTest {
 
     @Test
     public void fromEventList_ShouldRejectEventDigestWithoutAnySalientEvents() {
-        Event firstNonSalientEvent = aQueueEventFixture()
+        Event firstNonSalientEvent = aQueuePaymentEventFixture()
                 .withEventType("FIRST_NON_STATE_TRANSITION_EVENT")
                 .withResourceType(ResourceType.PAYMENT)
                 .toEntity();
 
-        Event secondNonSalientEvent = aQueueEventFixture()
+        Event secondNonSalientEvent = aQueuePaymentEventFixture()
                 .withEventType("SECOND_NON_STATE_TRANSITION_EVENT")
                 .withResourceType(ResourceType.PAYMENT)
                 .toEntity();

--- a/src/test/java/uk/gov/pay/ledger/event/model/TransactionEntityFactoryTest.java
+++ b/src/test/java/uk/gov/pay/ledger/event/model/TransactionEntityFactoryTest.java
@@ -13,7 +13,7 @@ import java.util.Map;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static uk.gov.pay.ledger.util.fixture.QueueEventFixture.aQueueEventFixture;
+import static uk.gov.pay.ledger.util.fixture.QueuePaymentEventFixture.aQueuePaymentEventFixture;
 
 public class TransactionEntityFactoryTest {
 
@@ -31,17 +31,17 @@ public class TransactionEntityFactoryTest {
 
     @Test
     public void fromShouldConvertEventDigestToTransactionEntity() {
-        Event paymentCreatedEvent = aQueueEventFixture()
+        Event paymentCreatedEvent = aQueuePaymentEventFixture()
                 .withEventType(SalientEventType.PAYMENT_CREATED.name())
                 .withDefaultEventDataForEventType(SalientEventType.PAYMENT_CREATED.name())
                 .withResourceType(ResourceType.PAYMENT)
                 .toEntity();
-        Event paymentDetailsEvent = aQueueEventFixture()
+        Event paymentDetailsEvent = aQueuePaymentEventFixture()
                 .withEventType("PAYMENT_DETAILS_ENTERED")
                 .withDefaultEventDataForEventType("PAYMENT_DETAILS_ENTERED")
                 .withResourceType(ResourceType.PAYMENT)
                 .toEntity();
-        Event captureConfirmedEvent = aQueueEventFixture()
+        Event captureConfirmedEvent = aQueuePaymentEventFixture()
                 .withEventType("CAPTURE_CONFIRMED")
                 .withEventData("{\"net_amount\": 55, \"total_amount\": 105, \"fee\": 33}")
                 .withResourceType(ResourceType.PAYMENT)
@@ -89,14 +89,14 @@ public class TransactionEntityFactoryTest {
     @Test
     public void fromShouldConvertEventDigestToTransactionForChildResource() throws IOException {
         String parentResourceExternalId = "parent-resource-external-id";
-        Event refundCreatedEvent = aQueueEventFixture()
+        Event refundCreatedEvent = aQueuePaymentEventFixture()
                 .withEventType("REFUND_CREATED_BY_USER")
                 .withResourceExternalId("resource-external-id")
                 .withParentResourceExternalId(parentResourceExternalId)
                 .withResourceType(ResourceType.REFUND)
                 .withEventData("{\"refunded_by\": \"refunded-by-id\", \"amount\": 1000}")
                 .toEntity();
-        Event refundSubmittedEvent = aQueueEventFixture()
+        Event refundSubmittedEvent = aQueuePaymentEventFixture()
                 .withEventType("REFUND_SUBMITTED")
                 .withResourceExternalId("resource-external-id")
                 .withParentResourceExternalId(parentResourceExternalId)
@@ -119,10 +119,10 @@ public class TransactionEntityFactoryTest {
 
     @Test
     public void create_ShouldCorrectlySetStateForMostRecentSalientEventType() {
-        Event paymentCreatedEvent = aQueueEventFixture().withEventType("PAYMENT_CREATED").toEntity();
-        Event nonSalientEvent = aQueueEventFixture().withEventType("NON_STATE_TRANSITION_EVENT").toEntity();
-        Event paymentStartedEvent = aQueueEventFixture().withEventType("PAYMENT_STARTED").toEntity();
-        Event secondNonSalientEvent = aQueueEventFixture().withEventType("SECOND_NON_STATE_TRANSITION_EVENT").toEntity();
+        Event paymentCreatedEvent = aQueuePaymentEventFixture().withEventType("PAYMENT_CREATED").toEntity();
+        Event nonSalientEvent = aQueuePaymentEventFixture().withEventType("NON_STATE_TRANSITION_EVENT").toEntity();
+        Event paymentStartedEvent = aQueuePaymentEventFixture().withEventType("PAYMENT_STARTED").toEntity();
+        Event secondNonSalientEvent = aQueuePaymentEventFixture().withEventType("SECOND_NON_STATE_TRANSITION_EVENT").toEntity();
 
         EventDigest eventDigest = EventDigest.fromEventList(List.of(secondNonSalientEvent, paymentStartedEvent, nonSalientEvent, paymentCreatedEvent));
         TransactionEntity transactionEntity = transactionEntityFactory.create(eventDigest);

--- a/src/test/java/uk/gov/pay/ledger/pact/CaptureConfirmedEventQueueContractTest.java
+++ b/src/test/java/uk/gov/pay/ledger/pact/CaptureConfirmedEventQueueContractTest.java
@@ -14,7 +14,7 @@ import uk.gov.pay.ledger.rule.AppWithPostgresAndSqsRule;
 import uk.gov.pay.ledger.rule.SqsTestDocker;
 import uk.gov.pay.ledger.transaction.dao.TransactionDao;
 import uk.gov.pay.ledger.transaction.entity.TransactionEntity;
-import uk.gov.pay.ledger.util.fixture.QueueEventFixture;
+import uk.gov.pay.ledger.util.fixture.QueuePaymentEventFixture;
 
 import java.time.ZonedDateTime;
 import java.util.HashMap;
@@ -46,7 +46,7 @@ public class CaptureConfirmedEventQueueContractTest {
     @Pact(provider = "connector", consumer = "ledger")
     public MessagePact createCaptureConfirmedEventPact(MessagePactBuilder builder) {
         String eventType = "CAPTURE_CONFIRMED";
-        QueueEventFixture captureConfirmedEvent = QueueEventFixture.aQueueEventFixture()
+        QueuePaymentEventFixture captureConfirmedEvent = QueuePaymentEventFixture.aQueuePaymentEventFixture()
                 .withResourceExternalId(externalId)
                 .withEventDate(eventDate)
                 .withGatewayAccountId(gatewayAccountId)

--- a/src/test/java/uk/gov/pay/ledger/pact/ContractTestSuite.java
+++ b/src/test/java/uk/gov/pay/ledger/pact/ContractTestSuite.java
@@ -9,7 +9,10 @@ import org.junit.runners.Suite;
         TransactionsApiContractTest.class,
         PaymentCreatedEventQueueContractTest.class,
         CaptureConfirmedEventQueueContractTest.class,
-        GetTransactionContractTest.class
+        GetTransactionContractTest.class,
+        RefundCreatedByUserEventQueueContractTest.class,
+        RefundSubmittedEventQueueContractTest.class,
+        RefundSucceededEventQueueContractTest.class
 })
 public class ContractTestSuite {
 

--- a/src/test/java/uk/gov/pay/ledger/pact/PaymentCreatedEventQueueContractTest.java
+++ b/src/test/java/uk/gov/pay/ledger/pact/PaymentCreatedEventQueueContractTest.java
@@ -12,7 +12,7 @@ import uk.gov.pay.ledger.rule.AppWithPostgresAndSqsRule;
 import uk.gov.pay.ledger.rule.SqsTestDocker;
 import uk.gov.pay.ledger.transaction.dao.TransactionDao;
 import uk.gov.pay.ledger.transaction.entity.TransactionEntity;
-import uk.gov.pay.ledger.util.fixture.QueueEventFixture;
+import uk.gov.pay.ledger.util.fixture.QueuePaymentEventFixture;
 
 import java.time.ZonedDateTime;
 import java.util.HashMap;
@@ -42,7 +42,7 @@ public class PaymentCreatedEventQueueContractTest {
 
     @Pact(provider = "connector", consumer = "ledger")
     public MessagePact createPaymentCreatedEventPact(MessagePactBuilder builder) {
-        QueueEventFixture paymentCreatedEventFixture = QueueEventFixture.aQueueEventFixture()
+        QueuePaymentEventFixture paymentCreatedEventFixture = QueuePaymentEventFixture.aQueuePaymentEventFixture()
                 .withResourceExternalId(externalId)
                 .withEventDate(eventDate)
                 .withGatewayAccountId(gatewayAccountId)

--- a/src/test/java/uk/gov/pay/ledger/pact/RefundCreatedByUserEventQueueContractTest.java
+++ b/src/test/java/uk/gov/pay/ledger/pact/RefundCreatedByUserEventQueueContractTest.java
@@ -5,8 +5,6 @@ import au.com.dius.pact.consumer.MessagePactProviderRule;
 import au.com.dius.pact.consumer.Pact;
 import au.com.dius.pact.consumer.PactVerification;
 import au.com.dius.pact.model.v3.messaging.MessagePact;
-import com.google.gson.JsonObject;
-import com.google.gson.JsonParser;
 import org.junit.Rule;
 import org.junit.Test;
 import org.testcontainers.shaded.org.apache.commons.lang.RandomStringUtils;
@@ -14,11 +12,12 @@ import uk.gov.pay.ledger.event.model.ResourceType;
 import uk.gov.pay.ledger.rule.AppWithPostgresAndSqsRule;
 import uk.gov.pay.ledger.rule.SqsTestDocker;
 import uk.gov.pay.ledger.transaction.dao.TransactionDao;
-import uk.gov.pay.ledger.util.DatabaseTestHelper;
+import uk.gov.pay.ledger.transaction.entity.TransactionEntity;
 import uk.gov.pay.ledger.util.fixture.QueueRefundEventFixture;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
 import static io.dropwizard.testing.ConfigOverride.config;
@@ -47,7 +46,7 @@ public class RefundCreatedByUserEventQueueContractTest {
 
     @Pact(provider = "connector", consumer = "ledger")
     public MessagePact createRefundCreatedByUserEventPact(MessagePactBuilder builder) {
-        Map<String, String> metadata = new HashMap();
+        Map<String, String> metadata = new HashMap<>();
         metadata.put("contentType", "application/json");
 
         return builder
@@ -60,25 +59,26 @@ public class RefundCreatedByUserEventQueueContractTest {
     @Test
     @PactVerification({"connector"})
     public void test() throws Exception {
-        aTransactionFixture()
+        aTransactionFixture()  // adds parent payment transaction for refund to be inserted
                 .withExternalId(refundFixture.getParentResourceExternalId())
+                .withTransactionType("PAYMENT")
                 .insert(appRule.getJdbi());
 
         appRule.getSqsClient().sendMessage(SqsTestDocker.getQueueUrl("event-queue"), new String(currentMessage));
-
-        DatabaseTestHelper dbHelper = DatabaseTestHelper.aDatabaseTestHelper(appRule.getJdbi());
         TransactionDao transactionDao = new TransactionDao(appRule.getJdbi());
-        await().atMost(1000, TimeUnit.SECONDS).until(
+
+        await().atMost(1, TimeUnit.SECONDS).until(
                 () -> transactionDao.findTransactionByExternalId(refundFixture.getResourceExternalId()).isPresent()
         );
 
-        Map<String, Object> event = dbHelper.getEventByExternalId(refundFixture.getResourceExternalId());
-        JsonObject eventData = new JsonParser().parse(event.get("event_data").toString()).getAsJsonObject();
+        Optional<TransactionEntity> transaction = transactionDao.findTransactionByExternalId(refundFixture.getResourceExternalId());
 
-        assertThat(event.get("resource_external_id"), is(refundFixture.getResourceExternalId()));
-        assertThat(event.get("parent_resource_external_id"), is(refundFixture.getParentResourceExternalId()));
-        assertThat(eventData.get("amount").getAsLong(), is(refundFixture.getAmount()));
-        assertThat(eventData.get("refunded_by").getAsString(), is(refundFixture.getRefundedBy()));
+        assertThat(transaction.get().getExternalId(), is(refundFixture.getResourceExternalId()));
+        assertThat(transaction.get().getParentExternalId(), is(refundFixture.getParentResourceExternalId()));
+        assertThat(transaction.get().getAmount(), is(refundFixture.getAmount()));
+        assertThat(transaction.get().getCreatedDate(),is(refundFixture.getEventDate()));
+        assertThat(transaction.get().getTransactionDetails(),
+                is("{\"refunded_by\": \"" + refundFixture.getRefundedBy() + "\"}"));
     }
 
     public void setMessage(byte[] messageContents) {

--- a/src/test/java/uk/gov/pay/ledger/pact/RefundCreatedByUserEventQueueContractTest.java
+++ b/src/test/java/uk/gov/pay/ledger/pact/RefundCreatedByUserEventQueueContractTest.java
@@ -1,0 +1,87 @@
+package uk.gov.pay.ledger.pact;
+
+import au.com.dius.pact.consumer.MessagePactBuilder;
+import au.com.dius.pact.consumer.MessagePactProviderRule;
+import au.com.dius.pact.consumer.Pact;
+import au.com.dius.pact.consumer.PactVerification;
+import au.com.dius.pact.model.v3.messaging.MessagePact;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import org.junit.Rule;
+import org.junit.Test;
+import org.testcontainers.shaded.org.apache.commons.lang.RandomStringUtils;
+import uk.gov.pay.ledger.event.model.ResourceType;
+import uk.gov.pay.ledger.rule.AppWithPostgresAndSqsRule;
+import uk.gov.pay.ledger.rule.SqsTestDocker;
+import uk.gov.pay.ledger.transaction.dao.TransactionDao;
+import uk.gov.pay.ledger.util.DatabaseTestHelper;
+import uk.gov.pay.ledger.util.fixture.QueueRefundEventFixture;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import static io.dropwizard.testing.ConfigOverride.config;
+import static org.awaitility.Awaitility.await;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static uk.gov.pay.ledger.util.fixture.QueueRefundEventFixture.aQueueRefundEventFixture;
+import static uk.gov.pay.ledger.util.fixture.TransactionFixture.aTransactionFixture;
+
+public class RefundCreatedByUserEventQueueContractTest {
+    @Rule
+    public MessagePactProviderRule mockProvider = new MessagePactProviderRule(this);
+
+    @Rule
+    public AppWithPostgresAndSqsRule appRule = new AppWithPostgresAndSqsRule(
+            config("queueMessageReceiverConfig.backgroundProcessingEnabled", "true")
+    );
+
+    private byte[] currentMessage;
+
+    private QueueRefundEventFixture refundFixture = aQueueRefundEventFixture()
+            .withResourceType(ResourceType.REFUND)
+            .withEventType("REFUND_CREATED_BY_USER")
+            .withRefundedBy(RandomStringUtils.randomAlphanumeric(14))
+            .withDefaultEventDataForEventType("REFUND_CREATED_BY_USER");
+
+    @Pact(provider = "connector", consumer = "ledger")
+    public MessagePact createRefundCreatedByUserEventPact(MessagePactBuilder builder) {
+        Map<String, String> metadata = new HashMap();
+        metadata.put("contentType", "application/json");
+
+        return builder
+                .expectsToReceive("a refund created by user message")
+                .withMetadata(metadata)
+                .withContent(refundFixture.getAsPact())
+                .toPact();
+    }
+
+    @Test
+    @PactVerification({"connector"})
+    public void test() throws Exception {
+        aTransactionFixture()
+                .withExternalId(refundFixture.getParentResourceExternalId())
+                .insert(appRule.getJdbi());
+
+        appRule.getSqsClient().sendMessage(SqsTestDocker.getQueueUrl("event-queue"), new String(currentMessage));
+
+        DatabaseTestHelper dbHelper = DatabaseTestHelper.aDatabaseTestHelper(appRule.getJdbi());
+        TransactionDao transactionDao = new TransactionDao(appRule.getJdbi());
+        await().atMost(1000, TimeUnit.SECONDS).until(
+                () -> transactionDao.findTransactionByExternalId(refundFixture.getResourceExternalId()).isPresent()
+        );
+
+        Map<String, Object> event = dbHelper.getEventByExternalId(refundFixture.getResourceExternalId());
+        JsonObject eventData = new JsonParser().parse(event.get("event_data").toString()).getAsJsonObject();
+
+        assertThat(event.get("resource_external_id"), is(refundFixture.getResourceExternalId()));
+        assertThat(event.get("parent_resource_external_id"), is(refundFixture.getParentResourceExternalId()));
+        assertThat(eventData.get("amount").getAsLong(), is(refundFixture.getAmount()));
+        assertThat(eventData.get("refunded_by").getAsString(), is(refundFixture.getRefundedBy()));
+    }
+
+    public void setMessage(byte[] messageContents) {
+        currentMessage = messageContents;
+    }
+}

--- a/src/test/java/uk/gov/pay/ledger/pact/RefundSubmittedEventQueueContractTest.java
+++ b/src/test/java/uk/gov/pay/ledger/pact/RefundSubmittedEventQueueContractTest.java
@@ -5,19 +5,18 @@ import au.com.dius.pact.consumer.MessagePactProviderRule;
 import au.com.dius.pact.consumer.Pact;
 import au.com.dius.pact.consumer.PactVerification;
 import au.com.dius.pact.model.v3.messaging.MessagePact;
-import com.google.gson.JsonObject;
-import com.google.gson.JsonParser;
 import org.junit.Rule;
 import org.junit.Test;
 import uk.gov.pay.ledger.event.model.ResourceType;
 import uk.gov.pay.ledger.rule.AppWithPostgresAndSqsRule;
 import uk.gov.pay.ledger.rule.SqsTestDocker;
 import uk.gov.pay.ledger.transaction.dao.TransactionDao;
-import uk.gov.pay.ledger.util.DatabaseTestHelper;
+import uk.gov.pay.ledger.transaction.entity.TransactionEntity;
 import uk.gov.pay.ledger.util.fixture.QueueRefundEventFixture;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
 import static io.dropwizard.testing.ConfigOverride.config;
@@ -56,26 +55,24 @@ public class RefundSubmittedEventQueueContractTest {
 
     @Test
     @PactVerification({"connector"})
-    public void test() throws Exception {
+    public void test() {
         aTransactionFixture()
                 .withExternalId(refundFixture.getParentResourceExternalId())
                 .insert(appRule.getJdbi());
 
         appRule.getSqsClient().sendMessage(SqsTestDocker.getQueueUrl("event-queue"), new String(currentMessage));
-
-        DatabaseTestHelper dbHelper = DatabaseTestHelper.aDatabaseTestHelper(appRule.getJdbi());
         TransactionDao transactionDao = new TransactionDao(appRule.getJdbi());
 
         await().atMost(1, TimeUnit.SECONDS).until(
                 () -> transactionDao.findTransactionByExternalId(refundFixture.getResourceExternalId()).isPresent()
         );
 
-        Map<String, Object> event = dbHelper.getEventByExternalId(refundFixture.getResourceExternalId());
-        JsonObject eventData = new JsonParser().parse(event.get("event_data").toString()).getAsJsonObject();
+        Optional<TransactionEntity> transaction = transactionDao.findTransactionByExternalId(refundFixture.getResourceExternalId());
 
-        assertThat(event.get("resource_external_id"), is(refundFixture.getResourceExternalId()));
-        assertThat(event.get("parent_resource_external_id"), is(refundFixture.getParentResourceExternalId()));
-        assertThat(eventData.entrySet().isEmpty(), is(true));
+        assertThat(transaction.get().getExternalId(), is(refundFixture.getResourceExternalId()));
+        assertThat(transaction.get().getParentExternalId(),is(refundFixture.getParentResourceExternalId()));
+        assertThat(transaction.get().getCreatedDate(),is(refundFixture.getEventDate()));
+        assertThat(transaction.get().getTransactionDetails(), is("{}"));
     }
 
     public void setMessage(byte[] messageContents) {

--- a/src/test/java/uk/gov/pay/ledger/pact/RefundSubmittedEventQueueContractTest.java
+++ b/src/test/java/uk/gov/pay/ledger/pact/RefundSubmittedEventQueueContractTest.java
@@ -1,0 +1,84 @@
+package uk.gov.pay.ledger.pact;
+
+import au.com.dius.pact.consumer.MessagePactBuilder;
+import au.com.dius.pact.consumer.MessagePactProviderRule;
+import au.com.dius.pact.consumer.Pact;
+import au.com.dius.pact.consumer.PactVerification;
+import au.com.dius.pact.model.v3.messaging.MessagePact;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import org.junit.Rule;
+import org.junit.Test;
+import uk.gov.pay.ledger.event.model.ResourceType;
+import uk.gov.pay.ledger.rule.AppWithPostgresAndSqsRule;
+import uk.gov.pay.ledger.rule.SqsTestDocker;
+import uk.gov.pay.ledger.transaction.dao.TransactionDao;
+import uk.gov.pay.ledger.util.DatabaseTestHelper;
+import uk.gov.pay.ledger.util.fixture.QueueRefundEventFixture;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import static io.dropwizard.testing.ConfigOverride.config;
+import static org.awaitility.Awaitility.await;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static uk.gov.pay.ledger.util.fixture.QueueRefundEventFixture.aQueueRefundEventFixture;
+import static uk.gov.pay.ledger.util.fixture.TransactionFixture.aTransactionFixture;
+
+public class RefundSubmittedEventQueueContractTest {
+    @Rule
+    public MessagePactProviderRule mockProvider = new MessagePactProviderRule(this);
+
+    @Rule
+    public AppWithPostgresAndSqsRule appRule = new AppWithPostgresAndSqsRule(
+            config("queueMessageReceiverConfig.backgroundProcessingEnabled", "true")
+    );
+
+    private byte[] currentMessage;
+    private QueueRefundEventFixture refundFixture = aQueueRefundEventFixture()
+            .withResourceType(ResourceType.REFUND)
+            .withEventType("REFUND_SUBMITTED")
+            .withDefaultEventDataForEventType("REFUND_SUBMITTED");
+
+    @Pact(provider = "connector", consumer = "ledger")
+    public MessagePact createRefundSubmittedEventPact(MessagePactBuilder builder) {
+        Map<String, String> metadata = new HashMap();
+        metadata.put("contentType", "application/json");
+
+        return builder
+                .expectsToReceive("a refund submitted message")
+                .withMetadata(metadata)
+                .withContent(refundFixture.getAsPact())
+                .toPact();
+    }
+
+    @Test
+    @PactVerification({"connector"})
+    public void test() throws Exception {
+        aTransactionFixture()
+                .withExternalId(refundFixture.getParentResourceExternalId())
+                .insert(appRule.getJdbi());
+
+        appRule.getSqsClient().sendMessage(SqsTestDocker.getQueueUrl("event-queue"), new String(currentMessage));
+
+        DatabaseTestHelper dbHelper = DatabaseTestHelper.aDatabaseTestHelper(appRule.getJdbi());
+        TransactionDao transactionDao = new TransactionDao(appRule.getJdbi());
+
+        await().atMost(1, TimeUnit.SECONDS).until(
+                () -> transactionDao.findTransactionByExternalId(refundFixture.getResourceExternalId()).isPresent()
+        );
+
+        Map<String, Object> event = dbHelper.getEventByExternalId(refundFixture.getResourceExternalId());
+        JsonObject eventData = new JsonParser().parse(event.get("event_data").toString()).getAsJsonObject();
+
+        assertThat(event.get("resource_external_id"), is(refundFixture.getResourceExternalId()));
+        assertThat(event.get("parent_resource_external_id"), is(refundFixture.getParentResourceExternalId()));
+        assertThat(eventData.entrySet().isEmpty(), is(true));
+    }
+
+    public void setMessage(byte[] messageContents) {
+        currentMessage = messageContents;
+    }
+}

--- a/src/test/java/uk/gov/pay/ledger/pact/RefundSucceededEventQueueContractTest.java
+++ b/src/test/java/uk/gov/pay/ledger/pact/RefundSucceededEventQueueContractTest.java
@@ -1,0 +1,91 @@
+package uk.gov.pay.ledger.pact;
+
+import au.com.dius.pact.consumer.MessagePactBuilder;
+import au.com.dius.pact.consumer.MessagePactProviderRule;
+import au.com.dius.pact.consumer.Pact;
+import au.com.dius.pact.consumer.PactVerification;
+import au.com.dius.pact.consumer.dsl.PactDslJsonBody;
+import au.com.dius.pact.model.v3.messaging.MessagePact;
+import com.google.gson.JsonParser;
+import org.junit.Rule;
+import org.junit.Test;
+import org.testcontainers.shaded.org.apache.commons.lang.RandomStringUtils;
+import uk.gov.pay.ledger.event.model.ResourceType;
+import uk.gov.pay.ledger.rule.AppWithPostgresAndSqsRule;
+import uk.gov.pay.ledger.rule.SqsTestDocker;
+import uk.gov.pay.ledger.transaction.dao.TransactionDao;
+import uk.gov.pay.ledger.util.DatabaseTestHelper;
+import uk.gov.pay.ledger.util.fixture.QueueRefundEventFixture;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import static io.dropwizard.testing.ConfigOverride.config;
+import static org.awaitility.Awaitility.await;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static uk.gov.pay.ledger.util.fixture.QueueRefundEventFixture.aQueueRefundEventFixture;
+import static uk.gov.pay.ledger.util.fixture.TransactionFixture.aTransactionFixture;
+
+public class RefundSucceededEventQueueContractTest {
+    @Rule
+    public MessagePactProviderRule mockProvider = new MessagePactProviderRule(this);
+
+    @Rule
+    public AppWithPostgresAndSqsRule appRule = new AppWithPostgresAndSqsRule(
+            config("queueMessageReceiverConfig.backgroundProcessingEnabled", "true")
+    );
+
+    private byte[] currentMessage;
+
+    private QueueRefundEventFixture refundFixture = aQueueRefundEventFixture()
+            .withResourceType(ResourceType.REFUND)
+            .withEventType("REFUND_SUCCEEDED")
+            .withReference(RandomStringUtils.randomAlphanumeric(14))
+            .withDefaultEventDataForEventType("REFUND_SUCCEEDED");
+
+    @Pact(provider = "connector", consumer = "ledger")
+    public MessagePact createRefundSucceededEventPact(MessagePactBuilder builder) {
+        Map<String, String> metadata = new HashMap();
+        metadata.put("contentType", "application/json");
+
+        PactDslJsonBody pactBody = refundFixture.getAsPact();
+
+        return builder
+                .expectsToReceive("a refund succeeded message")
+                .withMetadata(metadata)
+                .withContent(pactBody)
+                .toPact();
+    }
+
+    @Test
+    @PactVerification({"connector"})
+    public void test() throws Exception {
+        aTransactionFixture()
+                .withExternalId(refundFixture.getParentResourceExternalId())
+                .insert(appRule.getJdbi());
+
+        appRule.getSqsClient().sendMessage(SqsTestDocker.getQueueUrl("event-queue"), new String(currentMessage));
+
+        DatabaseTestHelper dbHelper = DatabaseTestHelper.aDatabaseTestHelper(appRule.getJdbi());
+        TransactionDao transactionDao = new TransactionDao(appRule.getJdbi());
+
+        await().atMost(1, TimeUnit.SECONDS).until(
+                () -> transactionDao.findTransactionByExternalId(refundFixture.getResourceExternalId()).isPresent()
+        );
+
+        Map<String, Object> event = dbHelper.getEventByExternalId(refundFixture.getResourceExternalId());
+
+        assertThat(event.get("resource_external_id"), is(refundFixture.getResourceExternalId()));
+        assertThat(event.get("parent_resource_external_id"), is(refundFixture.getParentResourceExternalId()));
+
+        String eventReference = new JsonParser().parse(event.get("event_data").toString())
+                .getAsJsonObject().get("reference").getAsString();
+        assertThat(eventReference, is(refundFixture.getReference()));
+    }
+
+    public void setMessage(byte[] messageContents) {
+        currentMessage = messageContents;
+    }
+}

--- a/src/test/java/uk/gov/pay/ledger/queue/EventMessageHandlerTest.java
+++ b/src/test/java/uk/gov/pay/ledger/queue/EventMessageHandlerTest.java
@@ -18,7 +18,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static uk.gov.pay.ledger.util.fixture.QueueEventFixture.aQueueEventFixture;
+import static uk.gov.pay.ledger.util.fixture.QueuePaymentEventFixture.aQueuePaymentEventFixture;
 
 @RunWith(MockitoJUnitRunner.class)
 public class EventMessageHandlerTest {
@@ -56,7 +56,7 @@ public class EventMessageHandlerTest {
 
     @Test
     public void shouldMarkMessageAsProcessed_WhenEventIsProcessedSuccessfully() throws QueueException {
-        Event event = aQueueEventFixture()
+        Event event = aQueuePaymentEventFixture()
                 .toEntity();
         when(eventMessage.getEvent()).thenReturn(event);
         when(createEventResponse.isSuccessful()).thenReturn(true);

--- a/src/test/java/uk/gov/pay/ledger/queue/QueueMessageReceiverIT.java
+++ b/src/test/java/uk/gov/pay/ledger/queue/QueueMessageReceiverIT.java
@@ -12,7 +12,7 @@ import static io.dropwizard.testing.ConfigOverride.config;
 import static io.restassured.RestAssured.given;
 import static io.restassured.http.ContentType.JSON;
 import static org.hamcrest.CoreMatchers.is;
-import static uk.gov.pay.ledger.util.fixture.QueueEventFixture.aQueueEventFixture;
+import static uk.gov.pay.ledger.util.fixture.QueuePaymentEventFixture.aQueuePaymentEventFixture;
 
 public class QueueMessageReceiverIT {
 
@@ -24,14 +24,14 @@ public class QueueMessageReceiverIT {
     @Test
     public void shouldHandleOutOfOrderEvents() throws InterruptedException {
         final String resourceExternalId = "rexid";
-        aQueueEventFixture()
+        aQueuePaymentEventFixture()
                 .withResourceExternalId(resourceExternalId)
                 .withEventDate(CREATED_AT)
                 .withEventType("AUTHORISATION_SUCCESSFUL")
                 .insert(rule.getSqsClient());
 
         // A created event with an earlier timestamp, sent later
-        aQueueEventFixture()
+        aQueuePaymentEventFixture()
                 .withResourceExternalId(resourceExternalId)
                 .withEventDate(CREATED_AT.minusMinutes(1))
                 .withEventType(SalientEventType.PAYMENT_CREATED.name())
@@ -53,14 +53,14 @@ public class QueueMessageReceiverIT {
     public void shouldContinueToHandleMessagesFromQueueForDownstreamExceptions() throws InterruptedException {
         final String resourceExternalId = "rexid";
         final String resourceExternalId2 = "rexid2";
-        aQueueEventFixture()
+        aQueuePaymentEventFixture()
                 .withResourceType(ResourceType.SERVICE) // throws PSQL exception. change to UNKNOWN when 'service' events are allowed
                 .withResourceExternalId(resourceExternalId)
                 .withEventDate(CREATED_AT)
                 .withEventType("AUTHORISATION_SUCCESSFUL")
                 .insert(rule.getSqsClient());
 
-        aQueueEventFixture()
+        aQueuePaymentEventFixture()
                 .withResourceExternalId(resourceExternalId2)
                 .withResourceType(ResourceType.PAYMENT)
                 .withEventDate(CREATED_AT.minusMinutes(1))
@@ -89,14 +89,14 @@ public class QueueMessageReceiverIT {
     public void shouldHandleRefundEvent() throws InterruptedException {
         final String resourceExternalId = "rexid";
         final String parentResourceExternalId = "parentRexId";
-        aQueueEventFixture()
+        aQueuePaymentEventFixture()
                 .withResourceExternalId(parentResourceExternalId)
                 .withEventDate(CREATED_AT)
                 .withEventType("AUTHORISATION_SUCCESSFUL")
                 .insert(rule.getSqsClient());
 
         Thread.sleep(100);
-        aQueueEventFixture()
+        aQueuePaymentEventFixture()
                 .withResourceExternalId(resourceExternalId)
                 .withParentResourceExternalId(parentResourceExternalId)
                 .withEventDate(CREATED_AT)

--- a/src/test/java/uk/gov/pay/ledger/queue/sqs/EventQueueIT.java
+++ b/src/test/java/uk/gov/pay/ledger/queue/sqs/EventQueueIT.java
@@ -24,7 +24,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import static uk.gov.pay.ledger.util.fixture.QueueEventFixture.aQueueEventFixture;
+import static uk.gov.pay.ledger.util.fixture.QueuePaymentEventFixture.aQueuePaymentEventFixture;
 
 @Ignore
 public class EventQueueIT {
@@ -40,7 +40,7 @@ public class EventQueueIT {
 
     @Test
     public void shouldGetEventMessageDtoFromTheQueue() throws QueueException {
-        Event event = aQueueEventFixture()
+        Event event = aQueuePaymentEventFixture()
                 .insert(client)
                 .toEntity();
 
@@ -58,7 +58,7 @@ public class EventQueueIT {
 
     @Test
     public void shouldGetEventMessageFromTheQueue() throws QueueException {
-        Event event = aQueueEventFixture()
+        Event event = aQueuePaymentEventFixture()
                 .insert(client)
                 .toEntity();
 

--- a/src/test/java/uk/gov/pay/ledger/util/fixture/QueueEventFixtureUtil.java
+++ b/src/test/java/uk/gov/pay/ledger/util/fixture/QueueEventFixtureUtil.java
@@ -1,0 +1,70 @@
+package uk.gov.pay.ledger.util.fixture;
+
+import au.com.dius.pact.consumer.dsl.PactDslJsonBody;
+import com.amazonaws.services.sqs.AmazonSQS;
+import com.amazonaws.services.sqs.model.SendMessageResult;
+import com.google.gson.JsonParser;
+import com.google.gson.JsonPrimitive;
+import uk.gov.pay.ledger.event.model.ResourceType;
+import uk.gov.pay.ledger.rule.SqsTestDocker;
+
+import java.time.ZonedDateTime;
+
+public class QueueEventFixtureUtil {
+
+    public static String insert(AmazonSQS sqsClient, String eventType, ZonedDateTime eventDate, String resourceExternalId,
+                                           String parentResourceExternalId, ResourceType resourceType, String eventData) {
+        String messageBody = String.format("{" +
+                        "\"timestamp\": \"%s\"," +
+                        "\"resource_external_id\": \"%s\"," +
+                        (parentResourceExternalId == null || parentResourceExternalId.isEmpty() ? "%s" : "\"parent_resource_external_id\": \"%s\",") +
+                        "\"event_type\":\"%s\"," +
+                        "\"resource_type\": \"%s\"," +
+                        "\"event_details\": %s" +
+                        "}",
+                eventDate.toString(),
+                resourceExternalId,
+                parentResourceExternalId == null ? "" : parentResourceExternalId,
+                eventType,
+                resourceType.toString().toLowerCase(),
+                eventData
+        );
+
+        SendMessageResult result = sqsClient.sendMessage(SqsTestDocker.getQueueUrl("event-queue"), messageBody);
+        return result.getMessageId();
+    }
+
+    public static PactDslJsonBody getAsPact(String eventType, ZonedDateTime eventDate, String resourceExternalId,
+                                     String parentResourceExternalId, ResourceType resourceType, String eventData) {
+        PactDslJsonBody eventDetails = new PactDslJsonBody();
+
+        eventDetails.stringType("event_type", eventType);
+        eventDetails.stringType("timestamp", eventDate.toString());
+        eventDetails.stringType("resource_external_id", resourceExternalId);
+        eventDetails.stringType("resource_type", resourceType.toString().toLowerCase());
+        if (parentResourceExternalId != null && !parentResourceExternalId.isEmpty()) {
+            eventDetails.stringType("parent_resource_external_id", parentResourceExternalId);
+        }
+
+        PactDslJsonBody paymentCreatedEventDetails = new PactDslJsonBody();
+        new JsonParser().parse(eventData).getAsJsonObject().entrySet()
+                .forEach(e -> {
+                    try {
+                        JsonPrimitive value = ((JsonPrimitive) e.getValue());
+                        if (value.isNumber()) {
+                            paymentCreatedEventDetails.integerType(e.getKey(), value.getAsInt());
+                        } else if (value.isBoolean()) {
+                            paymentCreatedEventDetails.booleanType(e.getKey(), value.getAsBoolean());
+                        } else {
+                            paymentCreatedEventDetails.stringType(e.getKey(), value.getAsString());
+                        }
+                    } catch (Exception ex) {
+                        paymentCreatedEventDetails.stringType(e.getKey(), e.getValue().getAsString());
+                    }
+                });
+
+        eventDetails.object("event_details", paymentCreatedEventDetails);
+
+        return eventDetails;
+    }
+}

--- a/src/test/java/uk/gov/pay/ledger/util/fixture/QueueRefundEventFixture.java
+++ b/src/test/java/uk/gov/pay/ledger/util/fixture/QueueRefundEventFixture.java
@@ -1,0 +1,160 @@
+package uk.gov.pay.ledger.util.fixture;
+
+import au.com.dius.pact.consumer.dsl.PactDslJsonBody;
+import com.amazonaws.services.sqs.AmazonSQS;
+import com.google.common.collect.ImmutableMap;
+import com.google.gson.GsonBuilder;
+import org.apache.commons.lang3.RandomStringUtils;
+import uk.gov.pay.ledger.event.model.Event;
+import uk.gov.pay.ledger.event.model.ResourceType;
+
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+
+public class QueueRefundEventFixture implements QueueFixture<QueueRefundEventFixture, Event> {
+    private String sqsMessageId;
+    private ResourceType resourceType = ResourceType.REFUND;
+    private Long amount = 50L;
+    private String resourceExternalId = RandomStringUtils.randomAlphanumeric(20);
+    private String parentResourceExternalId = RandomStringUtils.randomAlphanumeric(20);
+    private ZonedDateTime eventDate = ZonedDateTime.now(ZoneOffset.UTC);
+    private String eventType = "REFUND_CREATED_BY_USER";
+    private String eventData = "{\"event_data\": \"event data\"}";
+    private String refundedBy = RandomStringUtils.randomAlphanumeric(20);
+    private String reference = null;
+
+    private QueueRefundEventFixture() {
+    }
+
+    public static QueueRefundEventFixture aQueueRefundEventFixture() {
+        return new QueueRefundEventFixture();
+    }
+
+    public QueueRefundEventFixture withAmount(Long amount) {
+        this.amount = amount;
+        return this;
+    }
+
+    public QueueRefundEventFixture withResourceExternalId(String resourceExternalId) {
+        this.resourceExternalId = resourceExternalId;
+        return this;
+    }
+
+    public QueueRefundEventFixture withParentResourceExternalId(String parentResourceExternalId) {
+        this.parentResourceExternalId = parentResourceExternalId;
+        return this;
+    }
+
+    public QueueRefundEventFixture withEventDate(ZonedDateTime eventDate) {
+        this.eventDate = eventDate;
+        return this;
+    }
+
+    public QueueRefundEventFixture withEventType(String eventType) {
+        this.eventType = eventType;
+        return this;
+    }
+
+    public QueueRefundEventFixture withRefundedBy(String refundedBy) {
+        this.refundedBy = refundedBy;
+        return this;
+    }
+
+    public QueueRefundEventFixture withReference(String reference) {
+        this.reference = reference;
+        return this;
+    }
+
+    public QueueRefundEventFixture withDefaultEventDataForEventType(String eventType) {
+        switch (eventType) {
+            case "REFUND_CREATED_BY_SERVICE":
+                eventData = new GsonBuilder().create()
+                        .toJson(ImmutableMap.builder()
+                                .put("amount", amount)
+                                .build());
+                break;
+            case "REFUND_CREATED_BY_USER":
+                eventData = new GsonBuilder().create()
+                        .toJson(ImmutableMap.builder()
+                                .put("amount", amount)
+                                .put("refunded_by", refundedBy)
+                                .build());
+                break;
+            case "REFUND_SUBMITTED":
+                eventData = "{}";
+                break;
+            case "REFUND_SUCCEEDED" :
+                eventData = new GsonBuilder().create()
+                        .toJson(ImmutableMap.builder()
+                                .put("reference", reference)
+                                .build());
+                break;
+            default:
+                eventData = new GsonBuilder().create()
+                        .toJson(ImmutableMap.of("event_data", "event_data"));
+        }
+        return this;
+    }
+
+    @Override
+    public Event toEntity() {
+        return new Event(0L, sqsMessageId, resourceType, resourceExternalId, parentResourceExternalId, eventDate, eventType, eventData);
+    }
+
+    public String getSqsMessageId() {
+        return sqsMessageId;
+    }
+
+    public ResourceType getResourceType() {
+        return resourceType;
+    }
+
+    public String getResourceExternalId() {
+        return resourceExternalId;
+    }
+
+    public ZonedDateTime getEventDate() {
+        return eventDate;
+    }
+
+    public String getEventType() {
+        return eventType;
+    }
+
+    public String getEventData() {
+        return eventData;
+    }
+
+    public String getRefundedBy() {
+        return refundedBy;
+    }
+
+    public String getReference() {
+        return reference;
+    }
+
+    @Override
+    public QueueRefundEventFixture insert(AmazonSQS sqsClient) {
+        this.sqsMessageId = QueueEventFixtureUtil.insert(sqsClient, eventType, eventDate, resourceExternalId,
+                parentResourceExternalId, resourceType, eventData);
+        return this;
+    }
+
+    public PactDslJsonBody getAsPact() {
+        return QueueEventFixtureUtil.getAsPact(eventType, eventDate, resourceExternalId,
+                parentResourceExternalId, resourceType, eventData);
+    }
+
+    public QueueRefundEventFixture withResourceType(ResourceType resourceType) {
+        this.resourceType = resourceType;
+        return this;
+    }
+
+    public String getParentResourceExternalId() {
+        return parentResourceExternalId;
+    }
+
+    public Long getAmount() {
+        return amount;
+    }
+}


### PR DESCRIPTION
## WHAT

- add refund created by user, refund submitted and refund succeeded pact tests
- add granular checks under `PactVerification` that unique to the given event_details payload
- add queue event fixture
- small code clean up in `PaymentCreatedEventQueueContractTest`
- All 3 tests insert a payment transaction into the db. Although it is not strictly necessary to run the tests, it makes them run cleaner. Without the payment transaction the code throws an
exception down the line (`insert or update on table transaction violates foreign key constraint transaction_parent_transaction_id_fkey`)