### PR TITLE
PP-5454 Service method for transaction events

### DIFF
--- a/src/main/java/uk/gov/pay/ledger/transaction/model/TransactionEvent.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/model/TransactionEvent.java
@@ -1,0 +1,68 @@
+package uk.gov.pay.ledger.transaction.model;
+
+import uk.gov.pay.ledger.event.model.Event;
+import uk.gov.pay.ledger.event.model.ResourceType;
+import uk.gov.pay.ledger.event.model.SalientEventType;
+import uk.gov.pay.ledger.transaction.entity.TransactionEntity;
+import uk.gov.pay.ledger.transaction.state.TransactionState;
+
+import java.time.ZonedDateTime;
+
+public class TransactionEvent {
+
+    private final String externalId;
+    private final Long amount;
+    private final TransactionState state;
+    private final ResourceType resourceType;
+    private final String eventType;
+    private final ZonedDateTime timestamp;
+    private final String data;
+
+    public TransactionEvent(String externalId, Long amount, TransactionState state, ResourceType resourceType, String eventType, ZonedDateTime timestamp, String data) {
+        this.externalId = externalId;
+        this.amount = amount;
+        this.resourceType = resourceType;
+        this.state = state;
+        this.eventType = eventType;
+        this.timestamp = timestamp;
+        this.data = data;
+    }
+
+    public static TransactionEvent from(TransactionEntity transactionEntity, Event event) {
+        return new TransactionEvent(transactionEntity.getExternalId(),
+                transactionEntity.getAmount(),
+                SalientEventType.from(event.getEventType()).map(TransactionState::fromEventType).orElse(null),
+                event.getResourceType(),
+                event.getEventType(),
+                event.getEventDate(),
+                event.getEventData());
+    }
+
+    public String getExternalId() {
+        return externalId;
+    }
+
+    public Long getAmount() {
+        return amount;
+    }
+
+    public TransactionState getState() {
+        return state;
+    }
+
+    public ResourceType getResourceType() {
+        return resourceType;
+    }
+
+    public String getEventType() {
+        return eventType;
+    }
+
+    public ZonedDateTime getTimestamp() {
+        return timestamp;
+    }
+
+    public String getData() {
+        return data;
+    }
+}

--- a/src/main/java/uk/gov/pay/ledger/transaction/model/TransactionEvent.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/model/TransactionEvent.java
@@ -18,24 +18,25 @@ public class TransactionEvent {
     private final ZonedDateTime timestamp;
     private final String data;
 
-    public TransactionEvent(String externalId, Long amount, TransactionState state, ResourceType resourceType, String eventType, ZonedDateTime timestamp, String data) {
-        this.externalId = externalId;
-        this.amount = amount;
-        this.resourceType = resourceType;
-        this.state = state;
-        this.eventType = eventType;
-        this.timestamp = timestamp;
-        this.data = data;
+    private TransactionEvent(TransactionEventBuilder builder) {
+        this.externalId = builder.externalId;
+        this.amount = builder.amount;
+        this.resourceType = builder.resourceType;
+        this.state = builder.state;
+        this.eventType = builder.eventType;
+        this.timestamp = builder.timestamp;
+        this.data = builder.data;
     }
 
     public static TransactionEvent from(TransactionEntity transactionEntity, Event event) {
-        return new TransactionEvent(transactionEntity.getExternalId(),
-                transactionEntity.getAmount(),
-                SalientEventType.from(event.getEventType()).map(TransactionState::fromEventType).orElse(null),
-                event.getResourceType(),
-                event.getEventType(),
-                event.getEventDate(),
-                event.getEventData());
+        return TransactionEventBuilder.aTransactionEvent()
+                .withExternalId(transactionEntity.getExternalId())
+                .withAmount(transactionEntity.getAmount())
+                .withState(SalientEventType.from(event.getEventType()).map(TransactionState::fromEventType).orElse(null))
+                .withResourceType(event.getResourceType())
+                .withEventType(event.getEventType())
+                .withTimestamp(event.getEventDate())
+                .withData(event.getEventData()).build();
     }
 
     public String getExternalId() {
@@ -64,5 +65,61 @@ public class TransactionEvent {
 
     public String getData() {
         return data;
+    }
+
+    public static final class TransactionEventBuilder {
+        private String externalId;
+        private Long amount;
+        private TransactionState state;
+        private ResourceType resourceType;
+        private String eventType;
+        private ZonedDateTime timestamp;
+        private String data;
+
+        private TransactionEventBuilder() {
+        }
+
+        static TransactionEventBuilder aTransactionEvent() {
+            return new TransactionEventBuilder();
+        }
+
+        public TransactionEventBuilder withExternalId(String externalId) {
+            this.externalId = externalId;
+            return this;
+        }
+
+        public TransactionEventBuilder withAmount(Long amount) {
+            this.amount = amount;
+            return this;
+        }
+
+        public TransactionEventBuilder withState(TransactionState state) {
+            this.state = state;
+            return this;
+        }
+
+        public TransactionEventBuilder withResourceType(ResourceType resourceType) {
+            this.resourceType = resourceType;
+            return this;
+        }
+
+        public TransactionEventBuilder withEventType(String eventType) {
+            this.eventType = eventType;
+            return this;
+        }
+
+        TransactionEventBuilder withTimestamp(ZonedDateTime timestamp) {
+            this.timestamp = timestamp;
+            return this;
+        }
+
+        TransactionEventBuilder withData(String data) {
+            this.data = data;
+            return this;
+        }
+
+        public TransactionEvent build() {
+            return new TransactionEvent(this);
+        }
     }
 }

--- a/src/main/java/uk/gov/pay/ledger/transaction/model/TransactionEventResponse.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/model/TransactionEventResponse.java
@@ -1,0 +1,26 @@
+package uk.gov.pay.ledger.transaction.model;
+
+import java.util.List;
+
+public class TransactionEventResponse {
+
+    private final String transactionId;
+    private final List<TransactionEvent> events;
+
+    private TransactionEventResponse(String externalId, List<TransactionEvent> events) {
+        this.transactionId = externalId;
+        this.events = events;
+    }
+
+    public static TransactionEventResponse of(String externalId, List<TransactionEvent> events) {
+        return new TransactionEventResponse(externalId, events);
+    }
+
+    public String getTransactionId() {
+        return transactionId;
+    }
+
+    public List<TransactionEvent> getEvents() {
+        return events;
+    }
+}

--- a/src/main/java/uk/gov/pay/ledger/transaction/service/TransactionService.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/service/TransactionService.java
@@ -1,34 +1,47 @@
 package uk.gov.pay.ledger.transaction.service;
 
 import com.google.inject.Inject;
+import uk.gov.pay.ledger.event.dao.EventDao;
+import uk.gov.pay.ledger.event.model.Event;
 import uk.gov.pay.ledger.event.model.EventDigest;
 import uk.gov.pay.ledger.event.model.TransactionEntityFactory;
 import uk.gov.pay.ledger.transaction.dao.TransactionDao;
 import uk.gov.pay.ledger.transaction.entity.TransactionEntity;
-import uk.gov.pay.ledger.transaction.search.model.Link;
 import uk.gov.pay.ledger.transaction.model.Payment;
 import uk.gov.pay.ledger.transaction.model.PaymentFactory;
+import uk.gov.pay.ledger.transaction.model.TransactionEvent;
+import uk.gov.pay.ledger.transaction.model.TransactionEventResponse;
 import uk.gov.pay.ledger.transaction.model.TransactionSearchResponse;
 import uk.gov.pay.ledger.transaction.search.common.HalLinkBuilder;
 import uk.gov.pay.ledger.transaction.search.common.TransactionSearchParams;
+import uk.gov.pay.ledger.transaction.search.model.Link;
 import uk.gov.pay.ledger.transaction.search.model.PaginationBuilder;
 import uk.gov.pay.ledger.transaction.search.model.TransactionView;
 
+import javax.ws.rs.BadRequestException;
 import javax.ws.rs.core.UriInfo;
+import java.util.Collection;
+import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
+
+import static java.lang.String.format;
+import static java.util.stream.Collectors.groupingBy;
 
 public class TransactionService {
 
     private final TransactionDao transactionDao;
+    private final EventDao eventDao;
     private TransactionEntityFactory transactionEntityFactory;
     private PaymentFactory paymentFactory;
 
     @Inject
-    public TransactionService(TransactionDao transactionDao, TransactionEntityFactory transactionEntityFactory,
+    public TransactionService(TransactionDao transactionDao, EventDao eventDao, TransactionEntityFactory transactionEntityFactory,
                               PaymentFactory paymentFactory) {
         this.transactionDao = transactionDao;
+        this.eventDao = eventDao;
         this.transactionEntityFactory = transactionEntityFactory;
         this.paymentFactory = paymentFactory;
     }
@@ -39,8 +52,8 @@ public class TransactionService {
     }
 
     public Optional<TransactionView> getTransaction(String transactionExternalId, UriInfo uriInfo) {
-            return transactionDao.findTransactionByExternalId(transactionExternalId)
-                    .map(entity -> decorateWithLinks(TransactionView.from(paymentFactory.createTransactionEntity(entity)), uriInfo));
+        return transactionDao.findTransactionByExternalId(transactionExternalId)
+                .map(entity -> decorateWithLinks(TransactionView.from(paymentFactory.createTransactionEntity(entity)), uriInfo));
     }
 
     public TransactionSearchResponse searchTransactions(TransactionSearchParams searchParams, UriInfo uriInfo) {
@@ -87,5 +100,51 @@ public class TransactionService {
     public void upsertTransactionFor(EventDigest eventDigest) {
         TransactionEntity transaction = transactionEntityFactory.create(eventDigest);
         transactionDao.upsert(transaction);
+    }
+
+    public TransactionEventResponse findTransactionEvents(String externalId, String gatewayAccountId) {
+        Map<String, TransactionEntity> transactionEntityMap = getTransactionsAsMap(externalId, gatewayAccountId);
+
+        if (transactionEntityMap.isEmpty()) {
+            throw new BadRequestException(format("Transaction with id [%s] not found", externalId));
+        }
+
+        List<TransactionEvent> transactionEvents = getTransactionEventsFor(transactionEntityMap);
+
+        return TransactionEventResponse.of(externalId, removeDuplicates(transactionEvents));
+    }
+
+    private Map<String, TransactionEntity> getTransactionsAsMap(String externalId, String gatewayAccountId) {
+        return transactionDao.findTransactionByExternalOrParentIdAndGatewayAccountId(
+                externalId, gatewayAccountId)
+                .stream()
+                .collect(Collectors.toMap(TransactionEntity::getExternalId,
+                        transactionEntity -> transactionEntity));
+    }
+
+    private List<TransactionEvent> getTransactionEventsFor(Map<String, TransactionEntity> transactionEntityMap) {
+        List<Event> events = eventDao.findEventsForExternalIds(transactionEntityMap.keySet());
+        return mapToTransactionEvent(transactionEntityMap, events);
+    }
+
+    private List<TransactionEvent> removeDuplicates(List<TransactionEvent> transactionEvents) {
+        // removes 1. events without mapping to transaction state
+        // 2. duplicate events based on external_id,resource_type & state (gets the first created event based on event date)
+        Collection<Optional<TransactionEvent>> values = transactionEvents.stream()
+                .filter(transactionEvent -> transactionEvent.getState() != null)
+                .collect(groupingBy(transactionEvent -> transactionEvent.getExternalId() + transactionEvent.getResourceType() + transactionEvent.getState(),
+                        Collectors.minBy(Comparator.comparing(TransactionEvent::getTimestamp))))
+                .values();
+
+        return values.stream().filter(Optional::isPresent)
+                .map(Optional::get)
+                .sorted(Comparator.comparing(TransactionEvent::getTimestamp))
+                .collect(Collectors.toList());
+    }
+
+    private List<TransactionEvent> mapToTransactionEvent(Map<String, TransactionEntity> transactionEntityMap, List<Event> eventList) {
+        return eventList.stream()
+                .map(event -> TransactionEvent.from(transactionEntityMap.get(event.getResourceExternalId()), event))
+                .collect(Collectors.toList());
     }
 }

--- a/src/main/java/uk/gov/pay/ledger/transaction/service/TransactionService.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/service/TransactionService.java
@@ -127,6 +127,12 @@ public class TransactionService {
         return mapToTransactionEvent(transactionEntityMap, events);
     }
 
+    private List<TransactionEvent> mapToTransactionEvent(Map<String, TransactionEntity> transactionEntityMap, List<Event> eventList) {
+        return eventList.stream()
+                .map(event -> TransactionEvent.from(transactionEntityMap.get(event.getResourceExternalId()), event))
+                .collect(Collectors.toList());
+    }
+
     private List<TransactionEvent> removeDuplicates(List<TransactionEvent> transactionEvents) {
         // removes 1. events without mapping to transaction state
         // 2. duplicate events based on external_id,resource_type & state (gets the first created event based on event date)
@@ -142,9 +148,4 @@ public class TransactionService {
                 .collect(Collectors.toList());
     }
 
-    private List<TransactionEvent> mapToTransactionEvent(Map<String, TransactionEntity> transactionEntityMap, List<Event> eventList) {
-        return eventList.stream()
-                .map(event -> TransactionEvent.from(transactionEntityMap.get(event.getResourceExternalId()), event))
-                .collect(Collectors.toList());
-    }
 }


### PR DESCRIPTION
## WHAT

- Adds service method `findTransactionEvents` to search for events by external_id and gateway_account_id
     - Maps transactions and events to TransactionEvent
     - Removes event without a state mapping
     - Gets the earliest event based on external_id, event resource type, and state
     - Sorts returns by event date ascending
- Unit tests