### PR TITLE
PP-5527: update TransactionMapper

### DIFF
--- a/src/main/java/uk/gov/pay/ledger/transaction/dao/mapper/TransactionMapper.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/dao/mapper/TransactionMapper.java
@@ -21,7 +21,7 @@ public class TransactionMapper implements RowMapper<TransactionEntity> {
                 .withGatewayAccountId(rs.getString("gateway_account_id"))
                 .withExternalId(rs.getString("external_id"))
                 .withParentExternalId(rs.getString("parent_external_id"))
-                .withAmount(rs.getLong("amount"))
+                .withAmount(getLongWithNullCheck(rs, "amount"))
                 .withReference(rs.getString("reference"))
                 .withDescription(rs.getString("description"))
                 .withState(TransactionState.valueOf(rs.getString("state")))
@@ -33,16 +33,21 @@ public class TransactionMapper implements RowMapper<TransactionEntity> {
                 .withCardBrand(rs.getString("card_brand"))
                 .withLastDigitsCardNumber(rs.getString("last_digits_card_number"))
                 .withFirstDigitsCardNumber(rs.getString("first_digits_card_number"))
-                .withNetAmount(rs.getLong("net_amount"))
-                .withTotalAmount(rs.getLong("total_amount"))
+                .withNetAmount(getLongWithNullCheck(rs, "net_amount"))
+                .withTotalAmount(getLongWithNullCheck(rs, "total_amount"))
                 .withSettlementSubmittedTime(getZonedDateTime(rs, "settlement_submitted_time").orElse(null))
                 .withSettledTime(getZonedDateTime(rs, "settled_time").orElse(null))
                 .withRefundStatus(rs.getString("refund_status"))
-                .withRefundAmountRefunded(rs.getLong("refund_amount_refunded"))
-                .withRefundAmountAvailable(rs.getLong("refund_amount_available"))
-                .withFee(rs.getLong("fee"))
+                .withRefundAmountRefunded(getLongWithNullCheck(rs, "refund_amount_refunded"))
+                .withRefundAmountAvailable(getLongWithNullCheck(rs, "refund_amount_available"))
+                .withFee(getLongWithNullCheck(rs, "fee"))
                 .withTransactionType(rs.getString("type"))
                 .build();
+    }
+
+    private Long getLongWithNullCheck(ResultSet rs, String columnName) throws SQLException {
+        long value = rs.getLong(columnName);
+        return rs.wasNull() ? null : value;
     }
 
     private Optional<ZonedDateTime> getZonedDateTime(ResultSet rs, String columnLabel) throws SQLException {

--- a/src/test/java/uk/gov/pay/ledger/transaction/dao/TransactionDaoIT.java
+++ b/src/test/java/uk/gov/pay/ledger/transaction/dao/TransactionDaoIT.java
@@ -13,6 +13,7 @@ import java.util.List;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static uk.gov.pay.ledger.util.fixture.TransactionFixture.aTransactionFixture;
 
@@ -103,6 +104,10 @@ public class TransactionDaoIT {
         assertThat(transaction.getLastDigitsCardNumber(), is(transactionEntity.getLastDigitsCardNumber()));
         assertThat(transaction.getFirstDigitsCardNumber(), is(transactionEntity.getFirstDigitsCardNumber()));
         assertThat(transaction.getTransactionType(), is(transactionEntity.getTransactionType()));
+        assertThat(transaction.getFee(), is(nullValue()));
+        assertThat(transaction.getTotalAmount(), is(nullValue()));
+        assertThat(transaction.getRefundAmountAvailable(), is(transactionEntity.getRefundAmountAvailable()));
+        assertThat(transaction.getRefundAmountRefunded(), is(transactionEntity.getRefundAmountRefunded()));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/ledger/transaction/resource/TransactionResourceIT.java
+++ b/src/test/java/uk/gov/pay/ledger/transaction/resource/TransactionResourceIT.java
@@ -23,6 +23,7 @@ import static io.restassured.RestAssured.given;
 import static io.restassured.http.ContentType.JSON;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.nullValue;
 import static uk.gov.pay.commons.model.ApiResponseDateTimeFormatter.ISO_INSTANT_MILLISECOND_PRECISION;
 import static uk.gov.pay.ledger.util.DatabaseTestHelper.aDatabaseTestHelper;
 import static uk.gov.pay.ledger.util.fixture.TransactionFixture.aPersistedTransactionList;
@@ -168,6 +169,12 @@ public class TransactionResourceIT {
                 .body("results[0].delayed_capture", is(transactionToVerify.getDelayedCapture()))
                 .body("results[0].transaction_id", is(transactionToVerify.getExternalId()))
                 .body("results[0].transaction_type", is(TransactionType.PAYMENT.name()))
+                .body("results[0].net_amount", is(nullValue()))
+                .body("results[0].total_amount", is(nullValue()))
+                .body("results[0].fee", is(nullValue()))
+                .body("results[0].refund_summary.amount_available", is(transactionToVerify.getRefundSummary().getAmountAvailable().intValue()))
+                .body("results[0].refund_summary.amount_submitted", is(transactionToVerify.getRefundSummary().getAmountSubmitted().intValue()))
+                .body("results[0].refund_summary.amount_refunded", is(transactionToVerify.getRefundSummary().getAmountRefunded().intValue()))
 
                 .body("count", is(2))
                 .body("page", is(2))


### PR DESCRIPTION
* in order to be able to read null value from db (instead of defaulting to the value of long primitive type)

(extended to other Long values not only `fee`)