### PR TITLE
PP-5463 Fix refund summary persistence

### DIFF
--- a/src/main/java/uk/gov/pay/ledger/event/dao/EventDao.java
+++ b/src/main/java/uk/gov/pay/ledger/event/dao/EventDao.java
@@ -42,6 +42,7 @@ public interface EventDao {
             "    FROM event " +
             "    WHERE resource_type_id = :resourceTypeId AND " +
             "          resource_external_id = :resourceExternalId AND  " +
+            "          event_date = :eventDate AND   " +
             "          event_type = :eventType) ")
     @GetGeneratedKeys
     Optional<Long> insertIfDoesNotExist(@BindBean Event event, @Bind("resourceTypeId") int resourceTypeId);

--- a/src/main/java/uk/gov/pay/ledger/transaction/dao/TransactionDao.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/dao/TransactionDao.java
@@ -40,14 +40,15 @@ public class TransactionDao {
             "INSERT INTO transaction(" +
                 "external_id,parent_external_id,gateway_account_id,amount,description,reference,state,email,cardholder_name," +
                 "external_metadata,created_date,transaction_details,event_count,card_brand, " +
-                "last_digits_card_number,first_digits_card_number,net_amount,total_amount,fee,type" +
+                "last_digits_card_number,first_digits_card_number,net_amount,total_amount,fee,type,refund_amount_available," +
+                    "refund_amount_submitted, refund_status" +
             ") " +
             "VALUES (" +
                 ":externalId,:parentExternalId,:gatewayAccountId,:amount,:description,:reference,:state,:email,:cardholderName," +
                 "CAST(:externalMetadata as jsonb),:createdDate,CAST(:transactionDetails as jsonb), :eventCount," +
                 ":cardBrand,:lastDigitsCardNumber,:firstDigitsCardNumber,:netAmount,:totalAmount,:fee," +
-                ":transactionType::transaction_type" +
-            ")" +
+                ":transactionType::transaction_type,:refundAmountAvailable,:refundAmountSubmitted,:refundStatus" +
+            ") " +
             "ON CONFLICT (external_id) " +
             "DO UPDATE SET " +
                 "external_id = EXCLUDED.external_id," +
@@ -69,7 +70,10 @@ public class TransactionDao {
                 "net_amount = EXCLUDED.net_amount," +
                 "total_amount = EXCLUDED.total_amount," +
                 "fee = EXCLUDED.fee," +
-                "type = EXCLUDED.type " +
+                "type = EXCLUDED.type, " +
+                "refund_amount_available = EXCLUDED.refund_amount_available, " +
+                "refund_amount_submitted = EXCLUDED.refund_amount_submitted, " +
+                "refund_status = EXCLUDED.refund_status " +
             "WHERE EXCLUDED.event_count > transaction.event_count;";
 
     private final Jdbi jdbi;

--- a/src/test/java/uk/gov/pay/ledger/transaction/dao/TransactionDaoIT.java
+++ b/src/test/java/uk/gov/pay/ledger/transaction/dao/TransactionDaoIT.java
@@ -59,6 +59,9 @@ public class TransactionDaoIT {
         assertThat(retrievedTransaction.getTotalAmount(), is(transactionEntity.getTotalAmount()));
         assertThat(retrievedTransaction.getFee(), is(transactionEntity.getFee()));
         assertThat(retrievedTransaction.getTransactionType(), is(transactionEntity.getTransactionType()));
+        assertThat(retrievedTransaction.getRefundAmountAvailable(), is(transactionEntity.getRefundAmountAvailable()));
+        assertThat(retrievedTransaction.getRefundAmountSubmitted(), is(transactionEntity.getRefundAmountSubmitted()));
+        assertThat(retrievedTransaction.getRefundStatus(), is(transactionEntity.getRefundStatus()));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/ledger/util/DatabaseTestHelper.java
+++ b/src/test/java/uk/gov/pay/ledger/util/DatabaseTestHelper.java
@@ -17,15 +17,18 @@ public class DatabaseTestHelper {
         return new DatabaseTestHelper(jdbi);
     }
 
-    public Map<String, Object> getEventByExternalId(String externalId) {
+    public List<Map<String, Object>> getEventsByExternalId(String externalId) {
         return jdbi.withHandle(handle ->
                 handle
                         .createQuery("SELECT * FROM event WHERE resource_external_id = :external_id")
                         .bind("external_id", externalId)
                         .mapToMap()
-                        .findFirst()
-                        .get()
+                        .list()
         );
+    }
+
+    public Map<String, Object> getEventByExternalId(String externalId) {
+        return getEventsByExternalId(externalId).stream().findFirst().get();
     }
 
     public void truncateAllData() {
@@ -48,7 +51,7 @@ public class DatabaseTestHelper {
     public List<Map<String, Object>> getAllTransactions() {
         return jdbi.withHandle(handle ->
                 handle.createQuery("SELECT * FROM transaction")
-                .mapToMap()
-                .list());
+                        .mapToMap()
+                        .list());
     }
 }


### PR DESCRIPTION
Persist data associated with refund summary.
Persist multiple events of same type and resource_external_id if
they have different timestamps.