### PR TITLE
PP-5389 Index for transaction `reference` column

### DIFF
--- a/src/main/resources/migrations/00023_index_transaction_lower_reference.sql
+++ b/src/main/resources/migrations/00023_index_transaction_lower_reference.sql
@@ -1,0 +1,5 @@
+--liquibase formatted sql
+
+--changeset uk.gov.pay:index_transaction_lower_reference runInTransaction:false
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS transaction_lower_reference_idx ON transaction USING btree(lower(reference));


### PR DESCRIPTION
## WHAT
- `Reference` is used by all dependent services to search transaction (publicapi, selfservice, toolbox)