### PR TITLE
PP-5605: fix mapping between event type and external state

### DIFF
--- a/src/main/java/uk/gov/pay/ledger/transaction/state/TransactionState.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/state/TransactionState.java
@@ -80,7 +80,7 @@ public enum TransactionState {
                     Map.entry(SalientEventType.AUTHORISATION_SUCCESSFUL, SUBMITTED),
                     Map.entry(SalientEventType.AUTHORISATION_REJECTED, FAILED_REJECTED),
                     Map.entry(SalientEventType.AUTHORISATION_SUCCEEDED, SUBMITTED),
-                    Map.entry(SalientEventType.AUTHORISATION_CANCELLED, FAILED_CANCELLED),
+                    Map.entry(SalientEventType.AUTHORISATION_CANCELLED, FAILED_REJECTED),
                     Map.entry(SalientEventType.GATEWAY_ERROR_DURING_AUTHORISATION, ERROR_GATEWAY),
                     Map.entry(SalientEventType.GATEWAY_TIMEOUT_DURING_AUTHORISATION, ERROR_GATEWAY),
                     Map.entry(SalientEventType.UNEXPECTED_GATEWAY_ERROR_DURING_AUTHORISATION, ERROR_GATEWAY),


### PR DESCRIPTION
* fix map for AUTHORISATION_CANCELLED from FAILED_CANCELLED to FAILED_REJECTED (same as in connector)
https://github.com/alphagov/pay-connector/blob/master/src/main/java/uk/gov/pay/connector/charge/model/domain/ChargeStatus.java#L36