### PR TITLE
PP-5454 Add DAO class for transaction events

### DIFF
--- a/src/main/java/uk/gov/pay/ledger/transactionevent/dao/TransactionEventDao.java
+++ b/src/main/java/uk/gov/pay/ledger/transactionevent/dao/TransactionEventDao.java
@@ -1,0 +1,42 @@
+package uk.gov.pay.ledger.transactionevent.dao;
+
+import com.google.inject.Inject;
+import org.jdbi.v3.core.Jdbi;
+import org.jdbi.v3.core.statement.Query;
+import org.jdbi.v3.sqlobject.customizer.Bind;
+import uk.gov.pay.ledger.transactionevent.dao.mapper.TransactionEventEntityMapper;
+import uk.gov.pay.ledger.transactionevent.model.TransactionEventEntity;
+
+import java.util.List;
+
+public class TransactionEventDao {
+
+    private static final String TRANSACTION_EVENTS_QUERY = "SELECT t.external_id, t.type, t.amount," +
+            "       event_date, event_type, event_data" +
+            "  FROM transaction t, event e " +
+            " WHERE (t.external_id = :externalId" +
+            "         or t.parent_external_id = :externalId )" +
+            "  AND t.external_id = e.resource_external_id" +
+            "  AND t.gateway_account_id = :gatewayAccountId" +
+            " ORDER BY e.event_date asc";
+
+    private final Jdbi jdbi;
+
+    @Inject
+    public TransactionEventDao(Jdbi jdbi) {
+        this.jdbi = jdbi;
+    }
+
+    List<TransactionEventEntity> getTransactionEventsByExternalIdAndGatewayAccountId(@Bind("externalId") String externalId,
+                                                                                     @Bind("gatewayAccountId") String gatewayAccountId) {
+        return jdbi.withHandle(handle -> {
+            Query query = handle.createQuery(TRANSACTION_EVENTS_QUERY)
+                    .bind("externalId", externalId)
+                    .bind("gatewayAccountId", gatewayAccountId);
+
+            return query
+                    .map(new TransactionEventEntityMapper())
+                    .list();
+        });
+    }
+}

--- a/src/main/java/uk/gov/pay/ledger/transactionevent/dao/mapper/TransactionEventEntityMapper.java
+++ b/src/main/java/uk/gov/pay/ledger/transactionevent/dao/mapper/TransactionEventEntityMapper.java
@@ -1,0 +1,31 @@
+package uk.gov.pay.ledger.transactionevent.dao.mapper;
+
+import org.jdbi.v3.core.mapper.RowMapper;
+import org.jdbi.v3.core.statement.StatementContext;
+import uk.gov.pay.ledger.transactionevent.model.TransactionEventEntity;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+
+public class TransactionEventEntityMapper implements RowMapper<TransactionEventEntity> {
+
+    @Override
+    public TransactionEventEntity map(ResultSet rs, StatementContext ctx) throws SQLException {
+        return new TransactionEventEntity.Builder()
+                .withExternalId(rs.getString("external_id"))
+                .withAmount(rs.getLong("amount"))
+                .withEventType(rs.getString("event_type"))
+                .withEventData(rs.getString("event_data"))
+                .withEventDate(getZonedDateTime(rs, "event_date"))
+                .withTransactionType(rs.getString("type"))
+                .build();
+    }
+
+    private ZonedDateTime getZonedDateTime(ResultSet rs, String columnLabel) throws SQLException {
+        Timestamp timestamp = rs.getTimestamp(columnLabel);
+        return ZonedDateTime.ofInstant(timestamp.toInstant(), ZoneOffset.UTC);
+    }
+}

--- a/src/main/java/uk/gov/pay/ledger/transactionevent/model/TransactionEventEntity.java
+++ b/src/main/java/uk/gov/pay/ledger/transactionevent/model/TransactionEventEntity.java
@@ -1,0 +1,119 @@
+package uk.gov.pay.ledger.transactionevent.model;
+
+import java.time.ZonedDateTime;
+
+public class TransactionEventEntity {
+
+    private String externalId;
+    private String transactionType;
+    private Long amount;
+    private ZonedDateTime eventDate;
+    private String eventType;
+    private String eventData;
+
+    public TransactionEventEntity() {
+    }
+
+    public TransactionEventEntity(TransactionEventEntity.Builder builder) {
+        this.externalId = builder.externalId;
+        this.amount = builder.amount;
+        this.transactionType = builder.transactionType;
+        this.eventDate = builder.eventDate;
+        this.eventData = builder.eventData;
+        this.eventType = builder.eventType;
+    }
+
+    public String getExternalId() {
+        return externalId;
+    }
+
+    public String getTransactionType() {
+        return transactionType;
+    }
+
+    public Long getAmount() {
+        return amount;
+    }
+
+    public ZonedDateTime getEventDate() {
+        return eventDate;
+    }
+
+    public String getEventType() {
+        return eventType;
+    }
+
+    public String getEventData() {
+        return eventData;
+    }
+
+    public void setExternalId(String externalId) {
+        this.externalId = externalId;
+    }
+
+    public void setTransactionType(String transactionType) {
+        this.transactionType = transactionType;
+    }
+
+    public void setAmount(Long amount) {
+        this.amount = amount;
+    }
+
+    public void setEventDate(ZonedDateTime eventDate) {
+        this.eventDate = eventDate;
+    }
+
+    public void setEventType(String eventType) {
+        this.eventType = eventType;
+    }
+
+    public void setEventData(String eventData) {
+        this.eventData = eventData;
+    }
+
+    public static class Builder {
+        private String externalId;
+        private String transactionType;
+        private Long amount;
+        private ZonedDateTime eventDate;
+        private String eventType;
+        private String eventData;
+
+        public Builder() {
+        }
+
+        public TransactionEventEntity build() {
+            return new TransactionEventEntity(this);
+        }
+
+        public TransactionEventEntity.Builder withExternalId(String externalId) {
+            this.externalId = externalId;
+            return this;
+        }
+
+        public TransactionEventEntity.Builder withAmount(Long amount) {
+            this.amount = amount;
+            return this;
+        }
+
+        public TransactionEventEntity.Builder withTransactionType(String transactionType) {
+            this.transactionType = transactionType;
+            return this;
+        }
+
+        public TransactionEventEntity.Builder withEventType(String eventType) {
+            this.eventType = eventType;
+            return this;
+        }
+
+        public TransactionEventEntity.Builder withEventData(String eventData) {
+            this.eventData = eventData;
+            return this;
+        }
+
+        public TransactionEventEntity.Builder withEventDate(ZonedDateTime eventDate) {
+            this.eventDate = eventDate;
+            return this;
+        }
+    }
+}

--- a/src/test/java/uk/gov/pay/ledger/transactionevent/dao/TransactionEventDaoIT.java
+++ b/src/test/java/uk/gov/pay/ledger/transactionevent/dao/TransactionEventDaoIT.java
@@ -1,0 +1,124 @@
+package uk.gov.pay.ledger.transactionevent.dao;
+
+import org.junit.ClassRule;
+import org.junit.Test;
+import uk.gov.pay.ledger.rule.AppWithPostgresAndSqsRule;
+import uk.gov.pay.ledger.transactionevent.model.TransactionEventEntity;
+import uk.gov.pay.ledger.util.fixture.EventFixture;
+import uk.gov.pay.ledger.util.fixture.TransactionFixture;
+
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static uk.gov.pay.ledger.util.fixture.TransactionFixture.aTransactionFixture;
+
+public class TransactionEventDaoIT {
+
+    @ClassRule
+    public static AppWithPostgresAndSqsRule rule = new AppWithPostgresAndSqsRule();
+
+    private TransactionEventDao transactionEventDao = new TransactionEventDao(rule.getJdbi());
+
+    @Test
+    public void shouldCorrectlyMapDBColumnsToTransactionEventEntity() {
+        EventFixture eventFixture = EventFixture.anEventFixture()
+                .insert(rule.getJdbi());
+
+        TransactionFixture transactionFixture = aTransactionFixture()
+                .withExternalId(eventFixture.getResourceExternalId())
+                .withAmount(100L)
+                .withTransactionType("PAYMENT")
+                .insert(rule.getJdbi());
+
+        TransactionEventEntity transactionEventEntity =
+                transactionEventDao.getTransactionEventsByExternalIdAndGatewayAccountId(
+                        transactionFixture.getExternalId(), transactionFixture.getGatewayAccountId()).get(0);
+
+        assertThat(transactionEventEntity.getAmount(), is(100L));
+        assertThat(transactionEventEntity.getExternalId(), is(transactionFixture.getExternalId()));
+        assertThat(transactionEventEntity.getTransactionType(), is(transactionFixture.getTransactionType()));
+        assertThat(transactionEventEntity.getEventData(), is(eventFixture.getEventData()));
+        assertThat(transactionEventEntity.getEventDate(), is(eventFixture.getEventDate()));
+        assertThat(transactionEventEntity.getEventType(), is(eventFixture.getEventType()));
+    }
+
+    @Test
+    public void shouldFilterEventsByExternalIdAndGatewayAccountId() {
+        EventFixture eventFixture1 = EventFixture.anEventFixture()
+                .withResourceExternalId("external-id-1")
+                .withEventType("CAPTURE_APPROVED")
+                .withEventData("{\"fee\": 10}")
+                .insert(rule.getJdbi());
+        TransactionFixture transactionFixture1 = aTransactionFixture()
+                .withExternalId(eventFixture1.getResourceExternalId())
+                .withAmount(100L)
+                .withTransactionType("PAYMENT")
+                .insert(rule.getJdbi());
+
+        EventFixture eventFixture2 = EventFixture.anEventFixture()
+                .withResourceExternalId("external-id-2")
+                .withEventType("PAYMENT_CREATED")
+                .insert(rule.getJdbi());
+        aTransactionFixture()
+                .withExternalId(eventFixture2.getResourceExternalId())
+                .withTransactionType("REFUND")
+                .insert(rule.getJdbi());
+
+        TransactionEventEntity transactionEventEntity =
+                transactionEventDao.getTransactionEventsByExternalIdAndGatewayAccountId(
+                        transactionFixture1.getExternalId(), transactionFixture1.getGatewayAccountId()).get(0);
+
+        assertThat(transactionEventEntity.getAmount(), is(100L));
+        assertThat(transactionEventEntity.getExternalId(), is("external-id-1"));
+        assertThat(transactionEventEntity.getTransactionType(), is("PAYMENT"));
+        assertThat(transactionEventEntity.getEventData(), is("{\"fee\": 10}"));
+        assertThat(transactionEventEntity.getEventDate(), is(eventFixture1.getEventDate()));
+        assertThat(transactionEventEntity.getEventType(), is("CAPTURE_APPROVED"));
+    }
+
+    @Test
+    public void shouldFilterEventsByParentExternalId() {
+        EventFixture eventFixtureParent = EventFixture.anEventFixture()
+                .withResourceExternalId("parent-external-id")
+                .withEventType("PAYMENT_CREATED")
+                .insert(rule.getJdbi());
+
+        TransactionFixture transactionFixtureParent = aTransactionFixture()
+                .withExternalId(eventFixtureParent.getResourceExternalId())
+                .withTransactionType("PAYMENT")
+                .insert(rule.getJdbi());
+
+        EventFixture eventFixtureChild = EventFixture.anEventFixture()
+                .withResourceExternalId("related-external-id")
+                .withEventType("REFUND_CREATED")
+                .withEventDate(eventFixtureParent.getEventDate().plusDays(1)) // to preserve ordering of DB results
+                .insert(rule.getJdbi());
+        TransactionFixture transactionFixtureChild = aTransactionFixture()
+                .withExternalId(eventFixtureChild.getResourceExternalId())
+                .withGatewayAccountId(transactionFixtureParent.getGatewayAccountId())
+                .withParentExternalId(transactionFixtureParent.getExternalId())
+                .withTransactionType("REFUND")
+                .insert(rule.getJdbi());
+
+        List<TransactionEventEntity> transactionEventEntityList =
+                transactionEventDao.getTransactionEventsByExternalIdAndGatewayAccountId(
+                        eventFixtureParent.getResourceExternalId(), transactionFixtureChild.getGatewayAccountId());
+
+        assertThat(transactionEventEntityList.size(), is(2));
+
+        assertThat(transactionEventEntityList.get(0).getAmount(), is(transactionFixtureParent.getAmount()));
+        assertThat(transactionEventEntityList.get(0).getExternalId(), is(transactionFixtureParent.getExternalId()));
+        assertThat(transactionEventEntityList.get(0).getTransactionType(), is(transactionFixtureParent.getTransactionType()));
+        assertThat(transactionEventEntityList.get(0).getEventData(), is(eventFixtureParent.getEventData()));
+        assertThat(transactionEventEntityList.get(0).getEventDate(), is(eventFixtureParent.getEventDate()));
+        assertThat(transactionEventEntityList.get(0).getEventType(), is(eventFixtureParent.getEventType()));
+
+        assertThat(transactionEventEntityList.get(1).getAmount(), is(transactionFixtureChild.getAmount()));
+        assertThat(transactionEventEntityList.get(1).getExternalId(), is(transactionFixtureChild.getExternalId()));
+        assertThat(transactionEventEntityList.get(1).getTransactionType(), is(transactionFixtureChild.getTransactionType()));
+        assertThat(transactionEventEntityList.get(1).getEventData(), is(eventFixtureChild.getEventData()));
+        assertThat(transactionEventEntityList.get(1).getEventDate(), is(eventFixtureChild.getEventDate()));
+        assertThat(transactionEventEntityList.get(1).getEventType(), is(eventFixtureChild.getEventType()));
+    }
+}

--- a/src/test/java/uk/gov/pay/ledger/util/fixture/TransactionFixture.java
+++ b/src/test/java/uk/gov/pay/ledger/util/fixture/TransactionFixture.java
@@ -54,6 +54,7 @@ public class TransactionFixture implements DbFixture<TransactionFixture, Transac
     private Long refundAmountSubmitted = 0L;
     private Long refundAmountAvailable = 100L;
     private String transactionType;
+    private String parentExternalId ;
 
 
     private TransactionFixture() {
@@ -121,6 +122,10 @@ public class TransactionFixture implements DbFixture<TransactionFixture, Transac
         this.externalId = externalId;
         return this;
     }
+    public TransactionFixture withParentExternalId(String parentExternalId) {
+        this.parentExternalId = parentExternalId;
+        return this;
+    }
 
     public TransactionFixture withAmount(Long amount) {
         this.amount = amount;
@@ -178,6 +183,10 @@ public class TransactionFixture implements DbFixture<TransactionFixture, Transac
     public TransactionFixture withTransactionDetails(String transactionDetails) {
         this.transactionDetails = transactionDetails;
         return this;
+    }
+
+    public String getTransactionType() {
+        return transactionType;
     }
 
     public Integer getEventCount() {
@@ -255,6 +264,7 @@ public class TransactionFixture implements DbFixture<TransactionFixture, Transac
                                 "    transaction(\n" +
                                 "        id,\n" +
                                 "        external_id,\n" +
+                                "        parent_external_id,\n" +
                                 "        gateway_account_id,\n" +
                                 "        amount,\n" +
                                 "        description,\n" +
@@ -279,9 +289,10 @@ public class TransactionFixture implements DbFixture<TransactionFixture, Transac
                                 "        settled_time,\n" +
                                 "        type\n" +
                                 "    )\n" +
-                                "VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, CAST(? as jsonb), ?, CAST(? as jsonb), ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?::transaction_type)\n",
+                                "VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, CAST(? as jsonb), ?, CAST(? as jsonb), ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?::transaction_type)\n",
                         id,
                         externalId,
+                        parentExternalId,
                         gatewayAccountId,
                         amount,
                         description,
@@ -340,6 +351,7 @@ public class TransactionFixture implements DbFixture<TransactionFixture, Transac
                 .withId(id)
                 .withGatewayAccountId(gatewayAccountId)
                 .withExternalId(externalId)
+                .withParentExternalId(parentExternalId)
                 .withAmount(amount)
                 .withReference(reference)
                 .withDescription(description)


### PR DESCRIPTION
## WHAT 

- Adds DAO class `TransactionEventDao` and method to query events by external_id & gateway_account_id
- Uses both Transaction and Event tables as `gateway_account_id` & `amount` (should be available for each event) are available in Transaction and the rest of information in Event.
- Filters events by `parent_external_id` to find refunds and related events (avoids self joining transaction table)
- Relevant integration tests