### PR TITLE
PP-5637 Drop index on gateway_account_id

### DIFF
--- a/src/main/resources/migrations/00029_drop_index_transaction_gateway_account_id.sql
+++ b/src/main/resources/migrations/00029_drop_index_transaction_gateway_account_id.sql
@@ -1,0 +1,5 @@
+--liquibase formatted sql
+
+--changeset uk.gov.pay:drop_index_transaction_gateway_account_id runInTransaction:false
+
+DROP INDEX CONCURRENTLY IF EXISTS transaction_gateway_account_id_idx;


### PR DESCRIPTION
## WHAT

Drop index on gateway_account_id in favour of using multi column index `transaction_gateway_account_id_and_type_idx` https://github.com/alphagov/pay-ledger/blob/207945b3dcc5bee08c3482a96e48b5f0c21a254f/src/main/resources/migrations/00028_multicolumn_index_transaction_gateway_account_id_and_type.sql#L5

Postgres will use multiple column index for searches from left most column (so search using `gateway_account_id` OR `gateway_account_id & type` uses multi column index)