### PR TITLE
PP-5389 Use COUNT(1) in favour of ID

### DIFF
--- a/src/main/java/uk/gov/pay/ledger/transaction/dao/TransactionDao.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/dao/TransactionDao.java
@@ -37,7 +37,7 @@ public class TransactionDao {
             ":searchExtraFields " +
             "ORDER BY t.created_date DESC OFFSET :offset LIMIT :limit";
 
-    private static final String COUNT_TRANSACTIONS = "SELECT count(t.id) " +
+    private static final String COUNT_TRANSACTIONS = "SELECT count(1) " +
             "FROM transaction t " +
             ":searchExtraFields ";
 


### PR DESCRIPTION
* this query is order of magnitudes faster than using a full ID for
count
* numbers to follow

`explain analyse select count(1) from transaction where  type= 'PAYMENT';`

>  QUERY PLAN
>----------------------------------------------
> Finalize Aggregate  (cost=381830.39..381830.40 rows=1 width=8) (actual time=833.308..833.308 rows=1 loops=1)
   ->  Gather  (cost=381830.18..381830.39 rows=2 width=8) (actual time=832.376..833.903 rows=3 loops=1)
         Workers Planned: 2
         Workers Launched: 2
         ->  Partial Aggregate  (cost=380830.18..380830.19 rows=1 width=8) (actual time=827.315..827.316 rows=1 loops=3)
               ->  Parallel Index Only Scan using transaction_type_idx on transaction  (cost=0.43..374593.98 rows=2494478 width=0) (actual time=0.023..588.446 rows=1995486 loops=3)
                     Index Cond: (type = 'PAYMENT'::transaction_type)
                     Heap Fetches: 886784
 Planning Time: 0.073 ms
 Execution Time: 833.939 ms
(10 rows)


`ledger=> explain analyse select count(id) from transaction where  type= 'PAYMENT';`
>  QUERY PLAN
> -----------------------------------------------
> Finalize Aggregate  (cost=969414.56..969414.57 rows=1 width=8) (actual time=41667.374..41667.374 rows=1 loops=1)
   ->  Gather  (cost=969414.35..969414.56 rows=2 width=8) (actual time=41667.102..41668.588 rows=3 loops=1)
         Workers Planned: 2
         Workers Launched: 2
         ->  Partial Aggregate  (cost=968414.35..968414.36 rows=1 width=8) (actual time=41664.936..41664.937 rows=1 loops=3)
               ->  Parallel Seq Scan on transaction  (cost=0.00..962178.15 rows=2494478 width=8) (actual time=1.129..41480.565 rows=1995488 loops=3)
                     Filter: (type = 'PAYMENT'::transaction_type)
                     Rows Removed by Filter: 28116
 Planning Time: 0.077 ms
 Execution Time: 41668.622 ms
(10 rows)



with @kbottla 

