### PR TITLE
PP-5637 Search transaction by status version

### DIFF
--- a/src/main/java/uk/gov/pay/ledger/transaction/service/TransactionService.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/service/TransactionService.java
@@ -96,7 +96,7 @@ public class TransactionService {
         PaginationBuilder paginationBuilder = new PaginationBuilder(searchParams, uriInfo);
         paginationBuilder = paginationBuilder.withTotalCount(total).buildResponse();
 
-        List<TransactionView> transactionViewList = mapToTransactionViewList(transactionList);
+        List<TransactionView> transactionViewList = mapToTransactionViewList(transactionList, searchParams.getStatusVersion());
 
         return new TransactionSearchResponse(
                 total,
@@ -106,9 +106,9 @@ public class TransactionService {
         ).withPaginationBuilder(paginationBuilder);
     }
 
-    private List<TransactionView> mapToTransactionViewList(List<Transaction> transactionList) {
+    private List<TransactionView> mapToTransactionViewList(List<Transaction> transactionList, int statusVersion) {
         return transactionList.stream()
-                .map(transaction -> TransactionView.from(transaction, DEFAULT_STATUS_VERSION))
+                .map(transaction -> TransactionView.from(transaction, statusVersion))
                 .collect(Collectors.toList());
     }
     // @TODO(sfount) handling writing invalid transaction should be tested at `EventMessageHandler` integration level

--- a/src/main/java/uk/gov/pay/ledger/transaction/state/TransactionState.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/state/TransactionState.java
@@ -128,4 +128,10 @@ public enum TransactionState {
                 .filter(v -> v.getStatus().equals(status))
                 .collect(Collectors.toList());
     }
+
+    public static List<TransactionState> getStatesForOldStatus(String status) {
+        return stream(values())
+                .filter(v -> v.getOldStatus().equals(status))
+                .collect(Collectors.toList());
+    }
 }

--- a/src/test/java/uk/gov/pay/ledger/transaction/resource/TransactionResourceIT.java
+++ b/src/test/java/uk/gov/pay/ledger/transaction/resource/TransactionResourceIT.java
@@ -326,6 +326,47 @@ public class TransactionResourceIT {
     }
 
     @Test
+    public void shouldSearchTransactionCorrectlyByStateAndStatusVersion1() {
+        TransactionFixture submittedPayment = aTransactionFixture()
+                .withState(TransactionState.FAILED_REJECTED)
+                .insert(rule.getJdbi());
+
+        given().port(port)
+                .contentType(JSON)
+                .get("/v1/transaction?" +
+                        "account_id=" + submittedPayment.getGatewayAccountId() +
+                        "&state=failed" +
+                        "&status_version=1"
+                )
+                .then()
+                .statusCode(Response.Status.OK.getStatusCode())
+                .contentType(JSON)
+                .body("count", is(1))
+                .body("results[0].transaction_id", is(submittedPayment.getExternalId()))
+                .body("results[0].state.status", is("failed"));
+    }
+
+    @Test
+    public void shouldSearchTransactionCorrectlyByStateWithDefaultStatusVersion2() {
+        TransactionFixture submittedPayment = aTransactionFixture()
+                .withState(TransactionState.FAILED_REJECTED)
+                .insert(rule.getJdbi());
+
+        given().port(port)
+                .contentType(JSON)
+                .get("/v1/transaction?" +
+                        "account_id=" + submittedPayment.getGatewayAccountId() +
+                        "&state=declined"
+                )
+                .then()
+                .statusCode(Response.Status.OK.getStatusCode())
+                .contentType(JSON)
+                .body("count", is(1))
+                .body("results[0].transaction_id", is(submittedPayment.getExternalId()))
+                .body("results[0].state.status", is("declined"));
+    }
+
+    @Test
     public void shouldSearchUsingGatewayAccountId() {
         String targetGatewayAccountId = "123";
         String otherGatewayAccountId = "456";

--- a/src/test/java/uk/gov/pay/ledger/transaction/service/TransactionServiceTest.java
+++ b/src/test/java/uk/gov/pay/ledger/transaction/service/TransactionServiceTest.java
@@ -99,7 +99,8 @@ public class TransactionServiceTest {
     }
 
     @Test
-    public void shouldReturnAListOfTransactions() {
+    public void shouldReturnAListOfTransactionsWithStatusVersion2() {
+        searchParams.setStatusVersion(2);
         List<TransactionEntity> transactionViewList = TransactionFixture.aTransactionList(gatewayAccountId, 4);
         transactionViewList.add(aTransactionFixture().withState(TransactionState.FAILED_REJECTED).toEntity());
         when(mockTransactionDao.searchTransactions(any(TransactionSearchParams.class))).thenReturn(transactionViewList);
@@ -110,6 +111,17 @@ public class TransactionServiceTest {
         assertThat(transactionSearchResponse.getTotal(), is(5L));
         assertThat(transactionSearchResponse.getTransactionViewList().size(), is(5));
         assertThat(transactionSearchResponse.getTransactionViewList().get(4).getState().getStatus(), is("declined"));
+    }
+
+    @Test
+    public void shouldReturnAListOfTransactionsWithStatusVersion1() {
+        searchParams.setStatusVersion(1);
+        List<TransactionEntity> transactionViewList = TransactionFixture.aTransactionList(gatewayAccountId, 4);
+        transactionViewList.add(aTransactionFixture().withState(TransactionState.FAILED_REJECTED).toEntity());
+        when(mockTransactionDao.searchTransactions(any(TransactionSearchParams.class))).thenReturn(transactionViewList);
+        when(mockTransactionDao.getTotalForSearch(any(TransactionSearchParams.class))).thenReturn(5L);
+        TransactionSearchResponse transactionSearchResponse = transactionService.searchTransactions(searchParams, mockUriInfo);
+        assertThat(transactionSearchResponse.getTransactionViewList().get(4).getState().getStatus(), is("failed"));
     }
 
     @Test


### PR DESCRIPTION
## WHAT
- Adds new query param (status_version) to search endpoint to search/return transactions with  old_status (for `status_version=1`) or new_status (when no status version specified or `status_version=2`)

## WHY
- To match current Connector functionality
- Connector supports different search endpoints for selfservice and publicapi and returns old/new status based on endpoint invoked

**For Selfservice**
https://connector_url:9003/v2/api/accounts/{account_id}/charges?payment_states=timedout

Returns (state with `new status`)

```
"state":
{
    "finished": true,
    "code": "P0020",
    "message": "Payment expired",
    "status": "timedout"
},
```

**For PublicAPI**
https://connector_url/v1/api/accounts/{accountId}/charges?state=failed

Returns (state with `old status`)
```

"state": {
    "finished": true,
    "code": "P0020",
    "message": "Payment expired",
    "status": "failed"
}
```