### PR TITLE
PP-5541 Remove refund submitted column

### DIFF
--- a/src/main/resources/migrations/00019_remove_transaction_refund_submitted_amount.sql
+++ b/src/main/resources/migrations/00019_remove_transaction_refund_submitted_amount.sql
@@ -1,0 +1,6 @@
+--liquibase formatted sql
+
+--changeset uk.gov.pay:remove_transaction_refund_submitted_amount
+
+ALTER TABLE transaction
+    DROP COLUMN refund_amount_submitted;


### PR DESCRIPTION
(Waiting on pacts given services master builds failing)

Depends on (forked from) https://github.com/alphagov/pay-ledger/pull/208

* column replaced in favour of `submitted` -> `refunded`
* migration succeeded, remove old column that is no longer used