### PR TITLE
PP-5526 Fix card expiry_date

### DIFF
--- a/src/main/java/uk/gov/pay/ledger/transaction/model/TransactionFactory.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/model/TransactionFactory.java
@@ -46,7 +46,7 @@ public class TransactionFactory {
 
             CardDetails cardDetails = CardDetails.from(entity.getCardholderName(), billingAddress, entity.getCardBrand(),
                     entity.getLastDigitsCardNumber(), entity.getFirstDigitsCardNumber(),
-                    safeGetAsString(transactionDetails, "card_expiry_date"));
+                    safeGetAsString(transactionDetails, "expiry_date"));
 
             Map<String, Object> metadata = null;
             if (entity.getExternalMetadata() != null) {

--- a/src/test/java/uk/gov/pay/ledger/transaction/model/TransactionFactoryTest.java
+++ b/src/test/java/uk/gov/pay/ledger/transaction/model/TransactionFactoryTest.java
@@ -40,6 +40,7 @@ public class TransactionFactoryTest {
             "  \"gateway_transaction_id\": \"gti_12334\",\n" +
             "  \"corporate_surcharge\": 12,\n" +
             "  \"fee\": 5,\n" +
+            "  \"expiry_date\": \"10/27\",\n" +
             "  \"address_line1\": \"line 1\",\n" +
             "  \"address_line2\": \"line 2\",\n" +
             "  \"address_postcode\": \"A11 11BB\",\n" +
@@ -59,6 +60,7 @@ public class TransactionFactoryTest {
     private Long refundAmountSubmitted = 0L;
     private Long refundAmountAvailable = 99L;
     private Long fee = 66L;
+    private String cardExpiryDate = "10/27";
 
     @Before
     public void setUp() {
@@ -132,6 +134,7 @@ public class TransactionFactoryTest {
         assertThat(payment.getPaymentProvider(), is("sandbox"));
         assertThat(payment.getCreatedDate(), is(createdDate));
         assertThat(payment.getCardDetails(), notNullValue());
+        assertThat(payment.getCardDetails().getExpiryDate(), is(cardExpiryDate));
         assertThat(payment.getCardDetails().getLastDigitsCardNumber(), is(lastDigitsCardNumber));
         assertThat(payment.getCardDetails().getFirstDigitsCardNumber(), is(firstDigitsCardNumber));
         assertThat(payment.getCardDetails().getCardHolderName(), is(cardholderName));

--- a/src/test/java/uk/gov/pay/ledger/transaction/resource/TransactionResourceIT.java
+++ b/src/test/java/uk/gov/pay/ledger/transaction/resource/TransactionResourceIT.java
@@ -58,6 +58,7 @@ public class TransactionResourceIT {
                 .contentType(JSON)
                 .body("transaction_id", is(transactionFixture.getExternalId()))
                 .body("card_details.cardholder_name", is(transactionFixture.getCardDetails().getCardHolderName()))
+                .body("card_details.expiry_date", is(transactionFixture.getCardDetails().getExpiryDate()))
                 .body("card_details.billing_address.line1", is(transactionFixture.getCardDetails().getBillingAddress().getAddressLine1()));
     }
 
@@ -161,6 +162,7 @@ public class TransactionResourceIT {
                 .body("results[0].card_details.billing_address.city", is(transactionToVerify.getCardDetails().getBillingAddress().getAddressCity()))
                 .body("results[0].card_details.billing_address.country", is(transactionToVerify.getCardDetails().getBillingAddress().getAddressCountry()))
                 .body("results[0].card_details.card_brand", is(transactionToVerify.getCardDetails().getCardBrand()))
+                .body("results[0].card_details.expiry_date", is(transactionToVerify.getCardDetails().getExpiryDate()))
                 .body("results[0].delayed_capture", is(transactionToVerify.getDelayedCapture()))
                 .body("results[0].transaction_id", is(transactionToVerify.getExternalId()))
                 .body("results[0].transaction_type", is(TransactionType.PAYMENT.name()))

--- a/src/test/java/uk/gov/pay/ledger/util/fixture/TransactionFixture.java
+++ b/src/test/java/uk/gov/pay/ledger/util/fixture/TransactionFixture.java
@@ -36,6 +36,7 @@ public class TransactionFixture implements DbFixture<TransactionFixture, Transac
     private String transactionDetails = "{}";
     private Integer eventCount = 1;
     private String cardBrand = "visa";
+    private String cardExpiryDate = "10/21";
     private String language = "en";
     private String lastDigitsCardNumber;
     private String firstDigitsCardNumber;
@@ -332,15 +333,18 @@ public class TransactionFixture implements DbFixture<TransactionFixture, Transac
         transactionDetails.addProperty("corporate_surcharge", corporateCardSurcharge);
         transactionDetails.addProperty("refunded_by", refundedById);
         Optional.ofNullable(cardDetails)
-                .ifPresent(cd -> Optional.ofNullable(cd.getBillingAddress())
-                        .ifPresent(ba -> {
-                            transactionDetails.addProperty("address_line1", ba.getAddressLine1());
-                            transactionDetails.addProperty("address_line2", ba.getAddressLine2());
-                            transactionDetails.addProperty("address_postcode", ba.getAddressPostCode());
-                            transactionDetails.addProperty("address_city", ba.getAddressCity());
-                            transactionDetails.addProperty("address_county", ba.getAddressCounty());
-                            transactionDetails.addProperty("address_country", ba.getAddressCountry());
-                        }));
+                .ifPresent(cd -> {
+                    transactionDetails.addProperty("expiry_date", cardExpiryDate);
+                    Optional.ofNullable(cd.getBillingAddress())
+                            .ifPresent(ba -> {
+                                transactionDetails.addProperty("address_line1", ba.getAddressLine1());
+                                transactionDetails.addProperty("address_line2", ba.getAddressLine2());
+                                transactionDetails.addProperty("address_postcode", ba.getAddressPostCode());
+                                transactionDetails.addProperty("address_city", ba.getAddressCity());
+                                transactionDetails.addProperty("address_county", ba.getAddressCounty());
+                                transactionDetails.addProperty("address_country", ba.getAddressCountry());
+                            });
+                });
 
         return transactionDetails;
     }
@@ -439,7 +443,7 @@ public class TransactionFixture implements DbFixture<TransactionFixture, Transac
                     "London", null, "GB");
 
             cardDetails = new CardDetails(cardholderName, billingAddress, cardBrand,
-                    "1234", "123456", "11/23");
+                    "1234", "123456", cardExpiryDate);
         }
         return this;
     }


### PR DESCRIPTION
## WHAT 
- `expiry_date` is currently missing from transaction view / search.
- Corrected expected JSON field and updated relevant tests