### PR TITLE
PP-5559: don't include empty parameters in query parameters or db query

### DIFF
--- a/src/main/java/uk/gov/pay/ledger/transaction/search/common/TransactionSearchParams.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/search/common/TransactionSearchParams.java
@@ -152,10 +152,10 @@ public class TransactionSearchParams {
         if (isNotBlank(cardHolderName)) {
             filters.add(" t.cardholder_name ILIKE :" + CARDHOLDER_NAME_FIELD);
         }
-        if (fromDate != null) {
+        if (isNotBlank(fromDate)) {
             filters.add(" t.created_date > :" + FROM_DATE_FIELD);
         }
-        if (toDate != null) {
+        if (isNotBlank(toDate)) {
             filters.add(" t.created_date < :" + TO_DATE_FIELD);
         }
         if (isSet(paymentStates) || isSet(refundStates)) {
@@ -194,13 +194,13 @@ public class TransactionSearchParams {
             if (isNotBlank(reference)) {
                 queryMap.put(REFERENCE_FIELD, likeClause(reference));
             }
-            if (cardHolderName != null) {
+            if (isNotBlank(cardHolderName)) {
                 queryMap.put(CARDHOLDER_NAME_FIELD, likeClause(cardHolderName));
             }
-            if (fromDate != null) {
+            if (isNotBlank(fromDate)) {
                 queryMap.put(FROM_DATE_FIELD, ZonedDateTime.parse(fromDate));
             }
-            if (toDate != null) {
+            if (isNotBlank(toDate)) {
                 queryMap.put(TO_DATE_FIELD, ZonedDateTime.parse(toDate));
             }
             if (isNotBlank(state)) {
@@ -257,13 +257,13 @@ public class TransactionSearchParams {
     public String buildQueryParamString(Long forPage) {
         List<String> queries = new ArrayList<>();
 
-        if (accountId != null) {
+        if (isNotBlank(accountId)) {
             queries.add(GATEWAY_ACCOUNT_EXTERNAL_FIELD + "=" + accountId);
         }
-        if (fromDate != null) {
+        if (isNotBlank(fromDate)) {
             queries.add(FROM_DATE_FIELD + "=" + fromDate);
         }
-        if (toDate != null) {
+        if (isNotBlank(toDate)) {
             queries.add(TO_DATE_FIELD + "=" + toDate);
         }
 

--- a/src/test/java/uk/gov/pay/ledger/transaction/search/common/TransactionSearchParamsTest.java
+++ b/src/test/java/uk/gov/pay/ledger/transaction/search/common/TransactionSearchParamsTest.java
@@ -1,0 +1,118 @@
+package uk.gov.pay.ledger.transaction.search.common;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+
+public class TransactionSearchParamsTest {
+
+    private TransactionSearchParams transactionSearchParams;
+
+    @Before
+    public void setUp() {
+        transactionSearchParams = new TransactionSearchParams();
+    }
+
+    @Test
+    public void getsEmptyFilterTemplateWhenEmptyFromDate() {
+        transactionSearchParams.setFromDate("");
+        assertThat(transactionSearchParams.getFilterTemplates().size(), is(0));
+    }
+
+    @Test
+    public void getsFilterTemplateWhenValidFromDate() {
+        transactionSearchParams.setFromDate("2018-09-22T10:14:16.067Z");
+        assertThat(transactionSearchParams.getFilterTemplates().get(0), is(" t.created_date > :from_date"));
+    }
+
+    @Test
+    public void getsEmptyFilterTemplateWhenEmptyToDate() {
+        transactionSearchParams.setToDate("");
+        assertThat(transactionSearchParams.getFilterTemplates().size(), is(0));
+    }
+
+    @Test
+    public void getsFilterTemplateWhenValidToDate() {
+        transactionSearchParams.setToDate("2018-09-22T10:14:16.067Z");
+        assertThat(transactionSearchParams.getFilterTemplates().get(0), is(" t.created_date < :to_date"));
+    }
+
+    @Test
+    public void getsEmptyQueryMapWhenEmptyCardHolderName() {
+        transactionSearchParams.setCardHolderName("");
+        assertThat(transactionSearchParams.getQueryMap().size(), is(0));
+    }
+
+    @Test
+    public void getsQueryMapWhenNotEmptyCardHolderName() {
+        transactionSearchParams.setCardHolderName("Jan Kowalski");
+        assertThat(transactionSearchParams.getQueryMap().size(), is(1));
+        assertThat(transactionSearchParams.getQueryMap().get("cardholder_name"), is("%Jan Kowalski%"));
+    }
+
+    @Test
+    public void getsEmptyQueryMapWhenEmptyFromDate() {
+        transactionSearchParams.setFromDate("");
+        assertThat(transactionSearchParams.getQueryMap().size(), is(0));
+    }
+
+    @Test
+    public void getsQueryMapWhenValidFromDate() {
+        transactionSearchParams.setFromDate("2018-09-22T10:14:16.067Z");
+        assertThat(transactionSearchParams.getQueryMap().size(), is(1));
+        assertThat(transactionSearchParams.getQueryMap().get("from_date").toString(), is("2018-09-22T10:14:16.067Z"));
+    }
+
+    @Test
+    public void getsEmptyQueryMapWhenEmptyToDate() {
+        transactionSearchParams.setToDate("");
+        assertThat(transactionSearchParams.getQueryMap().size(), is(0));
+    }
+
+    @Test
+    public void getsQueryMapWhenValidToDate() {
+        transactionSearchParams.setToDate("2018-09-22T10:14:16.067Z");
+        assertThat(transactionSearchParams.getQueryMap().size(), is(1));
+        assertThat(transactionSearchParams.getQueryMap().get("to_date").toString(), is("2018-09-22T10:14:16.067Z"));
+    }
+
+    @Test
+    public void getsEmptyQueryParamStringWhenEmptyAccountId() {
+        transactionSearchParams.setAccountId("");
+        assertThat(transactionSearchParams.buildQueryParamString(1L), not(containsString("account_id")));
+    }
+
+    @Test
+    public void getsQueryParamStringWhenNotEmptyAccountId() {
+        transactionSearchParams.setAccountId("xyz");
+        assertThat(transactionSearchParams.buildQueryParamString(1L), containsString("account_id=xyz"));
+    }
+
+    @Test
+    public void getsEmptyQueryParamStringWhenEmptyFromDate() {
+        transactionSearchParams.setFromDate("");
+        assertThat(transactionSearchParams.buildQueryParamString(1L), not(containsString("from_date")));
+    }
+
+    @Test
+    public void getsQueryParamStringWhenNotEmptyFromDate() {
+        transactionSearchParams.setFromDate("2018-09-22T10:14:16.067Z");
+        assertThat(transactionSearchParams.buildQueryParamString(1L), containsString("from_date=2018-09-22T10:14:16.067Z"));
+    }
+
+    @Test
+    public void getsEmptyQueryParamStringWhenEmptyToDate() {
+        transactionSearchParams.setToDate("");
+        assertThat(transactionSearchParams.buildQueryParamString(1L), not(containsString("to_date")));
+    }
+
+    @Test
+    public void getsQueryParamStringWhenNotEmptyToDate() {
+        transactionSearchParams.setToDate("2018-09-22T10:14:16.067Z");
+        assertThat(transactionSearchParams.buildQueryParamString(1L), containsString("to_date=2018-09-22T10:14:16.067Z"));
+    }
+}


### PR DESCRIPTION
* changed null check to `isNotBlank` in `TransactionSearchParams` for:
** buildQueryParamString
** getFilterTemplates
** getQueryMap
* added unit tests to cover the changes