### PR TITLE
PP-5520 Use full thread pool for managed message receiver

### DIFF
--- a/src/main/java/uk/gov/pay/ledger/queue/managed/QueueMessageReceiver.java
+++ b/src/main/java/uk/gov/pay/ledger/queue/managed/QueueMessageReceiver.java
@@ -18,6 +18,8 @@ public class QueueMessageReceiver implements Managed {
     private static final Logger LOGGER = LoggerFactory.getLogger(QueueMessageReceiver.class);
     private final QueueMessageReceiverConfig config;
 
+    private final int queueReadScheduleNumberOfThreads;
+
     private ScheduledExecutorService scheduledExecutorService;
     private EventMessageHandler eventMessageHandler;
 
@@ -28,8 +30,7 @@ public class QueueMessageReceiver implements Managed {
             EventMessageHandler eventMessageHandler) {
         this.eventMessageHandler = eventMessageHandler;
         this.config = configuration.getQueueMessageReceiverConfig();
-
-        int queueReadScheduleNumberOfThreads = config.getNumberOfThreads();
+        this.queueReadScheduleNumberOfThreads = config.getNumberOfThreads();
 
         scheduledExecutorService = environment
                 .lifecycle()
@@ -43,12 +44,14 @@ public class QueueMessageReceiver implements Managed {
         long initialDelay = config.getThreadDelayInMilliseconds();
         long delay = config.getThreadDelayInMilliseconds();
 
-        scheduledExecutorService.scheduleWithFixedDelay(
-                this::receive,
-                initialDelay,
-                delay,
-                TimeUnit.MILLISECONDS
-        );
+        for(int i = 0; i < queueReadScheduleNumberOfThreads; i++) {
+            scheduledExecutorService.scheduleWithFixedDelay(
+                    this::receive,
+                    initialDelay,
+                    delay,
+                    TimeUnit.MILLISECONDS
+            );
+        }
     }
 
     private void receive() {


### PR DESCRIPTION
* thread pool size is currently specified with an environment variable,
currently only one thread is executed on the pool
* execute up to the total specified number of threads on @Override
start()

Relates to https://github.com/alphagov/pay-connector/pull/1641