### PR TITLE
PP-5637 Multicolumn index on gateway_account_id and type

### DIFF
--- a/src/main/resources/migrations/00028_multicolumn_index_transaction_gateway_account_id_and_type.sql
+++ b/src/main/resources/migrations/00028_multicolumn_index_transaction_gateway_account_id_and_type.sql
@@ -1,0 +1,5 @@
+--liquibase formatted sql
+
+--changeset uk.gov.pay:multicolumn_index_transaction_gateway_account_id_and_type runInTransaction:false
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS transaction_gateway_account_id_and_type_idx ON transaction USING btree(gateway_account_id, type);


### PR DESCRIPTION
## WHAT 

- Creates multicolumn index on `gateway_account_id` and `type` as  postgres doesn't use index on `gateway_account_id` sometimes.

1. Query by just gateway_account_id uses index (explain analyse select count(1) from transaction where gateway_account_id = '32';

**QUERY PLAN**
```
 Finalize Aggregate  (cost=346990.06..346990.07 rows=1 width=8) (actual time=250.628..250.628 rows=1 loops=1)
   ->  Gather  (cost=346989.85..346990.06 rows=2 width=8) (actual time=250.537..252.330 rows=3 loops=1)
         Workers Planned: 2
         Workers Launched: 2
         ->  Partial Aggregate  (cost=345989.85..345989.86 rows=1 width=8) (actual time=248.532..248.532 rows=1 loops=3)
               ->  Parallel Index Only Scan using transaction_gateway_account_id_idx on transaction  (cost=0.43..343500.43 rows=995768 width=0) (actual time=0.169..190.739 rows=795256 loops=3)
                     Index Cond: (gateway_account_id = '32'::text)
                     Heap Fetches: 165287
 Planning Time: 0.102 ms
 Execution Time: 252.369 ms
```

2. But when `type` is added (explain analyse select count(1) from transaction where gateway_account_id = '32' and type = 'PAYMENT';) falls back to using sequential scan

**QUERY PLAN**
```
 Finalize Aggregate  (cost=1015184.63..1015184.64 rows=1 width=8) (actual time=1434.213..1434.213 rows=1 loops=1)
   ->  Gather  (cost=1015184.42..1015184.63 rows=2 width=8) (actual time=1434.126..1435.555 rows=3 loops=1)
         Workers Planned: 2
         Workers Launched: 2
         ->  Partial Aggregate  (cost=1014184.42..1014184.43 rows=1 width=8) (actual time=1432.092..1432.092 rows=1 loops=3)
               ->  Parallel Seq Scan on transaction  (cost=0.00..1011730.10 rows=981728 width=0) (actual time=0.010..1376.063 rows=795259 loops=3)
                     Filter: (((gateway_account_id)::text = '32'::text) AND (type = 'PAYMENT'::transaction_type))
                     Rows Removed by Filter: 1326297
 Planning Time: 0.104 ms
 Execution Time: 1435.588 ms
```

3. Having multi column index improves performance as index is used (explain analyse select count(1) from transaction where gateway_account_id = '32' and type = 'PAYMENT';)

**QUERY PLAN**
```
 Finalize Aggregate  (cost=270722.73..270722.74 rows=1 width=8) (actual time=212.599..212.600 rows=1 loops=1)
   ->  Gather  (cost=270722.51..270722.72 rows=2 width=8) (actual time=212.466..213.733 rows=3 loops=1)
         Workers Planned: 2
         Workers Launched: 2
         ->  Partial Aggregate  (cost=269722.51..269722.52 rows=1 width=8) (actual time=210.261..210.262 rows=1 loops=3)
               ->  Parallel Index Only Scan using acct_type on transaction  (cost=0.43..267269.08 rows=981372 width=0) (actual time=0.031..157.748 rows=795144 loops=3)
                     Index Cond: ((gateway_account_id = '32'::text) AND (type = 'PAYMENT'::transaction_type))
                     Heap Fetches: 136033
 Planning Time: 0.333 ms
 Execution Time: 213.767 ms
```