### PR TITLE
PP-5541 Use refunded amount column in favour of refund submitted

### DIFF
--- a/src/main/java/uk/gov/pay/ledger/transaction/dao/TransactionDao.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/dao/TransactionDao.java
@@ -45,13 +45,13 @@ public class TransactionDao {
                 "external_id,parent_external_id,gateway_account_id,amount,description,reference,state,email,cardholder_name," +
                 "created_date,transaction_details,event_count,card_brand, " +
                 "last_digits_card_number,first_digits_card_number,net_amount,total_amount,fee,type,refund_amount_available," +
-                    "refund_amount_submitted, refund_status" +
+                    "refund_amount_refunded, refund_status" +
             ") " +
             "VALUES (" +
                 ":externalId,:parentExternalId,:gatewayAccountId,:amount,:description,:reference,:state,:email,:cardholderName," +
                 ":createdDate,CAST(:transactionDetails as jsonb), :eventCount," +
                 ":cardBrand,:lastDigitsCardNumber,:firstDigitsCardNumber,:netAmount,:totalAmount,:fee," +
-                ":transactionType::transaction_type,:refundAmountAvailable,:refundAmountSubmitted,:refundStatus" +
+                ":transactionType::transaction_type,:refundAmountAvailable,:refundAmountRefunded,:refundStatus" +
             ") " +
             "ON CONFLICT (external_id) " +
             "DO UPDATE SET " +
@@ -75,7 +75,7 @@ public class TransactionDao {
                 "fee = EXCLUDED.fee," +
                 "type = EXCLUDED.type, " +
                 "refund_amount_available = EXCLUDED.refund_amount_available, " +
-                "refund_amount_submitted = EXCLUDED.refund_amount_submitted, " +
+                "refund_amount_refunded = EXCLUDED.refund_amount_refunded, " +
                 "refund_status = EXCLUDED.refund_status " +
             "WHERE EXCLUDED.event_count > transaction.event_count;";
 

--- a/src/main/java/uk/gov/pay/ledger/transaction/dao/mapper/TransactionMapper.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/dao/mapper/TransactionMapper.java
@@ -38,7 +38,7 @@ public class TransactionMapper implements RowMapper<TransactionEntity> {
                 .withSettlementSubmittedTime(getZonedDateTime(rs, "settlement_submitted_time").orElse(null))
                 .withSettledTime(getZonedDateTime(rs, "settled_time").orElse(null))
                 .withRefundStatus(rs.getString("refund_status"))
-                .withRefundAmountSubmitted(rs.getLong("refund_amount_submitted"))
+                .withRefundAmountRefunded(rs.getLong("refund_amount_refunded"))
                 .withRefundAmountAvailable(rs.getLong("refund_amount_available"))
                 .withFee(rs.getLong("fee"))
                 .withTransactionType(rs.getString("type"))

--- a/src/main/java/uk/gov/pay/ledger/transaction/entity/TransactionEntity.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/entity/TransactionEntity.java
@@ -42,7 +42,7 @@ public class TransactionEntity {
     private ZonedDateTime settlementSubmittedTime;
     private ZonedDateTime settledTime;
     private String refundStatus;
-    private Long refundAmountSubmitted;
+    private Long refundAmountRefunded;
     private Long refundAmountAvailable;
 
     public TransactionEntity() {
@@ -70,7 +70,7 @@ public class TransactionEntity {
         this.settlementSubmittedTime = builder.settlementSubmittedTime;
         this.settledTime = builder.settledTime;
         this.refundStatus = builder.refundStatus;
-        this.refundAmountSubmitted = builder.refundAmountSubmitted;
+        this.refundAmountRefunded = builder.refundAmountRefunded;
         this.refundAmountAvailable = builder.refundAmountAvailable;
         this.fee = builder.fee;
         this.transactionType = builder.transactionType;
@@ -188,8 +188,8 @@ public class TransactionEntity {
         return refundStatus;
     }
 
-    public Long getRefundAmountSubmitted() {
-        return refundAmountSubmitted;
+    public Long getRefundAmountRefunded() {
+        return refundAmountRefunded;
     }
 
     public Long getRefundAmountAvailable() {
@@ -227,7 +227,7 @@ public class TransactionEntity {
         private ZonedDateTime settlementSubmittedTime;
         private ZonedDateTime settledTime;
         private String refundStatus;
-        private Long refundAmountSubmitted;
+        private Long refundAmountRefunded;
         private Long refundAmountAvailable;
         private String transactionType;
 
@@ -343,8 +343,8 @@ public class TransactionEntity {
             return this;
         }
 
-        public Builder withRefundAmountSubmitted(Long refundAmountSubmitted) {
-            this.refundAmountSubmitted = refundAmountSubmitted;
+        public Builder withRefundAmountRefunded(Long refundAmountRefunded) {
+            this.refundAmountRefunded = refundAmountRefunded;
             return this;
         }
 

--- a/src/main/java/uk/gov/pay/ledger/transaction/search/model/RefundSummary.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/search/model/RefundSummary.java
@@ -17,23 +17,26 @@ public class RefundSummary {
 
     private Long amountSubmitted;
 
+    private Long amountRefunded;
+
     public RefundSummary() {
     }
 
-    public RefundSummary(String status, Long amountAvailable, Long amountSubmitted) {
+    public RefundSummary(String status, Long amountAvailable, Long amountRefunded) {
         this.status = status;
         this.amountAvailable = amountAvailable;
-        this.amountSubmitted = amountSubmitted;
+        this.amountRefunded = amountRefunded;
+        this.amountSubmitted = amountRefunded;
     }
 
     public static RefundSummary from(TransactionEntity entity) {
         if (entity.getRefundStatus() == null &&
                 entity.getRefundAmountAvailable() == null &&
-                entity.getRefundAmountSubmitted() == null) {
+                entity.getRefundAmountRefunded() == null) {
             return null;
         }
 
-        return new RefundSummary(entity.getRefundStatus(), entity.getRefundAmountAvailable(), entity.getRefundAmountSubmitted());
+        return new RefundSummary(entity.getRefundStatus(), entity.getRefundAmountAvailable(), entity.getRefundAmountRefunded());
     }
 
     public String getUserExternalId() {
@@ -44,6 +47,10 @@ public class RefundSummary {
         return amountAvailable;
     }
 
+    public Long getAmountRefunded() {
+        return amountRefunded;
+    }
+
     public Long getAmountSubmitted() {
         return amountSubmitted;
     }
@@ -52,8 +59,8 @@ public class RefundSummary {
         return status;
     }
 
-    public static RefundSummary ofValue(String status, Long amountAvailable, Long amountSubmitted) {
-        return new RefundSummary(status, amountAvailable, amountSubmitted);
+    public static RefundSummary ofValue(String status, Long amountAvailable, Long amountRefunded) {
+        return new RefundSummary(status, amountAvailable, amountRefunded);
     }
 
     @Override
@@ -76,7 +83,7 @@ public class RefundSummary {
         if (!Objects.equals(amountAvailable, that.amountAvailable)) {
             return false;
         }
-        return Objects.equals(amountSubmitted, that.amountSubmitted);
+        return Objects.equals(amountRefunded, that.amountRefunded);
     }
 
     @Override
@@ -84,7 +91,7 @@ public class RefundSummary {
         int result = status.hashCode();
         result = 31 * result + (userExternalId != null ? userExternalId.hashCode() : 0);
         result = 31 * result + (amountAvailable != null ? amountAvailable.hashCode() : 0);
-        result = 31 * result + (amountSubmitted != null ? amountSubmitted.hashCode() : 0);
+        result = 31 * result + (amountRefunded != null ? amountRefunded.hashCode() : 0);
         return result;
     }
 
@@ -94,7 +101,7 @@ public class RefundSummary {
                 "status='" + status + '\'' +
                 "userExternalId='" + userExternalId + '\'' +
                 ", amountAvailable=" + amountAvailable +
-                ", amountSubmitted=" + amountSubmitted +
+                ", amountRefunded=" + amountRefunded +
                 '}';
     }
 }

--- a/src/test/java/uk/gov/pay/ledger/transaction/dao/TransactionDaoIT.java
+++ b/src/test/java/uk/gov/pay/ledger/transaction/dao/TransactionDaoIT.java
@@ -63,7 +63,7 @@ public class TransactionDaoIT {
         assertThat(retrievedTransaction.getFee(), is(transactionEntity.getFee()));
         assertThat(retrievedTransaction.getTransactionType(), is(transactionEntity.getTransactionType()));
         assertThat(retrievedTransaction.getRefundAmountAvailable(), is(transactionEntity.getRefundAmountAvailable()));
-        assertThat(retrievedTransaction.getRefundAmountSubmitted(), is(transactionEntity.getRefundAmountSubmitted()));
+        assertThat(retrievedTransaction.getRefundAmountRefunded(), is(transactionEntity.getRefundAmountRefunded()));
         assertThat(retrievedTransaction.getRefundStatus(), is(transactionEntity.getRefundStatus()));
     }
 

--- a/src/test/java/uk/gov/pay/ledger/transaction/model/TransactionFactoryTest.java
+++ b/src/test/java/uk/gov/pay/ledger/transaction/model/TransactionFactoryTest.java
@@ -60,7 +60,7 @@ public class TransactionFactoryTest {
     private ZonedDateTime settlementSubmittedTime = ZonedDateTime.parse("2017-09-09T09:35:45.695951+01");
     private ZonedDateTime settledTime = ZonedDateTime.parse("2017-09-09T12:13Z");
     private String refundStatus = "available";
-    private Long refundAmountSubmitted = 0L;
+    private Long refundAmountRefunded = 0L;
     private Long refundAmountAvailable = 99L;
     private Long fee = 66L;
     private String cardExpiryDate = "10/27";
@@ -88,7 +88,7 @@ public class TransactionFactoryTest {
                 .withSettlementSubmittedTime(settlementSubmittedTime)
                 .withSettledTime(settledTime)
                 .withRefundStatus(refundStatus)
-                .withRefundAmountSubmitted(refundAmountSubmitted)
+                .withRefundAmountRefunded(refundAmountRefunded)
                 .withRefundAmountAvailable(refundAmountAvailable)
                 .withFee(fee)
                 .build();
@@ -113,7 +113,7 @@ public class TransactionFactoryTest {
                 .withSettlementSubmittedTime(settlementSubmittedTime)
                 .withSettledTime(settledTime)
                 .withRefundStatus(refundStatus)
-                .withRefundAmountSubmitted(refundAmountSubmitted)
+                .withRefundAmountRefunded(refundAmountRefunded)
                 .withRefundAmountAvailable(refundAmountAvailable)
                 .build();
 
@@ -159,7 +159,7 @@ public class TransactionFactoryTest {
         assertThat(payment.getRefundSummary(), notNullValue());
         assertThat(payment.getRefundSummary().getStatus(), is(refundStatus));
         assertThat(payment.getRefundSummary().getAmountAvailable(), is(refundAmountAvailable));
-        assertThat(payment.getRefundSummary().getAmountSubmitted(), is(refundAmountSubmitted));
+        assertThat(payment.getRefundSummary().getAmountRefunded(), is(refundAmountRefunded));
         assertThat(payment.getSettlementSummary(), notNullValue());
         assertThat(payment.getSettlementSummary().getCapturedDate(), is(Optional.of("2017-09-09")));
         assertThat(payment.getSettlementSummary().getSettlementSubmittedTime(), is(Optional.of("2017-09-09T08:35:45.695Z")));
@@ -197,7 +197,7 @@ public class TransactionFactoryTest {
         assertThat(payment.getRefundSummary(), notNullValue());
         assertThat(payment.getRefundSummary().getStatus(), is(refundStatus));
         assertThat(payment.getRefundSummary().getAmountAvailable(), is(refundAmountAvailable));
-        assertThat(payment.getRefundSummary().getAmountSubmitted(), is(refundAmountSubmitted));
+        assertThat(payment.getRefundSummary().getAmountRefunded(), is(refundAmountRefunded));
         assertThat(payment.getSettlementSummary(), notNullValue());
         assertThat(payment.getSettlementSummary().getCapturedDate(), is(Optional.of("2017-09-09")));
         assertThat(payment.getSettlementSummary().getSettlementSubmittedTime(), is(Optional.of("2017-09-09T08:35:45.695Z")));

--- a/src/test/java/uk/gov/pay/ledger/util/fixture/TransactionFixture.java
+++ b/src/test/java/uk/gov/pay/ledger/util/fixture/TransactionFixture.java
@@ -56,7 +56,7 @@ public class TransactionFixture implements DbFixture<TransactionFixture, Transac
     private ZonedDateTime settlementSubmittedTime;
     private ZonedDateTime settledTime;
     private String refundStatus = "available";
-    private Long refundAmountSubmitted = 0L;
+    private Long refundAmountRefunded = 0L;
     private Long refundAmountAvailable = 100L;
     private String transactionType;
     private String parentExternalId;
@@ -291,7 +291,7 @@ public class TransactionFixture implements DbFixture<TransactionFixture, Transac
                                 "        net_amount,\n" +
                                 "        fee,\n" +
                                 "        refund_status,\n" +
-                                "        refund_amount_submitted,\n" +
+                                "        refund_amount_refunded,\n" +
                                 "        refund_amount_available,\n" +
                                 "        settlement_submitted_time,\n" +
                                 "        settled_time,\n" +
@@ -318,7 +318,7 @@ public class TransactionFixture implements DbFixture<TransactionFixture, Transac
                         netAmount,
                         fee,
                         refundStatus,
-                        refundAmountSubmitted,
+                        refundAmountRefunded,
                         refundAmountAvailable,
                         settlementSubmittedTime,
                         settledTime,
@@ -384,7 +384,7 @@ public class TransactionFixture implements DbFixture<TransactionFixture, Transac
                 .withSettlementSubmittedTime(settlementSubmittedTime)
                 .withSettledTime(settledTime)
                 .withRefundStatus(refundStatus)
-                .withRefundAmountSubmitted(refundAmountSubmitted)
+                .withRefundAmountRefunded(refundAmountRefunded)
                 .withRefundAmountAvailable(refundAmountAvailable)
                 .withFee(fee)
                 .withTransactionType(transactionType)
@@ -477,7 +477,7 @@ public class TransactionFixture implements DbFixture<TransactionFixture, Transac
     public TransactionFixture withRefundSummary(RefundSummary refundSummary) {
         this.refundStatus = refundSummary.getStatus();
         this.refundAmountAvailable = refundSummary.getAmountAvailable();
-        this.refundAmountSubmitted = refundSummary.getAmountSubmitted();
+        this.refundAmountRefunded = refundSummary.getAmountRefunded();
         return this;
     }
 


### PR DESCRIPTION
(Waiting on pacts given services master builds failing)

* database migration for column name change
* column name matches event structure defined by https://github.com/alphagov/pay-connector/pull/1515
* follow up PR to update payment resource model

Requires initial PR to introduce the column (through migration), followed up by a cleanup removing the extra column.