### PR TITLE
PP-5499 Includes parent_transaction_id in Refund response

### DIFF
--- a/src/main/java/uk/gov/pay/ledger/transaction/model/Refund.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/model/Refund.java
@@ -11,6 +11,7 @@ public class Refund extends Transaction {
     private final ZonedDateTime createdDate;
     private final Integer eventCount;
     private final String refundedBy;
+    private final String parentExternalId;
 
     public Refund(Builder builder) {
         super(builder.id, builder.gatewayAccountId, builder.amount, builder.externalId);
@@ -20,6 +21,7 @@ public class Refund extends Transaction {
         this.createdDate = builder.createdDate;
         this.eventCount = builder.eventCount;
         this.refundedBy = builder.refundedBy;
+        this.parentExternalId = builder.parentExternalId;
     }
 
     public String getReference() {
@@ -46,6 +48,10 @@ public class Refund extends Transaction {
         return refundedBy;
     }
 
+    public String getParentExternalId() {
+        return parentExternalId;
+    }
+
     @Override
     public TransactionType getTransactionType() {
         return TransactionType.REFUND;
@@ -62,6 +68,7 @@ public class Refund extends Transaction {
         private String gatewayAccountId;
         private Long amount;
         private String externalId;
+        private String parentExternalId;
 
         public Builder() {
         }
@@ -117,6 +124,11 @@ public class Refund extends Transaction {
 
         public Builder withRefundedBy(String refundedBy) {
             this.refundedBy = refundedBy;
+            return this;
+        }
+
+        public Builder withParentExternalId(String parentExternalId) {
+            this.parentExternalId = parentExternalId;
             return this;
         }
     }

--- a/src/main/java/uk/gov/pay/ledger/transaction/model/TransactionFactory.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/model/TransactionFactory.java
@@ -107,6 +107,7 @@ public class TransactionFactory {
                     .withCreatedDate(entity.getCreatedDate())
                     .withEventCount(entity.getEventCount())
                     .withRefundedBy(safeGetAsString(transactionDetails, "refunded_by"))
+                    .withParentExternalId(entity.getParentExternalId())
                     .build();
 
         } catch (IOException e) {

--- a/src/main/java/uk/gov/pay/ledger/transaction/search/model/TransactionView.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/search/model/TransactionView.java
@@ -37,6 +37,7 @@ public class TransactionView {
     private String reference;
     private String language;
     private String externalId;
+    private String parentExternalId;
     private String returnUrl;
     private String email;
     private String paymentProvider;
@@ -64,6 +65,7 @@ public class TransactionView {
         this.reference = builder.reference;
         this.language = builder.language;
         this.externalId = builder.externalId;
+        this.parentExternalId = builder.parentExternalId;
         this.returnUrl = builder.returnUrl;
         this.email = builder.email;
         this.paymentProvider = builder.paymentProvider;
@@ -82,7 +84,7 @@ public class TransactionView {
     }
 
     public static TransactionView from(Transaction transaction) {
-        if(transaction instanceof Payment) {
+        if (transaction instanceof Payment) {
             Payment payment = (Payment) transaction;
 
             return new Builder()
@@ -121,6 +123,7 @@ public class TransactionView {
                 .withDescription(refund.getDescription())
                 .withReference(refund.getReference())
                 .withExternalId(refund.getExternalId())
+                .withParentExternalId(refund.getParentExternalId())
                 .withCreatedDate(refund.getCreatedDate())
                 .withRefundedBy(refund.getRefundedBy())
                 .withTransactionType(refund.getTransactionType())
@@ -158,6 +161,11 @@ public class TransactionView {
     @JsonProperty("transaction_id")
     public String getTransactionId() {
         return externalId;
+    }
+
+    @JsonProperty("parent_transaction_id")
+    public String getParentTransactionId() {
+        return parentExternalId;
     }
 
     public String getReturnUrl() {
@@ -250,6 +258,7 @@ public class TransactionView {
         private String reference;
         private String language;
         private String externalId;
+        private String parentExternalId;
         private String returnUrl;
         private String email;
         private String paymentProvider;
@@ -328,6 +337,11 @@ public class TransactionView {
 
         public Builder withExternalId(String externalId) {
             this.externalId = externalId;
+            return this;
+        }
+
+        public Builder withParentExternalId(String parentExternalId) {
+            this.parentExternalId = parentExternalId;
             return this;
         }
 

--- a/src/test/java/uk/gov/pay/ledger/transaction/model/TransactionFactoryTest.java
+++ b/src/test/java/uk/gov/pay/ledger/transaction/model/TransactionFactoryTest.java
@@ -210,6 +210,7 @@ public class TransactionFactoryTest {
                 .withId(id)
                 .withGatewayAccountId(gatewayAccountId)
                 .withExternalId(externalId)
+                .withParentExternalId("parent-ext-id")
                 .withAmount(amount)
                 .withReference(reference)
                 .withState(state)
@@ -222,6 +223,7 @@ public class TransactionFactoryTest {
         assertThat(refundEntity.getGatewayAccountId(), is(gatewayAccountId));
         assertThat(refundEntity.getAmount(), is(amount));
         assertThat(refundEntity.getExternalId(), is(externalId));
+        assertThat(refundEntity.getParentExternalId(), is("parent-ext-id"));
         assertThat(refundEntity.getRefundedBy(), is("some_user_id"));
         assertThat(refundEntity.getReference(), is(reference));
         assertThat(refundEntity.getState(), is(state));


### PR DESCRIPTION
## WHAT 
- Adds `parent_transaction_id` for RefundTransaction response as `parent_external_id` is required to build `Refund for payment` link (in publicapi search refunds resource)
- Adds Pact state for Refund transactions search
- Refactored `TransactionsApiContractTest`