### PR TITLE
BAU Make pact data static

### DIFF
--- a/src/test/java/uk/gov/pay/ledger/pact/RefundCreatedByUserEventQueueContractTest.java
+++ b/src/test/java/uk/gov/pay/ledger/pact/RefundCreatedByUserEventQueueContractTest.java
@@ -6,14 +6,15 @@ import au.com.dius.pact.consumer.Pact;
 import au.com.dius.pact.consumer.PactVerification;
 import au.com.dius.pact.model.v3.messaging.MessagePact;
 import com.google.gson.Gson;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-import org.testcontainers.shaded.org.apache.commons.lang.RandomStringUtils;
 import uk.gov.pay.ledger.event.model.ResourceType;
 import uk.gov.pay.ledger.rule.AppWithPostgresAndSqsRule;
 import uk.gov.pay.ledger.rule.SqsTestDocker;
 import uk.gov.pay.ledger.transaction.dao.TransactionDao;
 import uk.gov.pay.ledger.transaction.entity.TransactionEntity;
+import uk.gov.pay.ledger.util.DatabaseTestHelper;
 import uk.gov.pay.ledger.util.fixture.QueueRefundEventFixture;
 
 import java.util.HashMap;
@@ -44,8 +45,13 @@ public class RefundCreatedByUserEventQueueContractTest {
     private QueueRefundEventFixture refundFixture = aQueueRefundEventFixture()
             .withResourceType(ResourceType.REFUND)
             .withEventType("REFUND_CREATED_BY_USER")
-            .withRefundedBy(RandomStringUtils.randomAlphanumeric(14))
+            .withRefundedBy("a_user_id")
             .withDefaultEventDataForEventType("REFUND_CREATED_BY_USER");
+
+    @Before
+    public void setUp() {
+        DatabaseTestHelper.aDatabaseTestHelper(appRule.getJdbi()).truncateAllData();
+    }
 
     @Pact(provider = "connector", consumer = "ledger")
     public MessagePact createRefundCreatedByUserEventPact(MessagePactBuilder builder) {

--- a/src/test/java/uk/gov/pay/ledger/pact/RefundSubmittedEventQueueContractTest.java
+++ b/src/test/java/uk/gov/pay/ledger/pact/RefundSubmittedEventQueueContractTest.java
@@ -5,6 +5,7 @@ import au.com.dius.pact.consumer.MessagePactProviderRule;
 import au.com.dius.pact.consumer.Pact;
 import au.com.dius.pact.consumer.PactVerification;
 import au.com.dius.pact.model.v3.messaging.MessagePact;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import uk.gov.pay.ledger.event.model.ResourceType;
@@ -12,6 +13,7 @@ import uk.gov.pay.ledger.rule.AppWithPostgresAndSqsRule;
 import uk.gov.pay.ledger.rule.SqsTestDocker;
 import uk.gov.pay.ledger.transaction.dao.TransactionDao;
 import uk.gov.pay.ledger.transaction.entity.TransactionEntity;
+import uk.gov.pay.ledger.util.DatabaseTestHelper;
 import uk.gov.pay.ledger.util.fixture.QueueRefundEventFixture;
 
 import java.util.HashMap;
@@ -51,6 +53,11 @@ public class RefundSubmittedEventQueueContractTest {
                 .withMetadata(metadata)
                 .withContent(refundFixture.getAsPact())
                 .toPact();
+    }
+
+    @Before
+    public void setUp() {
+        DatabaseTestHelper.aDatabaseTestHelper(appRule.getJdbi()).truncateAllData();
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/ledger/pact/RefundSucceededEventQueueContractTest.java
+++ b/src/test/java/uk/gov/pay/ledger/pact/RefundSucceededEventQueueContractTest.java
@@ -6,14 +6,15 @@ import au.com.dius.pact.consumer.Pact;
 import au.com.dius.pact.consumer.PactVerification;
 import au.com.dius.pact.consumer.dsl.PactDslJsonBody;
 import au.com.dius.pact.model.v3.messaging.MessagePact;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-import org.testcontainers.shaded.org.apache.commons.lang.RandomStringUtils;
 import uk.gov.pay.ledger.event.model.ResourceType;
 import uk.gov.pay.ledger.rule.AppWithPostgresAndSqsRule;
 import uk.gov.pay.ledger.rule.SqsTestDocker;
 import uk.gov.pay.ledger.transaction.dao.TransactionDao;
 import uk.gov.pay.ledger.transaction.entity.TransactionEntity;
+import uk.gov.pay.ledger.util.DatabaseTestHelper;
 import uk.gov.pay.ledger.util.fixture.QueueRefundEventFixture;
 
 import java.util.HashMap;
@@ -42,8 +43,13 @@ public class RefundSucceededEventQueueContractTest {
     private QueueRefundEventFixture refundFixture = aQueueRefundEventFixture()
             .withResourceType(ResourceType.REFUND)
             .withEventType("REFUND_SUCCEEDED")
-            .withReference(RandomStringUtils.randomAlphanumeric(14))
+            .withReference("a_reference")
             .withDefaultEventDataForEventType("REFUND_SUCCEEDED");
+
+    @Before
+    public void setUp() {
+        DatabaseTestHelper.aDatabaseTestHelper(appRule.getJdbi()).truncateAllData();
+    }
 
     @Pact(provider = "connector", consumer = "ledger")
     public MessagePact createRefundSucceededEventPact(MessagePactBuilder builder) {

--- a/src/test/java/uk/gov/pay/ledger/util/fixture/QueueRefundEventFixture.java
+++ b/src/test/java/uk/gov/pay/ledger/util/fixture/QueueRefundEventFixture.java
@@ -4,11 +4,9 @@ import au.com.dius.pact.consumer.dsl.PactDslJsonBody;
 import com.amazonaws.services.sqs.AmazonSQS;
 import com.google.common.collect.ImmutableMap;
 import com.google.gson.GsonBuilder;
-import org.apache.commons.lang3.RandomStringUtils;
 import uk.gov.pay.ledger.event.model.Event;
 import uk.gov.pay.ledger.event.model.ResourceType;
 
-import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 
 public class QueueRefundEventFixture implements QueueFixture<QueueRefundEventFixture, Event> {
@@ -16,12 +14,12 @@ public class QueueRefundEventFixture implements QueueFixture<QueueRefundEventFix
     private ResourceType resourceType = ResourceType.REFUND;
     private Long amount = 50L;
     private String gatewayAccountId = "123456";
-    private String resourceExternalId = RandomStringUtils.randomAlphanumeric(20);
-    private String parentResourceExternalId = RandomStringUtils.randomAlphanumeric(20);
+    private String resourceExternalId = "resource_external_id";
+    private String parentResourceExternalId = "parentResourceExternalId";
     private ZonedDateTime eventDate = ZonedDateTime.parse("2018-03-12T16:25:01.123456Z");
     private String eventType = "REFUND_CREATED_BY_USER";
     private String eventData = "{\"event_data\": \"event data\"}";
-    private String refundedBy = RandomStringUtils.randomAlphanumeric(20);
+    private String refundedBy = "a_user_id";
     private String reference = null;
 
     private QueueRefundEventFixture() {


### PR DESCRIPTION
Pact detects contract changes based on a hash of the contract content.
Therefore in order for semantically identical contracts not to be considered
different we need to write static data to the contract, rather than random
uuids etc.