### PR TITLE
BAU: clean up TransactionView

### DIFF
--- a/src/main/java/uk/gov/pay/ledger/transaction/search/model/RefundSummary.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/search/model/RefundSummary.java
@@ -17,7 +17,8 @@ public class RefundSummary {
 
     private Long amountSubmitted;
 
-    public RefundSummary() {}
+    public RefundSummary() {
+    }
 
     public RefundSummary(String status, Long amountAvailable, Long amountSubmitted) {
         this.status = status;
@@ -26,6 +27,12 @@ public class RefundSummary {
     }
 
     public static RefundSummary from(TransactionEntity entity) {
+        if (entity.getRefundStatus() == null &&
+                entity.getRefundAmountAvailable() == null &&
+                entity.getRefundAmountSubmitted() == null) {
+            return null;
+        }
+
         return new RefundSummary(entity.getRefundStatus(), entity.getRefundAmountAvailable(), entity.getRefundAmountSubmitted());
     }
 

--- a/src/main/java/uk/gov/pay/ledger/transaction/search/model/TransactionView.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/search/model/TransactionView.java
@@ -124,6 +124,11 @@ public class TransactionView {
         return language;
     }
 
+    @JsonProperty("transaction_id")
+    public String getTransactionId() {
+        return externalId;
+    }
+
     @JsonProperty("charge_id")
     public String getExternalId() {
         return externalId;


### PR DESCRIPTION
* added getter for "transaction_id" to deprecate "charge_id" which is overly specific and doesn't apply to refunds (at least not in the same context)
  * will create follow-up PR to remove it when the changes in public api are implemented
* made RefundSummary nullable when there are no values for it