### PR TITLE
PP-5540 external metadata

### DIFF
--- a/src/main/java/uk/gov/pay/ledger/transaction/dao/TransactionDao.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/dao/TransactionDao.java
@@ -43,13 +43,13 @@ public class TransactionDao {
     private static final String UPSERT_STRING =
             "INSERT INTO transaction(" +
                 "external_id,parent_external_id,gateway_account_id,amount,description,reference,state,email,cardholder_name," +
-                "external_metadata,created_date,transaction_details,event_count,card_brand, " +
+                "created_date,transaction_details,event_count,card_brand, " +
                 "last_digits_card_number,first_digits_card_number,net_amount,total_amount,fee,type,refund_amount_available," +
                     "refund_amount_submitted, refund_status" +
             ") " +
             "VALUES (" +
                 ":externalId,:parentExternalId,:gatewayAccountId,:amount,:description,:reference,:state,:email,:cardholderName," +
-                "CAST(:externalMetadata as jsonb),:createdDate,CAST(:transactionDetails as jsonb), :eventCount," +
+                ":createdDate,CAST(:transactionDetails as jsonb), :eventCount," +
                 ":cardBrand,:lastDigitsCardNumber,:firstDigitsCardNumber,:netAmount,:totalAmount,:fee," +
                 ":transactionType::transaction_type,:refundAmountAvailable,:refundAmountSubmitted,:refundStatus" +
             ") " +
@@ -64,7 +64,6 @@ public class TransactionDao {
                 "state = EXCLUDED.state," +
                 "email = EXCLUDED.email," +
                 "cardholder_name = EXCLUDED.cardholder_name," +
-                "external_metadata = EXCLUDED.external_metadata," +
                 "created_date = EXCLUDED.created_date," +
                 "transaction_details = EXCLUDED.transaction_details," +
                 "event_count = EXCLUDED.event_count," +

--- a/src/main/java/uk/gov/pay/ledger/transaction/dao/mapper/TransactionMapper.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/dao/mapper/TransactionMapper.java
@@ -27,7 +27,6 @@ public class TransactionMapper implements RowMapper<TransactionEntity> {
                 .withState(TransactionState.valueOf(rs.getString("state")))
                 .withEmail(rs.getString("email"))
                 .withCardholderName(rs.getString("cardholder_name"))
-                .withExternalMetadata(rs.getString("external_metadata"))
                 .withCreatedDate(getZonedDateTime(rs, "created_date").orElse(null))
                 .withTransactionDetails(rs.getString("transaction_details"))
                 .withEventCount(rs.getInt("event_count"))

--- a/src/main/java/uk/gov/pay/ledger/transaction/entity/TransactionEntity.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/entity/TransactionEntity.java
@@ -25,7 +25,6 @@ public class TransactionEntity {
     private TransactionState state;
     private String email;
     private String cardholderName;
-    private String externalMetadata;
     @JsonIgnore
     private ZonedDateTime createdDate;
     @JsonIgnore
@@ -60,7 +59,6 @@ public class TransactionEntity {
         this.state = builder.state;
         this.email = builder.email;
         this.cardholderName = builder.cardholderName;
-        this.externalMetadata = builder.externalMetadata;
         this.createdDate = builder.createdDate;
         this.transactionDetails = builder.transactionDetails;
         this.eventCount = builder.eventCount;
@@ -116,10 +114,6 @@ public class TransactionEntity {
 
     public String getCardholderName() {
         return cardholderName;
-    }
-
-    public String getExternalMetadata() {
-        return externalMetadata;
     }
 
     public ZonedDateTime getCreatedDate() {
@@ -222,7 +216,6 @@ public class TransactionEntity {
         private TransactionState state;
         private String email;
         private String cardholderName;
-        private String externalMetadata;
         private ZonedDateTime createdDate;
         private String transactionDetails;
         private Integer eventCount;
@@ -292,11 +285,6 @@ public class TransactionEntity {
 
         public Builder withCardholderName(String cardholderName) {
             this.cardholderName = cardholderName;
-            return this;
-        }
-
-        public Builder withExternalMetadata(String externalMetadata) {
-            this.externalMetadata = externalMetadata;
             return this;
         }
 

--- a/src/main/java/uk/gov/pay/ledger/transaction/model/TransactionFactory.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/model/TransactionFactory.java
@@ -49,9 +49,10 @@ public class TransactionFactory {
                     safeGetAsString(transactionDetails, "expiry_date"));
 
             Map<String, Object> metadata = null;
-            if (entity.getExternalMetadata() != null) {
-                metadata = objectMapper.readValue(entity.getExternalMetadata(), new TypeReference<Map<String, Object>>() {
-                });
+            if (transactionDetails.has("external_metadata")) {
+                metadata = objectMapper.readValue(
+                        objectMapper.treeAsTokens(transactionDetails.get("external_metadata")),
+                        new TypeReference<Map<String, Object>>() {});
             }
 
             RefundSummary refundSummary = RefundSummary.from(entity);

--- a/src/main/java/uk/gov/pay/ledger/transaction/search/model/ConvertedTransactionDetails.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/search/model/ConvertedTransactionDetails.java
@@ -4,6 +4,8 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import java.util.Map;
+
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class ConvertedTransactionDetails {
@@ -41,4 +43,6 @@ public class ConvertedTransactionDetails {
     private Long corporateSurcharge;
     @JsonProperty("refunded_by")
     private String refundedBy;
+    @JsonProperty("external_metadata")
+    private Map<String, Object> externalMetadata;
 }

--- a/src/test/java/uk/gov/pay/ledger/event/model/TransactionEntityFactoryTest.java
+++ b/src/test/java/uk/gov/pay/ledger/event/model/TransactionEntityFactoryTest.java
@@ -79,8 +79,8 @@ public class TransactionEntityFactoryTest {
                         "\"delayed_capture\":false," +
                         "\"return_url\":\"https://example.org\"," +
                         "\"gateway_transaction_id\":\"%s\"," +
-                        "\"corporate_surcharge\":5," +
-                        "\"external_metadata\":{\"key1\":\"value1\"}" +
+                        "\"corporate_surcharge\":5" +
+                        //"\"external_metadata\":{\"key1\":\"value1\"}" +    //todo: will be enabled after changes to connector
                         "}",
                 eventDigest.getEventPayload().get("gateway_transaction_id"));
 

--- a/src/test/java/uk/gov/pay/ledger/event/model/TransactionEntityFactoryTest.java
+++ b/src/test/java/uk/gov/pay/ledger/event/model/TransactionEntityFactoryTest.java
@@ -63,7 +63,6 @@ public class TransactionEntityFactoryTest {
         assertThat(transactionEntity.getFirstDigitsCardNumber(), is(eventDigest.getEventPayload().get("first_digits_card_number")));
         assertThat(transactionEntity.getLastDigitsCardNumber(), is(eventDigest.getEventPayload().get("last_digits_card_number")));
         assertThat(transactionEntity.getAmount(), is(((Integer)eventDigest.getEventPayload().get("amount")).longValue()));
-        assertThat(transactionEntity.getExternalMetadata(), is(eventDigest.getEventPayload().get("external_metadata")));
         assertThat(transactionEntity.getNetAmount(), is(((Integer)eventDigest.getEventPayload().get("net_amount")).longValue()));
         assertThat(transactionEntity.getTotalAmount(), is(((Integer)eventDigest.getEventPayload().get("total_amount")).longValue()));
         assertThat(transactionEntity.getFee(), is(((Integer)eventDigest.getEventPayload().get("fee")).longValue()));
@@ -80,7 +79,8 @@ public class TransactionEntityFactoryTest {
                         "\"delayed_capture\":false," +
                         "\"return_url\":\"https://example.org\"," +
                         "\"gateway_transaction_id\":\"%s\"," +
-                        "\"corporate_surcharge\":5" +
+                        "\"corporate_surcharge\":5," +
+                        "\"external_metadata\":{\"key1\":\"value1\"}" +
                         "}",
                 eventDigest.getEventPayload().get("gateway_transaction_id"));
 

--- a/src/test/java/uk/gov/pay/ledger/transaction/dao/TransactionDaoIT.java
+++ b/src/test/java/uk/gov/pay/ledger/transaction/dao/TransactionDaoIT.java
@@ -45,7 +45,6 @@ public class TransactionDaoIT {
         assertThat(retrievedTransaction.getState(), is(transactionEntity.getState()));
         assertThat(retrievedTransaction.getEmail(), is(transactionEntity.getEmail()));
         assertThat(retrievedTransaction.getCardholderName(), is(transactionEntity.getCardholderName()));
-        assertThat(retrievedTransaction.getExternalMetadata(), is(transactionEntity.getExternalMetadata()));
         assertThat(retrievedTransaction.getCreatedDate(), is(transactionEntity.getCreatedDate()));
         assertThat(retrievedTransaction.getTransactionDetails().contains(fixture.getLanguage()), is(true));
         assertThat(retrievedTransaction.getTransactionDetails().contains(fixture.getReturnUrl()), is(true));
@@ -88,7 +87,6 @@ public class TransactionDaoIT {
         assertThat(transaction.getState(), is(transactionEntity.getState()));
         assertThat(transaction.getEmail(), is(transactionEntity.getEmail()));
         assertThat(transaction.getCardholderName(), is(transactionEntity.getCardholderName()));
-        assertThat(transaction.getExternalMetadata(), is(transactionEntity.getExternalMetadata()));
         assertThat(transaction.getCreatedDate(), is(transactionEntity.getCreatedDate()));
         assertThat(transaction.getTransactionDetails().contains(fixture.getLanguage()), is(true));
         assertThat(transaction.getTransactionDetails().contains(fixture.getReturnUrl()), is(true));

--- a/src/test/java/uk/gov/pay/ledger/transaction/dao/TransactionDaoIT.java
+++ b/src/test/java/uk/gov/pay/ledger/transaction/dao/TransactionDaoIT.java
@@ -1,5 +1,6 @@
 package uk.gov.pay.ledger.transaction.dao;
 
+import com.google.common.collect.ImmutableMap;
 import org.junit.ClassRule;
 import org.junit.Test;
 import uk.gov.pay.ledger.rule.AppWithPostgresAndSqsRule;
@@ -9,6 +10,7 @@ import uk.gov.pay.ledger.util.fixture.TransactionFixture;
 
 import java.util.List;
 
+import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -28,6 +30,7 @@ public class TransactionDaoIT {
                 .withNetAmount(55)
                 .withTotalAmount(105)
                 .withFee(33)
+                .withExternalMetadata(ImmutableMap.of("key1", "value1", "anotherKey", ImmutableMap.of("nestedKey", "value")))
                 .withTransactionType("PAYMENT")
                 .withDefaultTransactionDetails();
         TransactionEntity transactionEntity = fixture.toEntity();
@@ -45,6 +48,7 @@ public class TransactionDaoIT {
         assertThat(retrievedTransaction.getState(), is(transactionEntity.getState()));
         assertThat(retrievedTransaction.getEmail(), is(transactionEntity.getEmail()));
         assertThat(retrievedTransaction.getCardholderName(), is(transactionEntity.getCardholderName()));
+        assertThat(retrievedTransaction.getTransactionDetails(), containsString("\"external_metadata\": {\"key1\": \"value1\", \"anotherKey\": {\"nestedKey\": \"value\"}}"));
         assertThat(retrievedTransaction.getCreatedDate(), is(transactionEntity.getCreatedDate()));
         assertThat(retrievedTransaction.getTransactionDetails().contains(fixture.getLanguage()), is(true));
         assertThat(retrievedTransaction.getTransactionDetails().contains(fixture.getReturnUrl()), is(true));
@@ -68,6 +72,7 @@ public class TransactionDaoIT {
         TransactionFixture fixture = aTransactionFixture()
                 .withDefaultCardDetails()
                 .withTransactionType("PAYMENT")
+                .withExternalMetadata(ImmutableMap.of("key1", "value1", "anotherKey", ImmutableMap.of("nestedKey", "value")))
                 .withDefaultTransactionDetails()
                 .insert(rule.getJdbi());
         TransactionEntity transactionEntity = fixture.toEntity();
@@ -87,6 +92,7 @@ public class TransactionDaoIT {
         assertThat(transaction.getState(), is(transactionEntity.getState()));
         assertThat(transaction.getEmail(), is(transactionEntity.getEmail()));
         assertThat(transaction.getCardholderName(), is(transactionEntity.getCardholderName()));
+        assertThat(transaction.getTransactionDetails(), containsString("\"external_metadata\": {\"key1\": \"value1\", \"anotherKey\": {\"nestedKey\": \"value\"}}"));
         assertThat(transaction.getCreatedDate(), is(transactionEntity.getCreatedDate()));
         assertThat(transaction.getTransactionDetails().contains(fixture.getLanguage()), is(true));
         assertThat(transaction.getTransactionDetails().contains(fixture.getReturnUrl()), is(true));

--- a/src/test/java/uk/gov/pay/ledger/transaction/model/TransactionFactoryTest.java
+++ b/src/test/java/uk/gov/pay/ledger/transaction/model/TransactionFactoryTest.java
@@ -30,7 +30,6 @@ public class TransactionFactoryTest {
     private TransactionState state = TransactionState.valueOf("CREATED");
     private String email = "test@email.com";
     private String cardholderName = "M Jan Kowalski";
-    private String fullExternalMetadata = "{\"ledger_code\":123, \"some_key\":\"key\"}";
     private ZonedDateTime createdDate = ZonedDateTime.now();
     private String fullTransactionDetails = "{\n" +
             "  \"language\": \"en\",\n" +
@@ -46,7 +45,11 @@ public class TransactionFactoryTest {
             "  \"address_postcode\": \"A11 11BB\",\n" +
             "  \"address_city\": \"London\",\n" +
             "  \"address_county\": \"London\",\n" +
-            "  \"address_country\": \"GB\"\n" +
+            "  \"address_country\": \"GB\"\n," +
+            "  \"external_metadata\": {\n" +
+            "       \"ledger_code\":123,\n" +
+            "       \"some_key\":\"key\"" +
+            "   }" +
             "}";
     private Integer eventCount = 2;
     private String cardBrand = "visa";
@@ -74,7 +77,6 @@ public class TransactionFactoryTest {
                 .withState(state)
                 .withEmail(email)
                 .withCardholderName(cardholderName)
-                .withExternalMetadata(fullExternalMetadata)
                 .withCreatedDate(createdDate)
                 .withTransactionDetails(fullTransactionDetails)
                 .withEventCount(eventCount)

--- a/src/test/java/uk/gov/pay/ledger/util/fixture/QueuePaymentEventFixture.java
+++ b/src/test/java/uk/gov/pay/ledger/util/fixture/QueuePaymentEventFixture.java
@@ -81,7 +81,7 @@ public class QueuePaymentEventFixture implements QueueFixture<QueuePaymentEventF
                                 .put("gateway_account_id", gatewayAccountId)
                                 .put("payment_provider", "sandbox")
                                 .put("delayed_capture", false)
-                                .put("external_metadata", externalMetadata)
+                                //.put("external_metadata", externalMetadata)   //todo: will be enabled after changes to connector
                                 .build());
                 break;
             case "PAYMENT_DETAILS_ENTERED":

--- a/src/test/java/uk/gov/pay/ledger/util/fixture/QueuePaymentEventFixture.java
+++ b/src/test/java/uk/gov/pay/ledger/util/fixture/QueuePaymentEventFixture.java
@@ -4,6 +4,7 @@ import au.com.dius.pact.consumer.dsl.PactDslJsonBody;
 import com.amazonaws.services.sqs.AmazonSQS;
 import com.google.common.collect.ImmutableMap;
 import com.google.gson.GsonBuilder;
+import com.google.gson.JsonObject;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.StringUtils;
 import uk.gov.pay.ledger.event.model.Event;
@@ -67,6 +68,9 @@ public class QueuePaymentEventFixture implements QueueFixture<QueuePaymentEventF
     public QueuePaymentEventFixture withDefaultEventDataForEventType(String eventType) {
         switch (eventType) {
             case "PAYMENT_CREATED":
+                var externalMetadata = new JsonObject();
+                externalMetadata.addProperty("key1", "value1");
+
                 eventData = new GsonBuilder().create()
                         .toJson(ImmutableMap.builder()
                                 .put("amount", 1000)
@@ -77,6 +81,7 @@ public class QueuePaymentEventFixture implements QueueFixture<QueuePaymentEventF
                                 .put("gateway_account_id", gatewayAccountId)
                                 .put("payment_provider", "sandbox")
                                 .put("delayed_capture", false)
+                                .put("external_metadata", externalMetadata)
                                 .build());
                 break;
             case "PAYMENT_DETAILS_ENTERED":


### PR DESCRIPTION
I wasn't quite sure whether to go with moving external_metdata to the transaction details so I prepared two versions:
* current version PR (both commits) shows implementation for keeping external_metadata at the top level
* first commit (only) shows version which moves external_metadata to transaction_details (without changes to db yet)