### PR TITLE
PP-5491 Correct transaction state handling

### DIFF
--- a/src/main/java/uk/gov/pay/ledger/event/model/TransactionEntityFactory.java
+++ b/src/main/java/uk/gov/pay/ledger/event/model/TransactionEntityFactory.java
@@ -26,7 +26,7 @@ public class TransactionEntityFactory {
         TransactionEntity entity = objectMapper.convertValue(eventDigest.getEventPayload(), TransactionEntity.class);
         entity.setTransactionDetails(transactionDetail);
         entity.setEventCount(eventDigest.getEventCount());
-        entity.setState(TransactionState.fromEventType(eventDigest.getMostRecentSalientEventType()).getStatus());
+        entity.setState(TransactionState.fromEventType(eventDigest.getMostRecentSalientEventType()));
         entity.setCreatedDate(eventDigest.getEventCreatedDate());
         entity.setExternalId(eventDigest.getResourceExternalId());
         entity.setParentExternalId(eventDigest.getParentResourceExternalId());

--- a/src/main/java/uk/gov/pay/ledger/transaction/dao/mapper/TransactionMapper.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/dao/mapper/TransactionMapper.java
@@ -3,6 +3,7 @@ package uk.gov.pay.ledger.transaction.dao.mapper;
 import org.jdbi.v3.core.mapper.RowMapper;
 import org.jdbi.v3.core.statement.StatementContext;
 import uk.gov.pay.ledger.transaction.entity.TransactionEntity;
+import uk.gov.pay.ledger.transaction.state.TransactionState;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -23,7 +24,7 @@ public class TransactionMapper implements RowMapper<TransactionEntity> {
                 .withAmount(rs.getLong("amount"))
                 .withReference(rs.getString("reference"))
                 .withDescription(rs.getString("description"))
-                .withState(rs.getString("state"))
+                .withState(TransactionState.valueOf(rs.getString("state")))
                 .withEmail(rs.getString("email"))
                 .withCardholderName(rs.getString("cardholder_name"))
                 .withExternalMetadata(rs.getString("external_metadata"))

--- a/src/main/java/uk/gov/pay/ledger/transaction/entity/TransactionEntity.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/entity/TransactionEntity.java
@@ -2,9 +2,9 @@ package uk.gov.pay.ledger.transaction.entity;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import uk.gov.pay.ledger.transaction.state.TransactionState;
 
 import java.time.ZonedDateTime;
 
@@ -22,7 +22,7 @@ public class TransactionEntity {
     private Long amount;
     private String reference;
     private String description;
-    private String state;
+    private TransactionState state;
     private String email;
     private String cardholderName;
     private String externalMetadata;
@@ -106,7 +106,7 @@ public class TransactionEntity {
         return description;
     }
 
-    public String getState() {
+    public TransactionState getState() {
         return state;
     }
 
@@ -154,7 +154,7 @@ public class TransactionEntity {
         this.eventCount = eventCount;
     }
 
-    public void setState(String state) {
+    public void setState(TransactionState state) {
         this.state = state;
     }
 
@@ -211,7 +211,7 @@ public class TransactionEntity {
     }
 
     public static class Builder {
-        public Long fee;
+        private Long fee;
         private Long id;
         private String gatewayAccountId;
         private String externalId;
@@ -219,7 +219,7 @@ public class TransactionEntity {
         private Long amount;
         private String reference;
         private String description;
-        private String state;
+        private TransactionState state;
         private String email;
         private String cardholderName;
         private String externalMetadata;
@@ -280,7 +280,7 @@ public class TransactionEntity {
             return this;
         }
 
-        public Builder withState(String state) {
+        public Builder withState(TransactionState state) {
             this.state = state;
             return this;
         }

--- a/src/main/java/uk/gov/pay/ledger/transaction/model/TransactionFactory.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/model/TransactionFactory.java
@@ -9,7 +9,6 @@ import org.slf4j.LoggerFactory;
 import uk.gov.pay.ledger.transaction.entity.TransactionEntity;
 import uk.gov.pay.ledger.transaction.search.model.RefundSummary;
 import uk.gov.pay.ledger.transaction.search.model.SettlementSummary;
-import uk.gov.pay.ledger.transaction.state.TransactionState;
 
 import java.io.IOException;
 import java.util.Map;
@@ -17,7 +16,7 @@ import java.util.Optional;
 
 public class TransactionFactory {
 
-    private static Logger LOGGER = LoggerFactory.getLogger(TransactionFactory.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(TransactionFactory.class);
     private ObjectMapper objectMapper;
 
     @Inject
@@ -58,14 +57,30 @@ public class TransactionFactory {
             RefundSummary refundSummary = RefundSummary.from(entity);
             SettlementSummary settlementSummary = new SettlementSummary(entity.getSettlementSubmittedTime(), entity.getSettledTime());
 
-            return new Payment(entity.getGatewayAccountId(), entity.getAmount(), entity.getReference(), entity.getDescription(),
-                    TransactionState.from(entity.getState()), safeGetAsString(transactionDetails, "language"),
-                    entity.getExternalId(), safeGetAsString(transactionDetails, "return_url"), entity.getEmail(),
-                    safeGetAsString(transactionDetails, "payment_provider"), entity.getCreatedDate(),
-                    cardDetails, safeGetAsBoolean(transactionDetails, "delayed_capture", false), metadata,
-                    entity.getEventCount(), safeGetAsString(transactionDetails, "gateway_transaction_id"),
-                    safeGetAsLong(transactionDetails, "corporate_surcharge"), entity.getFee(),
-                    entity.getNetAmount(), refundSummary, entity.getTotalAmount(), settlementSummary);
+            return new Payment(
+                    entity.getGatewayAccountId(),
+                    entity.getAmount(),
+                    entity.getReference(),
+                    entity.getDescription(),
+                    entity.getState(),
+                    safeGetAsString(transactionDetails, "language"),
+                    entity.getExternalId(),
+                    safeGetAsString(transactionDetails, "return_url"),
+                    entity.getEmail(),
+                    safeGetAsString(transactionDetails, "payment_provider"),
+                    entity.getCreatedDate(),
+                    cardDetails,
+                    safeGetAsBoolean(transactionDetails, "delayed_capture", false),
+                    metadata,
+                    entity.getEventCount(),
+                    safeGetAsString(transactionDetails, "gateway_transaction_id"),
+                    safeGetAsLong(transactionDetails, "corporate_surcharge"),
+                    entity.getFee(),
+                    entity.getNetAmount(),
+                    refundSummary,
+                    entity.getTotalAmount(),
+                    settlementSummary
+            );
         } catch (IOException e) {
             LOGGER.error("Error during the parsing transaction entity data [{}] [errorMessage={}]", entity.getExternalId(), e.getMessage());
         }
@@ -82,7 +97,7 @@ public class TransactionFactory {
                     .withAmount(entity.getAmount())
                     .withReference(entity.getReference())
                     .withDescription(entity.getDescription())
-                    .withState(TransactionState.from(entity.getState()))
+                    .withState(entity.getState())
                     .withExternalId(entity.getExternalId())
                     .withCreatedDate(entity.getCreatedDate())
                     .withEventCount(entity.getEventCount())

--- a/src/main/java/uk/gov/pay/ledger/transaction/search/common/TransactionSearchParams.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/search/common/TransactionSearchParams.java
@@ -3,13 +3,16 @@ package uk.gov.pay.ledger.transaction.search.common;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.pay.ledger.transaction.model.TransactionType;
+import uk.gov.pay.ledger.transaction.state.TransactionState;
 
 import javax.ws.rs.QueryParam;
 import java.time.ZonedDateTime;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import static java.lang.String.format;
+import static java.lang.String.join;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
 public class TransactionSearchParams {
@@ -158,13 +161,13 @@ public class TransactionSearchParams {
             //TODO implement
         }
         if (isNotBlank(state)) {
-            sb.append(" AND t.state = :" + STATE_FIELD);
+            sb.append(" AND t.state IN (<" + STATE_FIELD + ">)");
         }
         if (refundStates != null) {
             //TODO implement
         }
         if (cardBrands != null && !cardBrands.isEmpty()) {
-            sb.append(" AND t.card_brand IN(<" + CARD_BRAND_FIELD + ">)");
+            sb.append(" AND t.card_brand IN (<" + CARD_BRAND_FIELD + ">)");
         }
         if (isNotBlank(lastDigitsCardNumber)) {
             sb.append(" AND t.last_digits_card_number = :" + LAST_DIGITS_CARD_NUMBER_FIELD);
@@ -202,7 +205,9 @@ public class TransactionSearchParams {
                 queryMap.put(TO_DATE_FIELD, ZonedDateTime.parse(toDate));
             }
             if (isNotBlank(state)) {
-                queryMap.put(STATE_FIELD, state);
+                queryMap.put(STATE_FIELD, TransactionState.getStatesForStatus(state).stream()
+                        .map(TransactionState::name)
+                        .collect(Collectors.toList()));
             }
             if (cardBrands != null && !cardBrands.isEmpty()) {
                 queryMap.put(CARD_BRAND_FIELD, cardBrands.getParameters());

--- a/src/main/java/uk/gov/pay/ledger/transaction/state/TransactionState.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/state/TransactionState.java
@@ -7,7 +7,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.pay.ledger.event.model.SalientEventType;
 
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import static java.util.Arrays.stream;
 
@@ -29,23 +31,23 @@ public enum TransactionState {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(TransactionState.class);
 
+    private final String oldStatus;
     private final String status;
-    private final String newStatus;
     private final boolean finished;
     private final String code;
     private final String message;
 
     TransactionState(String status, boolean finished) {
+        this.oldStatus = status;
         this.status = status;
-        this.newStatus = status;
         this.finished = finished;
         this.code = null;
         this.message = null;
     }
 
-    TransactionState(String status, String newStatus, boolean finished, String code, String message) {
+    TransactionState(String oldStatus, String status, boolean finished, String code, String message) {
+        this.oldStatus = oldStatus;
         this.status = status;
-        this.newStatus = newStatus;
         this.finished = finished;
         this.code = code;
         this.message = message;
@@ -109,10 +111,16 @@ public enum TransactionState {
     }
 
     public static TransactionState from(String transactionState) {
-        return stream(values()).filter(v -> v.getStatus().equals(transactionState)).findFirst()
+        return stream(values()).filter(v -> v.name().equals(transactionState)).findFirst()
                 .orElseGet(() -> {
                     LOGGER.warn("Unknown transaction state {}", transactionState);
                     return null;
                 });
+    }
+
+    public static List<TransactionState> getStatesForStatus(String status) {
+        return stream(values())
+                .filter(v -> v.getStatus().equals(status))
+                .collect(Collectors.toList());
     }
 }

--- a/src/test/java/uk/gov/pay/ledger/event/model/TransactionEntityFactoryTest.java
+++ b/src/test/java/uk/gov/pay/ledger/event/model/TransactionEntityFactoryTest.java
@@ -51,7 +51,7 @@ public class TransactionEntityFactoryTest {
         TransactionEntity transactionEntity = transactionEntityFactory.create(eventDigest);
 
         assertThat(transactionEntity.getExternalId(), is(eventDigest.getResourceExternalId()));
-        assertThat(transactionEntity.getState(), is("created"));
+        assertThat(transactionEntity.getState().toString(), is("CREATED"));
         assertThat(transactionEntity.getCreatedDate(), is(paymentCreatedEvent.getEventDate()));
         assertThat(transactionEntity.getEventCount(), is(eventDigest.getEventCount()));
         assertThat(transactionEntity.getReference(), is(eventDigest.getEventPayload().get("reference")));
@@ -111,7 +111,7 @@ public class TransactionEntityFactoryTest {
         assertThat(transactionEntity.getTransactionType(), is("REFUND"));
         assertThat(transactionEntity.getParentExternalId(), is(eventDigest.getParentResourceExternalId()));
         assertThat(transactionEntity.getParentExternalId(), is(parentResourceExternalId));
-        assertThat(transactionEntity.getState(), is("submitted"));
+        assertThat(transactionEntity.getState().toString(), is("SUBMITTED"));
         assertThat(transactionEntity.getAmount(), is(1000L));
 
         Map<String, String> transactionDetails = objectMapper.readValue(transactionEntity.getTransactionDetails(), Map.class);
@@ -128,6 +128,6 @@ public class TransactionEntityFactoryTest {
         EventDigest eventDigest = EventDigest.fromEventList(List.of(secondNonSalientEvent, paymentStartedEvent, nonSalientEvent, paymentCreatedEvent));
         TransactionEntity transactionEntity = transactionEntityFactory.create(eventDigest);
 
-        assertThat(transactionEntity.getState(), is("started"));
+        assertThat(transactionEntity.getState().toString(), is("STARTED"));
     }
 }

--- a/src/test/java/uk/gov/pay/ledger/transaction/dao/TransactionDaoSearchIT.java
+++ b/src/test/java/uk/gov/pay/ledger/transaction/dao/TransactionDaoSearchIT.java
@@ -62,7 +62,7 @@ public class TransactionDaoSearchIT {
         assertThat(transaction.getAmount(), is(transactionFixture.getAmount()));
         assertThat(transaction.getReference(), is(transactionFixture.getReference()));
         assertThat(transaction.getDescription(), is(transactionFixture.getDescription()));
-        assertThat(transaction.getState(), is(transactionFixture.getState().getStatus()));
+        assertThat(transaction.getState(), is(transactionFixture.getState()));
         assertThat(transaction.getEmail(), is(transactionFixture.getEmail()));
         assertThat(transaction.getCardholderName(), is(transactionFixture.getCardDetails().getCardHolderName()));
         assertThat(transaction.getCardBrand(), is(transactionFixture.getCardDetails().getCardBrand()));

--- a/src/test/java/uk/gov/pay/ledger/transaction/model/TransactionFactoryTest.java
+++ b/src/test/java/uk/gov/pay/ledger/transaction/model/TransactionFactoryTest.java
@@ -27,7 +27,7 @@ public class TransactionFactoryTest {
     private Long amount = 100L;
     private String reference = "ref_237156782465";
     private String description = "test description";
-    private String state = "created";
+    private TransactionState state = TransactionState.valueOf("CREATED");
     private String email = "test@email.com";
     private String cardholderName = "M Jan Kowalski";
     private String fullExternalMetadata = "{\"ledger_code\":123, \"some_key\":\"key\"}";
@@ -125,7 +125,7 @@ public class TransactionFactoryTest {
         assertThat(payment.getExternalId(), is(externalId));
         assertThat(payment.getReference(), is(reference));
         assertThat(payment.getDescription(), is(description));
-        assertThat(payment.getState(), is(TransactionState.from(state)));
+        assertThat(payment.getState(), is(state));
         assertThat(payment.getLanguage(), is("en"));
         assertThat(payment.getReturnUrl(), is("https://test.url.com"));
         assertThat(payment.getEmail(), is(email));
@@ -169,7 +169,7 @@ public class TransactionFactoryTest {
         assertThat(payment.getExternalId(), is(externalId));
         assertThat(payment.getReference(), is(reference));
         assertThat(payment.getDescription(), is(description));
-        assertThat(payment.getState(), is(TransactionState.from(state)));
+        assertThat(payment.getState(), is(state));
         assertThat(payment.getLanguage(), nullValue());
         assertThat(payment.getReturnUrl(), nullValue());
         assertThat(payment.getEmail(), is(email));
@@ -219,7 +219,7 @@ public class TransactionFactoryTest {
         assertThat(refundEntity.getExternalId(), is(externalId));
         assertThat(refundEntity.getRefundedBy(), is("some_user_id"));
         assertThat(refundEntity.getReference(), is(reference));
-        assertThat(refundEntity.getState(), is(TransactionState.from(state)));
+        assertThat(refundEntity.getState(), is(state));
         assertThat(refundEntity.getCreatedDate(), is(createdDate));
         assertThat(refundEntity.getEventCount(), is(eventCount));
 

--- a/src/test/java/uk/gov/pay/ledger/util/fixture/TransactionFixture.java
+++ b/src/test/java/uk/gov/pay/ledger/util/fixture/TransactionFixture.java
@@ -296,7 +296,7 @@ public class TransactionFixture implements DbFixture<TransactionFixture, Transac
                         amount,
                         description,
                         reference,
-                        state.getStatus(),
+                        state,
                         email,
                         cardholderName,
                         externalMetadata,
@@ -354,7 +354,7 @@ public class TransactionFixture implements DbFixture<TransactionFixture, Transac
                 .withAmount(amount)
                 .withReference(reference)
                 .withDescription(description)
-                .withState(state.getStatus())
+                .withState(state)
                 .withEmail(email)
                 .withCardholderName(cardholderName)
                 .withExternalMetadata(externalMetadata)


### PR DESCRIPTION
Previously we were doing the following:

### Processing an Incoming event
- Make event digest
- Calculate TransactionState from latest salient event
- Store transaction state as Transaction.getStatus()

### Getting a transaction
- Get transaction status from db
- Convert to first TransactionState with matching status

This could lead to the following happening:

- Latest event is CANCEL_BY_USER_FAILED
- Therefore TransactionState is FAILED_CANCELLED
- Transaction state stored in DB as cancelled
- Transaction retrieved
- TransactionState calculated as CANCELLED

i.e. we could lose information about the real TransactionState and
therefore report the wrong state.

Now we store the actual name of the transaction state in the DB,
so we do not lose any information. I have had to adapt the search
so that now if someone searches for cancelled, we actual go and retrieve
transactions with state FAILED_CANCELLED and CANCELLED

This means all existing transaction states in DB will be wrong. This is fine as we will truncate existing data