### PR TITLE
PP-5441 Wait for the database to be available on startup

### DIFF
--- a/docker-startup.sh
+++ b/docker-startup.sh
@@ -15,7 +15,7 @@ if [ -n "${CERTS_PATH:-}" ]; then
   done
 fi
 
-#java $JAVA_OPTS -jar *-allinone.jar waitOnDependencies *.yaml
+java $JAVA_OPTS -jar *-allinone.jar waitOnDependencies *.yaml
 
 if [ "$RUN_MIGRATION" == "true" ]; then
   java $JAVA_OPTS -jar *-allinone.jar db migrate *.yaml

--- a/src/main/java/uk/gov/pay/ledger/app/LedgerApp.java
+++ b/src/main/java/uk/gov/pay/ledger/app/LedgerApp.java
@@ -15,6 +15,7 @@ import org.jdbi.v3.core.Jdbi;
 import uk.gov.pay.commons.utils.logging.LoggingFilter;
 import uk.gov.pay.ledger.event.resource.EventResource;
 import uk.gov.pay.ledger.exception.BadRequestExceptionMapper;
+import uk.gov.pay.ledger.healthcheck.DependentResourceWaitCommand;
 import uk.gov.pay.ledger.healthcheck.HealthCheckResource;
 import uk.gov.pay.ledger.healthcheck.SQSHealthCheck;
 import uk.gov.pay.ledger.queue.managed.QueueMessageReceiver;
@@ -44,6 +45,7 @@ public class LedgerApp extends Application<LedgerConfig> {
         });
 
         bootstrap.addBundle(new JdbiExceptionsBundle());
+        bootstrap.addCommand(new DependentResourceWaitCommand());
     }
 
     @Override

--- a/src/main/java/uk/gov/pay/ledger/healthcheck/DependentResourceWaitCommand.java
+++ b/src/main/java/uk/gov/pay/ledger/healthcheck/DependentResourceWaitCommand.java
@@ -1,0 +1,27 @@
+package uk.gov.pay.ledger.healthcheck;
+
+import io.dropwizard.cli.ConfiguredCommand;
+import io.dropwizard.setup.Bootstrap;
+import net.sourceforge.argparse4j.inf.Namespace;
+import net.sourceforge.argparse4j.inf.Subparser;
+
+import uk.gov.pay.commons.utils.startup.ApplicationStartupDependentResourceChecker;
+import uk.gov.pay.commons.utils.startup.DatabaseStartupResource;
+import uk.gov.pay.ledger.app.LedgerConfig;
+
+public class DependentResourceWaitCommand extends ConfiguredCommand<LedgerConfig> {
+    public DependentResourceWaitCommand() {
+        super("waitOnDependencies", "Waits for dependent resources to become available");
+    }
+
+    @Override
+    public void configure(Subparser subparser) {
+        super.configure(subparser);
+    }
+
+    @Override
+    protected void run(Bootstrap<LedgerConfig> bs, Namespace ns, LedgerConfig conf) {
+        new ApplicationStartupDependentResourceChecker(new DatabaseStartupResource(conf.getDataSourceFactory()))
+                .checkAndWaitForResource();
+    }
+}


### PR DESCRIPTION
Pinch code from pay-products to add a Dropwizard command 'waitOnDependencies'
which will poll the configured database connection until it connects
successfully

Call this from docker-startup.sh so that we don't fail on startup if the
database is temporarily unavailable (e.g. during end to end test runs)