### PR TITLE
PP-5537 add hard coded values to some pact tests

### DIFF
--- a/src/test/java/uk/gov/pay/ledger/pact/GetTransactionContractTest.java
+++ b/src/test/java/uk/gov/pay/ledger/pact/GetTransactionContractTest.java
@@ -21,6 +21,7 @@ import uk.gov.pay.ledger.util.DatabaseTestHelper;
 import java.time.ZonedDateTime;
 import java.util.Map;
 
+import static org.junit.platform.commons.util.StringUtils.isBlank;
 import static uk.gov.pay.ledger.util.DatabaseTestHelper.aDatabaseTestHelper;
 import static uk.gov.pay.ledger.util.fixture.TransactionFixture.aTransactionFixture;
 
@@ -103,6 +104,13 @@ public class GetTransactionContractTest {
     public void createTransactionWithFeeAndNetAmount(Map<String, String> params) {
         String transactionExternalId = params.get("charge_id");
         String gatewayAccountId = params.get("account_id");
+
+        if (isBlank(transactionExternalId)) {
+            transactionExternalId = "ch_123abc456xyz";
+        }
+        if (isBlank(gatewayAccountId)) {
+            gatewayAccountId = "123456";
+        }
 
         aTransactionFixture()
                 .withExternalId(transactionExternalId)

--- a/src/test/java/uk/gov/pay/ledger/pact/TransactionEventsApiContractTest.java
+++ b/src/test/java/uk/gov/pay/ledger/pact/TransactionEventsApiContractTest.java
@@ -20,6 +20,7 @@ import uk.gov.pay.ledger.util.DatabaseTestHelper;
 
 import java.util.Map;
 
+import static org.junit.platform.commons.util.StringUtils.isBlank;
 import static uk.gov.pay.ledger.util.DatabaseTestHelper.aDatabaseTestHelper;
 import static uk.gov.pay.ledger.util.fixture.EventFixture.anEventFixture;
 import static uk.gov.pay.ledger.util.fixture.TransactionFixture.aTransactionFixture;
@@ -54,6 +55,13 @@ public class TransactionEventsApiContractTest {
     public void createTransactionWithTwoEvents(Map<String, String> params) {
         String transactionId = params.get("transaction_id");
         String gatewayAccountId = params.get("gateway_account_id");
+
+        if (isBlank(transactionId)) {
+            transactionId = "ch_123abc456xyz";
+        }
+        if (isBlank(gatewayAccountId)) {
+            gatewayAccountId = "123456";
+        }
 
         aTransactionFixture()
                 .withExternalId(transactionId)

--- a/src/test/java/uk/gov/pay/ledger/pact/TransactionsApiContractTest.java
+++ b/src/test/java/uk/gov/pay/ledger/pact/TransactionsApiContractTest.java
@@ -21,6 +21,7 @@ import uk.gov.pay.ledger.util.DatabaseTestHelper;
 import java.time.ZonedDateTime;
 import java.util.Map;
 
+import static org.junit.platform.commons.util.StringUtils.isBlank;
 import static uk.gov.pay.ledger.util.DatabaseTestHelper.aDatabaseTestHelper;
 import static uk.gov.pay.ledger.util.fixture.TransactionFixture.aTransactionFixture;
 
@@ -108,6 +109,10 @@ public class TransactionsApiContractTest {
         String transactionExternalId1 = "someExternalId1";
         String transactionExternalId2 = "someExternalId2";
         String gatewayAccountId = params.get("gateway_account_id");
+
+        if (isBlank(gatewayAccountId)) {
+            gatewayAccountId = "123456";
+        }
 
         createPaymentTransaction(transactionExternalId1, gatewayAccountId);
         createPaymentTransaction(transactionExternalId2, gatewayAccountId);


### PR DESCRIPTION
## WHAT
- pact-js is not yet generating providerStates and thus we cannot pass params to be used on the provider side.