### PR TITLE
PP-5421 Update refund pact state

### DIFF
--- a/src/main/java/uk/gov/pay/ledger/transaction/service/TransactionService.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/service/TransactionService.java
@@ -158,6 +158,7 @@ public class TransactionService {
         List<TransactionView> transactions = transactionDao.findTransactionByParentIdAndGatewayAccountId(
                 parentTransactionExternalId, gatewayAccountId)
                 .stream()
+                .sorted(Comparator.comparing(TransactionEntity::getCreatedDate))
                 .map(transactionEntity ->
                         TransactionView.from(transactionFactory.createTransactionEntity(transactionEntity)))
                 .collect(Collectors.toList());

--- a/src/test/java/uk/gov/pay/ledger/pact/TransactionsApiContractTest.java
+++ b/src/test/java/uk/gov/pay/ledger/pact/TransactionsApiContractTest.java
@@ -100,6 +100,7 @@ public class TransactionsApiContractTest {
                 .withGatewayAccountId(gatewayAccountId)
                 .withAmount(200L)
                 .withTransactionType("REFUND")
+                .withState(TransactionState.ERROR_GATEWAY)
                 .withReference("reference2")
                 .withDescription("description2")
                 .withCreatedDate(ZonedDateTime.parse("2018-09-22T10:16:16.067Z"))


### PR DESCRIPTION
- Update refund pact state to also include a refund with state 'error'
- Minor update to `findTransactionsForParentExternalId` service method to always return results in order. If not, this can cause tests to flaky