### PR TITLE
PP-5520 Allow overriding of gateway account id on search

### DIFF
--- a/src/main/java/uk/gov/pay/ledger/transaction/dao/TransactionDao.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/dao/TransactionDao.java
@@ -4,13 +4,11 @@ import com.google.inject.Inject;
 import org.apache.commons.lang3.StringUtils;
 import org.jdbi.v3.core.Jdbi;
 import org.jdbi.v3.core.statement.Query;
-import org.jdbi.v3.core.statement.SqlStatements;
 import uk.gov.pay.ledger.transaction.dao.mapper.TransactionMapper;
 import uk.gov.pay.ledger.transaction.entity.TransactionEntity;
 import uk.gov.pay.ledger.transaction.model.TransactionType;
 import uk.gov.pay.ledger.transaction.search.common.TransactionSearchParams;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.BiConsumer;
@@ -166,6 +164,8 @@ public class TransactionDao {
         return jdbi.withHandle(handle -> {
             Query query = handle.createQuery(createSearchTemplate(searchParams, SEARCH_TRANSACTIONS));
             searchParams.getQueryMap().forEach(bindSearchParameter(query));
+            query.bind("offset", searchParams.getOffset());
+            query.bind("limit", searchParams.getDisplaySize());
             return query
                     .map(new TransactionMapper())
                     .list();
@@ -174,8 +174,7 @@ public class TransactionDao {
 
     public Long getTotalForSearch(TransactionSearchParams searchParams) {
         return jdbi.withHandle(handle -> {
-            Query query = handle.configure(SqlStatements.class, stmts -> stmts.setUnusedBindingAllowed(true))
-                    .createQuery(createSearchTemplate(searchParams, COUNT_TRANSACTIONS));
+            Query query = handle.createQuery(createSearchTemplate(searchParams, COUNT_TRANSACTIONS));
             searchParams.getQueryMap().forEach(bindSearchParameter(query));
             return query
                     .mapTo(Long.class)

--- a/src/main/java/uk/gov/pay/ledger/transaction/dao/TransactionDao.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/dao/TransactionDao.java
@@ -1,14 +1,16 @@
 package uk.gov.pay.ledger.transaction.dao;
 
 import com.google.inject.Inject;
-import org.jdbi.v3.core.Handle;
+import org.apache.commons.lang3.StringUtils;
 import org.jdbi.v3.core.Jdbi;
 import org.jdbi.v3.core.statement.Query;
+import org.jdbi.v3.core.statement.SqlStatements;
 import uk.gov.pay.ledger.transaction.dao.mapper.TransactionMapper;
 import uk.gov.pay.ledger.transaction.entity.TransactionEntity;
 import uk.gov.pay.ledger.transaction.model.TransactionType;
 import uk.gov.pay.ledger.transaction.search.common.TransactionSearchParams;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.BiConsumer;
@@ -33,14 +35,12 @@ public class TransactionDao {
             " WHERE parent_external_id = :parentExternalId" +
             "   AND gateway_account_id = :gatewayAccountId";
 
-    private static final String SEARCH_QUERY_STRING = "SELECT * FROM transaction t " +
-            "WHERE t.gateway_account_id = :account_id " +
+    private static final String SEARCH_TRANSACTIONS = "SELECT * FROM transaction t " +
             ":searchExtraFields " +
             "ORDER BY t.created_date DESC OFFSET :offset LIMIT :limit";
 
-    private static final String SEARCH_COUNT_QUERY_STRING = "SELECT count(t.id) " +
+    private static final String COUNT_TRANSACTIONS = "SELECT count(t.id) " +
             "FROM transaction t " +
-            "WHERE t.gateway_account_id = :account_id " +
             ":searchExtraFields ";
 
     private static final String UPSERT_STRING =
@@ -164,7 +164,8 @@ public class TransactionDao {
 
     public List<TransactionEntity> searchTransactions(TransactionSearchParams searchParams) {
         return jdbi.withHandle(handle -> {
-            Query query = getQuery(searchParams, handle, SEARCH_QUERY_STRING);
+            Query query = handle.createQuery(createSearchTemplate(searchParams, SEARCH_TRANSACTIONS));
+            searchParams.getQueryMap().forEach(bindSearchParameter(query));
             return query
                     .map(new TransactionMapper())
                     .list();
@@ -173,18 +174,27 @@ public class TransactionDao {
 
     public Long getTotalForSearch(TransactionSearchParams searchParams) {
         return jdbi.withHandle(handle -> {
-            Query query = getQuery(searchParams, handle, SEARCH_COUNT_QUERY_STRING);
+            Query query = handle.configure(SqlStatements.class, stmts -> stmts.setUnusedBindingAllowed(true))
+                    .createQuery(createSearchTemplate(searchParams, COUNT_TRANSACTIONS));
+            searchParams.getQueryMap().forEach(bindSearchParameter(query));
             return query
                     .mapTo(Long.class)
                     .findOnly();
         });
     }
 
-    private Query getQuery(TransactionSearchParams searchParams, Handle handle, String searchCountQueryString) {
-        String searchExtraFields = searchParams.generateQuery();
-        Query query = handle.createQuery(searchCountQueryString.replace(":searchExtraFields", searchExtraFields));
-        searchParams.getQueryMap().forEach(bindSearchParameter(query));
-        return query;
+    private String createSearchTemplate(
+            TransactionSearchParams searchParams,
+            String baseQueryString
+            ) {
+        String searchClauseTemplate = String.join(" AND ", searchParams.getFilterTemplates());
+        searchClauseTemplate = StringUtils.isNotBlank(searchClauseTemplate) ?
+                "WHERE " + searchClauseTemplate :
+                "";
+
+        return baseQueryString.replace(
+                ":searchExtraFields",
+                searchClauseTemplate);
     }
 
     private BiConsumer<String, Object> bindSearchParameter(Query query) {

--- a/src/main/java/uk/gov/pay/ledger/transaction/model/TransactionSearchResponse.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/model/TransactionSearchResponse.java
@@ -1,6 +1,5 @@
 package uk.gov.pay.ledger.transaction.model;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import uk.gov.pay.ledger.transaction.search.model.PaginationBuilder;
 import uk.gov.pay.ledger.transaction.search.model.TransactionView;
@@ -9,8 +8,6 @@ import java.util.List;
 
 public class TransactionSearchResponse {
 
-    @JsonIgnore
-    private String gatewayExternalId;
     @JsonProperty("total")
     private Long total;
     @JsonProperty("count")
@@ -22,9 +19,8 @@ public class TransactionSearchResponse {
     @JsonProperty("_links")
     private PaginationBuilder paginationBuilder;
 
-    public TransactionSearchResponse(String gatewayExternalId, Long total, Long count, Long page,
+    public TransactionSearchResponse(Long total, Long count, Long page,
                                      List<TransactionView> transactionViewList) {
-        this.gatewayExternalId = gatewayExternalId;
         this.total = total;
         this.count = count;
         this.page = page;
@@ -34,10 +30,6 @@ public class TransactionSearchResponse {
     public TransactionSearchResponse withPaginationBuilder(PaginationBuilder paginationBuilder) {
         this.paginationBuilder = paginationBuilder;
         return this;
-    }
-
-    public String getGatewayExternalId() {
-        return gatewayExternalId;
     }
 
     public Long getTotal() {

--- a/src/main/java/uk/gov/pay/ledger/transaction/search/common/TransactionSearchParams.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/search/common/TransactionSearchParams.java
@@ -21,8 +21,6 @@ public class TransactionSearchParams {
     private static final Logger LOGGER = LoggerFactory.getLogger(TransactionSearchParams.class);
 
     private static final String GATEWAY_ACCOUNT_EXTERNAL_FIELD = "account_id";
-    private static final String OFFSET_FIELD = "offset";
-    private static final String PAGE_SIZE_FIELD = "limit";
     private static final String CARDHOLDER_NAME_FIELD = "cardholder_name";
     private static final String FROM_DATE_FIELD = "from_date";
     private static final String TO_DATE_FIELD = "to_date";
@@ -185,8 +183,6 @@ public class TransactionSearchParams {
     public Map<String, Object> getQueryMap() {
         if (queryMap == null) {
             queryMap = new HashMap<>();
-            queryMap.put(OFFSET_FIELD, getOffset());
-            queryMap.put(PAGE_SIZE_FIELD, displaySize);
 
             if (isNotBlank(accountId)) {
                 queryMap.put(GATEWAY_ACCOUNT_EXTERNAL_FIELD, accountId);
@@ -308,7 +304,7 @@ public class TransactionSearchParams {
         return String.join("&", queries);
     }
 
-    private Long getOffset() {
+    public Long getOffset() {
         Long offset = 0l;
 
         if (pageNumber != null) {

--- a/src/main/java/uk/gov/pay/ledger/transaction/search/common/TransactionSearchParamsValidator.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/search/common/TransactionSearchParamsValidator.java
@@ -1,25 +1,17 @@
 package uk.gov.pay.ledger.transaction.search.common;
 
 import uk.gov.pay.ledger.exception.UnparsableDateException;
-import uk.gov.pay.ledger.exception.ValidationException;
 
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeParseException;
 
-import static java.lang.String.format;
-import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
 public class TransactionSearchParamsValidator {
-
-    private static final String GATEWAY_ACCOUNT_ID = "account_id";
     private static final String FROM_DATE_FIELD = "from_date";
     private static final String TO_DATE_FIELD = "to_date";
 
     public static void validateSearchParams(TransactionSearchParams searchParams) {
-
-        throwIfBlankFieldValue(GATEWAY_ACCOUNT_ID, searchParams.getAccountId());
-
         if (isNotBlank(searchParams.getFromDate())) {
             validateDate(FROM_DATE_FIELD, searchParams.getFromDate());
         }
@@ -34,10 +26,5 @@ public class TransactionSearchParamsValidator {
         } catch (DateTimeParseException e) {
             throw new UnparsableDateException(fieldName, dateToParse);
         }
-    }
-
-    private static void throwIfBlankFieldValue(String fieldName, String value) {
-        if (isBlank(value))
-            throw new ValidationException(format("Field [%s] cannot be empty", fieldName));
     }
 }

--- a/src/main/java/uk/gov/pay/ledger/transaction/search/model/PaginationBuilder.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/search/model/PaginationBuilder.java
@@ -97,7 +97,7 @@ public class PaginationBuilder {
         URI uri = uriInfo.getBaseUriBuilder()
                 .replacePath(uriInfo.getPath())
                 .replaceQuery(queryParams)
-                .build(searchParams.getAccountId());
+                .build();
 
         return uri.toString();
     }

--- a/src/main/java/uk/gov/pay/ledger/transaction/service/AccountIdSupplierManager.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/service/AccountIdSupplierManager.java
@@ -1,7 +1,6 @@
 package uk.gov.pay.ledger.transaction.service;
 
 import uk.gov.pay.ledger.exception.ValidationException;
-import uk.gov.pay.ledger.transaction.search.model.TransactionView;
 
 import java.util.Optional;
 import java.util.function.Function;
@@ -10,36 +9,36 @@ import java.util.function.Supplier;
 import static java.lang.String.format;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 
-public class AccountIdSupplierManager {
+public class AccountIdSupplierManager<T> {
 
     private static final String GATEWAY_ACCOUNT_ID = "account_id";
 
     private final boolean overrideAccountRestriction;
     private final String gatewayAccountId;
 
-    private Supplier<Optional<TransactionView>> privilegedSupplier;
-    private Function<String, Optional<TransactionView>> supplier;
+    private Supplier<T> privilegedSupplier;
+    private Function<String, T> supplier;
 
     public AccountIdSupplierManager(Boolean overrideAccountRestriction, String gatewayAccountId) {
         this.overrideAccountRestriction = Optional.ofNullable(overrideAccountRestriction).orElse(false);
         this.gatewayAccountId = gatewayAccountId;
     }
 
-    public static AccountIdSupplierManager of(Boolean overrideAccountRestriction, String gatewayAccountId) {
-        return new AccountIdSupplierManager(overrideAccountRestriction, gatewayAccountId);
+    public static <U> AccountIdSupplierManager<U> of(Boolean overrideAccountRestriction, String gatewayAccountId) {
+        return new AccountIdSupplierManager<>(overrideAccountRestriction, gatewayAccountId);
     }
 
-    public AccountIdSupplierManager withPrivilegedSupplier(Supplier<Optional<TransactionView>> supplier) {
+    public AccountIdSupplierManager<T> withPrivilegedSupplier(Supplier<T> supplier) {
         this.privilegedSupplier = supplier;
         return this;
     }
 
-    public AccountIdSupplierManager withSupplier(Function<String, Optional<TransactionView>> supplier) {
+    public AccountIdSupplierManager<T> withSupplier(Function<String, T> supplier) {
         this.supplier = supplier;
         return this;
     }
 
-    public Optional<TransactionView> validateAndGet() {
+    public T validateAndGet() {
         if(!overrideAccountRestriction && isBlank(gatewayAccountId)) {
             throw new ValidationException(format("Field [%s] cannot be empty", GATEWAY_ACCOUNT_ID));
         }

--- a/src/test/java/uk/gov/pay/ledger/transaction/search/common/TransactionSearchParamsValidatorTest.java
+++ b/src/test/java/uk/gov/pay/ledger/transaction/search/common/TransactionSearchParamsValidatorTest.java
@@ -17,14 +17,6 @@ public class TransactionSearchParamsValidatorTest {
     @Before
     public void setup(){
         searchParams = new TransactionSearchParams();
-        searchParams.setAccountId("account_id");
-    }
-    @Test
-    public void shouldThrowException_whenAccountIdIsNull() {
-        searchParams.setAccountId(null);
-        thrown.expect(ValidationException.class);
-        thrown.expectMessage("Field [account_id] cannot be empty");
-        TransactionSearchParamsValidator.validateSearchParams(searchParams);
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/ledger/transaction/service/TransactionServiceTest.java
+++ b/src/test/java/uk/gov/pay/ledger/transaction/service/TransactionServiceTest.java
@@ -78,7 +78,6 @@ public class TransactionServiceTest {
         when(mockTransactionDao.searchTransactions(any(TransactionSearchParams.class))).thenReturn(transactionViewList);
         when(mockTransactionDao.getTotalForSearch(any(TransactionSearchParams.class))).thenReturn(5L);
         TransactionSearchResponse transactionSearchResponse = transactionService.searchTransactions(searchParams, mockUriInfo);
-        assertThat(transactionSearchResponse.getGatewayExternalId(), is(gatewayAccountId));
         assertThat(transactionSearchResponse.getPage(), is(1L));
         assertThat(transactionSearchResponse.getCount(), is(5L));
         assertThat(transactionSearchResponse.getTotal(), is(5L));
@@ -94,7 +93,7 @@ public class TransactionServiceTest {
         when(mockTransactionDao.searchTransactions(any(TransactionSearchParams.class))).thenReturn(transactionViewList);
         when(mockTransactionDao.getTotalForSearch(any(TransactionSearchParams.class))).thenReturn(100L);
 
-        TransactionSearchResponse transactionSearchResponse = transactionService.searchTransactions(searchParams, mockUriInfo);
+        TransactionSearchResponse transactionSearchResponse = transactionService.searchTransactions(gatewayAccountId, searchParams, mockUriInfo);
         PaginationBuilder paginationBuilder = transactionSearchResponse.getPaginationBuilder();
 
         assertThat(paginationBuilder.getFirstLink().getHref(), is("http://app.com/v1/transaction?account_id=gateway_account_id&page=1&display_size=10"));


### PR DESCRIPTION
Use the already existing AccountIdSupplierManager to manage access
to transaction search without supplying a gateway account id. This
can be used by internal tools to get cross account data.

I have tried to minimise changes to make it clear what I have done, but
I have also started to move TransactionSearchParams towards a more
flexible structure. I have not over tested the account id override mechanism
as unit tests already exist for that.