### PR TITLE
Minor cleanups

### DIFF
--- a/src/main/java/uk/gov/pay/ledger/app/LedgerConfig.java
+++ b/src/main/java/uk/gov/pay/ledger/app/LedgerConfig.java
@@ -5,7 +5,6 @@ import io.dropwizard.Configuration;
 import io.dropwizard.db.DataSourceFactory;
 import uk.gov.pay.ledger.app.config.QueueMessageReceiverConfig;
 import uk.gov.pay.ledger.app.config.SqsConfig;
-import uk.gov.pay.ledger.queue.managed.QueueMessageReceiver;
 
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;

--- a/src/main/java/uk/gov/pay/ledger/healthcheck/SQSHealthCheck.java
+++ b/src/main/java/uk/gov/pay/ledger/healthcheck/SQSHealthCheck.java
@@ -2,7 +2,6 @@ package uk.gov.pay.ledger.healthcheck;
 
 import com.amazonaws.SdkClientException;
 import com.amazonaws.services.sqs.AmazonSQS;
-import com.amazonaws.services.sqs.model.AmazonSQSException;
 import com.amazonaws.services.sqs.model.GetQueueAttributesRequest;
 import com.codahale.metrics.health.HealthCheck;
 import com.google.inject.Inject;

--- a/src/main/java/uk/gov/pay/ledger/queue/QueueMessage.java
+++ b/src/main/java/uk/gov/pay/ledger/queue/QueueMessage.java
@@ -24,12 +24,10 @@ public class QueueMessage {
 
     public static List<QueueMessage> of(ReceiveMessageResult receiveMessageResult) {
 
-        List<QueueMessage> queueMessage = receiveMessageResult.getMessages()
+        return receiveMessageResult.getMessages()
                 .stream()
                 .map(c -> new QueueMessage(c.getMessageId(), c.getReceiptHandle(), c.getBody()))
                 .collect(Collectors.toList());
-
-        return queueMessage;
     }
 
     public static QueueMessage of(SendMessageResult messageResult, String validJsonMessage) {

--- a/src/main/java/uk/gov/pay/ledger/queue/managed/QueueMessageReceiver.java
+++ b/src/main/java/uk/gov/pay/ledger/queue/managed/QueueMessageReceiver.java
@@ -59,7 +59,7 @@ public class QueueMessageReceiver implements Managed {
         try {
             eventMessageHandler.handle();
         } catch (Exception e) {
-            LOGGER.error("Queue message receiver thread exception [{}]", e);
+            LOGGER.error("Queue message receiver thread exception", e);
         }
     }
 

--- a/src/main/java/uk/gov/pay/ledger/transaction/search/common/TransactionSearchParams.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/search/common/TransactionSearchParams.java
@@ -305,7 +305,7 @@ public class TransactionSearchParams {
     }
 
     public Long getOffset() {
-        Long offset = 0l;
+        Long offset = 0L;
 
         if (pageNumber != null) {
             offset = (pageNumber - 1) * getDisplaySize();

--- a/src/test/java/uk/gov/pay/ledger/event/dao/EventDaoIT.java
+++ b/src/test/java/uk/gov/pay/ledger/event/dao/EventDaoIT.java
@@ -84,7 +84,7 @@ public class EventDaoIT {
     }
 
     @Test
-    public void shouldInsertDuplicateEventWithDifferentTimestamp() throws IOException {
+    public void shouldInsertDuplicateEventWithDifferentTimestamp() {
         Event event = anEventFixture()
                 .insert(rule.getJdbi())
                 .toEntity();

--- a/src/test/java/uk/gov/pay/ledger/pact/CaptureConfirmedEventQueueContractTest.java
+++ b/src/test/java/uk/gov/pay/ledger/pact/CaptureConfirmedEventQueueContractTest.java
@@ -25,7 +25,6 @@ import java.util.concurrent.TimeUnit;
 
 import static io.dropwizard.testing.ConfigOverride.config;
 import static org.awaitility.Awaitility.await;
-import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 

--- a/src/test/java/uk/gov/pay/ledger/transaction/dao/TransactionDaoSearchIT.java
+++ b/src/test/java/uk/gov/pay/ledger/transaction/dao/TransactionDaoSearchIT.java
@@ -128,7 +128,7 @@ public class TransactionDaoSearchIT {
 
         for (int i = 0; i < 2; i++) {
             aTransactionFixture()
-                    .withAmount(100l + i)
+                    .withAmount(100L + i)
                     .withGatewayAccountId(gatewayAccountId)
                     .withReference("reference " + i)
                     .withDescription("description " + i)
@@ -235,7 +235,7 @@ public class TransactionDaoSearchIT {
 
         TransactionSearchParams searchParams = new TransactionSearchParams();
         searchParams.setAccountId(gatewayAccountId);
-        searchParams.setDisplaySize(10l);
+        searchParams.setDisplaySize(10L);
 
         List<TransactionEntity> transactionList = transactionDao.searchTransactions(searchParams);
 
@@ -260,8 +260,8 @@ public class TransactionDaoSearchIT {
 
         TransactionSearchParams searchParams = new TransactionSearchParams();
         searchParams.setAccountId(gatewayAccountId);
-        searchParams.setDisplaySize(2l);
-        searchParams.setPageNumber(3l);
+        searchParams.setDisplaySize(2L);
+        searchParams.setPageNumber(3L);
 
 
         List<TransactionEntity> transactionList = transactionDao.searchTransactions(searchParams);

--- a/src/test/java/uk/gov/pay/ledger/transaction/search/common/TransactionSearchParamsValidatorTest.java
+++ b/src/test/java/uk/gov/pay/ledger/transaction/search/common/TransactionSearchParamsValidatorTest.java
@@ -5,7 +5,6 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import uk.gov.pay.ledger.exception.UnparsableDateException;
-import uk.gov.pay.ledger.exception.ValidationException;
 
 public class TransactionSearchParamsValidatorTest {
 

--- a/src/test/java/uk/gov/pay/ledger/transaction/service/TransactionServiceTest.java
+++ b/src/test/java/uk/gov/pay/ledger/transaction/service/TransactionServiceTest.java
@@ -87,8 +87,8 @@ public class TransactionServiceTest {
     public void shouldListTransactionsWithAllPaginationLinks() {
         List<TransactionEntity> transactionViewList = TransactionFixture
                 .aTransactionList(gatewayAccountId, 100);
-        searchParams.setPageNumber(3l);
-        searchParams.setDisplaySize(10l);
+        searchParams.setPageNumber(3L);
+        searchParams.setDisplaySize(10L);
         when(mockTransactionDao.searchTransactions(any(TransactionSearchParams.class))).thenReturn(transactionViewList);
         when(mockTransactionDao.getTotalForSearch(any(TransactionSearchParams.class))).thenReturn(100L);
 

--- a/src/test/java/uk/gov/pay/ledger/transaction/service/TransactionServiceTest.java
+++ b/src/test/java/uk/gov/pay/ledger/transaction/service/TransactionServiceTest.java
@@ -37,7 +37,6 @@ import java.util.Map;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;

--- a/src/test/java/uk/gov/pay/ledger/util/fixture/QueuePaymentEventFixture.java
+++ b/src/test/java/uk/gov/pay/ledger/util/fixture/QueuePaymentEventFixture.java
@@ -10,7 +10,6 @@ import org.apache.commons.lang3.StringUtils;
 import uk.gov.pay.ledger.event.model.Event;
 import uk.gov.pay.ledger.event.model.ResourceType;
 
-import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 
 public class QueuePaymentEventFixture implements QueueFixture<QueuePaymentEventFixture, Event> {


### PR DESCRIPTION
Clean up `import`s, remove unused `throws` clauses and normalise long literals.

Also, fix up a log format error in `QueueMessageReceiver`