### PR TITLE
Use runAppE2E to run end to end tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -113,8 +113,8 @@ pipeline {
     }
     /*stage('Tests') {
       failFast true
-      parallel {
-        stage('Card Payment End-to-End Tests') {
+      stages {
+        stage('End-to-End Tests') {
             when {
                 anyOf {
                   branch 'master'
@@ -122,7 +122,7 @@ pipeline {
                 }
             }
             steps {
-                runCardPaymentsE2E("ledger")
+                runAppE2E("ledger", "card")
             }
         }
       }


### PR DESCRIPTION
Let's deprecate the run{test}E2E groovy routines and use runAppE2E everywhere

Even though this is commented out, update it to avoid surprises in future