### PR TITLE
PP-5454 DAO methods for transaction events

### DIFF
--- a/src/main/java/uk/gov/pay/ledger/event/dao/EventDao.java
+++ b/src/main/java/uk/gov/pay/ledger/event/dao/EventDao.java
@@ -4,6 +4,7 @@ import org.jdbi.v3.sqlobject.CreateSqlObject;
 import org.jdbi.v3.sqlobject.config.RegisterRowMapper;
 import org.jdbi.v3.sqlobject.customizer.Bind;
 import org.jdbi.v3.sqlobject.customizer.BindBean;
+import org.jdbi.v3.sqlobject.customizer.BindList;
 import org.jdbi.v3.sqlobject.statement.GetGeneratedKeys;
 import org.jdbi.v3.sqlobject.statement.SqlQuery;
 import org.jdbi.v3.sqlobject.statement.SqlUpdate;
@@ -13,6 +14,7 @@ import uk.gov.pay.ledger.event.model.Event;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 @RegisterRowMapper(EventMapper.class)
 public interface EventDao {
@@ -61,4 +63,13 @@ public interface EventDao {
             "e.event_type, e.event_data FROM event e, resource_type rt WHERE e.resource_external_id = :resourceExternalId" +
             " AND e.resource_type_id = rt.id ORDER BY e.event_date DESC")
     List<Event> getEventsByResourceExternalId(@Bind("resourceExternalId") String resourceExternalId);
+
+
+    @SqlQuery("SELECT  e.id, e.sqs_message_id, rt.name AS resource_type_name, e.resource_external_id, " +
+            "          e.parent_resource_external_id, e.event_date," +
+            "          e.event_type, e.event_data FROM event e, resource_type rt" +
+            " WHERE e.resource_external_id in (<externalIds>)" +
+            " AND e.resource_type_id = rt.id" +
+            " ORDER BY e.event_date ASC")
+    List<Event> findEventsForExternalIds(@BindList("externalIds") Set<String> externalIds);
 }

--- a/src/main/java/uk/gov/pay/ledger/transaction/dao/TransactionDao.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/dao/TransactionDao.java
@@ -11,6 +11,7 @@ import uk.gov.pay.ledger.transaction.search.common.TransactionSearchParams;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.BiConsumer;
+import java.util.stream.Collectors;
 
 public class TransactionDao {
 
@@ -20,6 +21,10 @@ public class TransactionDao {
     private static final String FIND_TRANSACTION_BY_EXTERNAL_ID_AND_GATEWAY_ACCOUNT_ID = "SELECT * FROM transaction " +
             "WHERE external_id = :externalId " +
             "and gateway_account_id = :gatewayAccountId";
+
+    private static final String FIND_TRANSACTIONS_BY_EXTERNAL_OR_PARENT_ID_AND_GATEWAY_ACCOUNT_ID = "SELECT * FROM transaction " +
+            "WHERE (external_id = :externalId or parent_external_id = :externalId) " +
+            "  AND gateway_account_id = :gatewayAccountId";
 
     private static final String SEARCH_QUERY_STRING = "SELECT * FROM transaction t " +
             "WHERE t.gateway_account_id = :account_id " +
@@ -89,6 +94,16 @@ public class TransactionDao {
                         .bind("externalId", externalId)
                         .map(new TransactionMapper())
                         .findFirst());
+    }
+
+    public List<TransactionEntity> findTransactionByExternalOrParentIdAndGatewayAccountId(String externalId, String gatewayAccountId) {
+        return jdbi.withHandle(handle ->
+                handle.createQuery(FIND_TRANSACTIONS_BY_EXTERNAL_OR_PARENT_ID_AND_GATEWAY_ACCOUNT_ID)
+                        .bind("externalId", externalId)
+                        .bind("gatewayAccountId", gatewayAccountId)
+                        .map(new TransactionMapper())
+                        .stream().collect(Collectors.toList())
+                        );
     }
 
     public List<TransactionEntity> searchTransactions(TransactionSearchParams searchParams) {

--- a/src/test/java/uk/gov/pay/ledger/util/fixture/TransactionFixture.java
+++ b/src/test/java/uk/gov/pay/ledger/util/fixture/TransactionFixture.java
@@ -54,6 +54,7 @@ public class TransactionFixture implements DbFixture<TransactionFixture, Transac
     private Long refundAmountSubmitted = 0L;
     private Long refundAmountAvailable = 100L;
     private String transactionType;
+    private String parentExternalId;
 
 
     private TransactionFixture() {
@@ -119,6 +120,11 @@ public class TransactionFixture implements DbFixture<TransactionFixture, Transac
 
     public TransactionFixture withExternalId(String externalId) {
         this.externalId = externalId;
+        return this;
+    }
+
+    public TransactionFixture withParentExternalId(String parentExternalId) {
+        this.parentExternalId = parentExternalId;
         return this;
     }
 
@@ -255,6 +261,7 @@ public class TransactionFixture implements DbFixture<TransactionFixture, Transac
                                 "    transaction(\n" +
                                 "        id,\n" +
                                 "        external_id,\n" +
+                                "        parent_external_id,\n" +
                                 "        gateway_account_id,\n" +
                                 "        amount,\n" +
                                 "        description,\n" +
@@ -279,9 +286,10 @@ public class TransactionFixture implements DbFixture<TransactionFixture, Transac
                                 "        settled_time,\n" +
                                 "        type\n" +
                                 "    )\n" +
-                                "VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, CAST(? as jsonb), ?, CAST(? as jsonb), ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?::transaction_type)\n",
+                                "VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, CAST(? as jsonb), ?, CAST(? as jsonb), ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?::transaction_type)\n",
                         id,
                         externalId,
+                        parentExternalId,
                         gatewayAccountId,
                         amount,
                         description,


### PR DESCRIPTION
## WHAT 
- Added method in TransactionDao to find transactions by external_id or parent_external_id (filters by gateway_accoun_id)
- Added method in EventDao to find events based on list of external ids
- Integration tests