### PR TITLE
PP-5389 Index for transation `gateway_transaction_id`

### DIFF
--- a/src/main/resources/migrations/00026_index_transaction_gateway_transaction_id.sql
+++ b/src/main/resources/migrations/00026_index_transaction_gateway_transaction_id.sql
@@ -1,0 +1,5 @@
+--liquibase formatted sql
+
+--changeset uk.gov.pay:index_transaction_gateway_transaction_id runInTransaction:false
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS transaction_gateway_transaction_id_idx ON transaction USING btree(gateway_transaction_id);


### PR DESCRIPTION
## WHAT
- `Gateway_transaction_id` is not directly used to search payments (via selfservice/publicapi) but index on it will be useful if a service sends us queries with gateway_transaction_id as reference