### PR TITLE
PP-5389 Gin index for `cardholder_name`

### DIFF
--- a/src/main/resources/migrations/00024_index_transaction_lower_cardholder_name.sql
+++ b/src/main/resources/migrations/00024_index_transaction_lower_cardholder_name.sql
@@ -1,0 +1,5 @@
+--liquibase formatted sql
+
+--changeset uk.gov.pay:index_transaction_lower_cardholder_name runInTransaction:false
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS transaction_lower_cardholder_name_idx ON transaction USING GIN (lower(cardholder_name) gin_trgm_ops);

--- a/src/test/java/uk/gov/pay/ledger/rule/PostgresTestDocker.java
+++ b/src/test/java/uk/gov/pay/ledger/rule/PostgresTestDocker.java
@@ -48,6 +48,7 @@ public class PostgresTestDocker {
         try (Connection connection = getConnection(getConnectionUrl(), dbUser, getDbPassword())) {
             connection.createStatement().execute("CREATE DATABASE " + dbName + " WITH owner=" + dbUser + " TEMPLATE postgres");
             connection.createStatement().execute("GRANT ALL PRIVILEGES ON DATABASE " + dbName + " TO " + dbUser);
+            connection.createStatement().execute("CREATE EXTENSION IF NOT EXISTS pg_trgm");
         } catch (SQLException e) {
             throw new RuntimeException(e);
         }


### PR DESCRIPTION
## WHAT

- Creates Gin index to be able to search cardholder_name using partial strings.
- Creates required extension for Gin indexes in postgres used for testing