### PR TITLE
PP-5647: add exact_reference_match query param to search endpoint

### DIFF
--- a/src/main/java/uk/gov/pay/ledger/transaction/search/common/TransactionSearchParams.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/search/common/TransactionSearchParams.java
@@ -157,17 +157,17 @@ public class TransactionSearchParams {
             filters.add(" t.type = :" + TRANSACTION_TYPE_FIELD + "::transaction_type");
         }
         if (isNotBlank(email)) {
-            filters.add(" lower(t.email) ILIKE :" + EMAIL_FIELD);
+            filters.add(" lower(t.email) LIKE lower(:" + EMAIL_FIELD + ")");
         }
         if (isNotBlank(reference)) {
             if(exactReferenceMatch) {
                 filters.add(" lower(t.reference) = lower(:" + REFERENCE_FIELD + ")");
             } else {
-                filters.add(" lower(t.reference) ILIKE :" + REFERENCE_FIELD);
+                filters.add(" lower(t.reference) LIKE lower(:" + REFERENCE_FIELD + ")");
             }
         }
         if (isNotBlank(cardHolderName)) {
-            filters.add(" lower(t.cardholder_name) ILIKE :" + CARDHOLDER_NAME_FIELD);
+            filters.add(" lower(t.cardholder_name) LIKE lower(:" + CARDHOLDER_NAME_FIELD + ")");
         }
         if (isNotBlank(fromDate)) {
             filters.add(" t.created_date > :" + FROM_DATE_FIELD);

--- a/src/main/java/uk/gov/pay/ledger/transaction/search/common/TransactionSearchParams.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/search/common/TransactionSearchParams.java
@@ -39,6 +39,9 @@ public class TransactionSearchParams {
     @DefaultValue("2")
     @QueryParam("status_version")
     int statusVersion;
+    @DefaultValue("false")
+    @QueryParam("exact_reference_match")
+    private boolean exactReferenceMatch;
     private String accountId;
     @QueryParam("email")
     private String email;
@@ -157,7 +160,11 @@ public class TransactionSearchParams {
             filters.add(" lower(t.email) ILIKE :" + EMAIL_FIELD);
         }
         if (isNotBlank(reference)) {
-            filters.add(" lower(t.reference) ILIKE :" + REFERENCE_FIELD);
+            if(exactReferenceMatch) {
+                filters.add(" lower(t.reference) = lower(:" + REFERENCE_FIELD + ")");
+            } else {
+                filters.add(" lower(t.reference) ILIKE :" + REFERENCE_FIELD);
+            }
         }
         if (isNotBlank(cardHolderName)) {
             filters.add(" lower(t.cardholder_name) ILIKE :" + CARDHOLDER_NAME_FIELD);
@@ -199,7 +206,11 @@ public class TransactionSearchParams {
                 queryMap.put(EMAIL_FIELD, likeClause(email));
             }
             if (isNotBlank(reference)) {
-                queryMap.put(REFERENCE_FIELD, likeClause(reference));
+                if(exactReferenceMatch) {
+                    queryMap.put(REFERENCE_FIELD, reference);
+                } else {
+                    queryMap.put(REFERENCE_FIELD, likeClause(reference));
+                }
             }
             if (isNotBlank(cardHolderName)) {
                 queryMap.put(CARDHOLDER_NAME_FIELD, likeClause(cardHolderName));
@@ -365,5 +376,10 @@ public class TransactionSearchParams {
 
     private boolean isSet(CommaDelimitedSetParameter commaDelimitedSetParameter) {
         return commaDelimitedSetParameter != null && !commaDelimitedSetParameter.isEmpty();
+    }
+
+    public TransactionSearchParams setExactReferenceMatch(boolean exactReferenceMatch) {
+        this.exactReferenceMatch = exactReferenceMatch;
+        return this;
     }
 }

--- a/src/test/java/uk/gov/pay/ledger/transaction/dao/TransactionDaoSearchIT.java
+++ b/src/test/java/uk/gov/pay/ledger/transaction/dao/TransactionDaoSearchIT.java
@@ -122,7 +122,7 @@ public class TransactionDaoSearchIT {
     }
 
     @Test
-    public void shouldReturn1Record_whenSearchingByReference() {
+    public void shouldReturn1Record_whenSearchingByExactReference() {
 
         String gatewayAccountId = "account-id-" + nextLong();
 

--- a/src/test/java/uk/gov/pay/ledger/transaction/dao/TransactionDaoSearchIT.java
+++ b/src/test/java/uk/gov/pay/ledger/transaction/dao/TransactionDaoSearchIT.java
@@ -137,7 +137,36 @@ public class TransactionDaoSearchIT {
 
         TransactionSearchParams searchParams = new TransactionSearchParams();
         searchParams.setAccountId(gatewayAccountId);
+        searchParams.setExactReferenceMatch(true);
         searchParams.setReference("reference 1");
+
+        List<TransactionEntity> transactionList = transactionDao.searchTransactions(searchParams);
+
+        assertThat(transactionList.size(), Matchers.is(1));
+        assertThat(transactionList.get(0).getReference(), is("reference 1"));
+
+        Long total = transactionDao.getTotalForSearch(searchParams);
+        assertThat(total, is(1L));
+    }
+
+    @Test
+    public void shouldReturn1Record_whenSearchingByPartialReference() {
+
+        String gatewayAccountId = "account-id-" + nextLong();
+
+        for (int i = 0; i < 2; i++) {
+            aTransactionFixture()
+                    .withAmount(100L + i)
+                    .withGatewayAccountId(gatewayAccountId)
+                    .withReference("reference " + i)
+                    .withDescription("description " + i)
+                    .insert(rule.getJdbi());
+        }
+
+        TransactionSearchParams searchParams = new TransactionSearchParams();
+        searchParams.setAccountId(gatewayAccountId);
+        searchParams.setExactReferenceMatch(false);
+        searchParams.setReference("1");
 
         List<TransactionEntity> transactionList = transactionDao.searchTransactions(searchParams);
 

--- a/src/test/java/uk/gov/pay/ledger/transaction/search/common/TransactionSearchParamsTest.java
+++ b/src/test/java/uk/gov/pay/ledger/transaction/search/common/TransactionSearchParamsTest.java
@@ -18,6 +18,28 @@ public class TransactionSearchParamsTest {
     }
 
     @Test
+    public void getsEmptyFilterAndQueryMapWhenEmptyReference() {
+        transactionSearchParams.setReference("");
+        assertThat(transactionSearchParams.getFilterTemplates().size(), is(0));
+        assertThat(transactionSearchParams.getQueryMap().size(), is(0));
+    }
+
+    @Test
+    public void getsFilterAndQueryMapWhenNotEmptyReference() {
+        transactionSearchParams.setReference("test-reference");
+        assertThat(transactionSearchParams.getFilterTemplates().get(0), is(" lower(t.reference) ILIKE :reference"));
+        assertThat(transactionSearchParams.getQueryMap().get("reference"), is("%test-reference%"));
+    }
+
+    @Test
+    public void getsFilterAndQueryMapWhenNotEmptyReferenceAndExactMatch() {
+        transactionSearchParams.setReference("test-reference");
+        transactionSearchParams.setExactReferenceMatch(true);
+        assertThat(transactionSearchParams.getFilterTemplates().get(0), is(" lower(t.reference) = lower(:reference)"));
+        assertThat(transactionSearchParams.getQueryMap().get("reference"), is("test-reference"));
+    }
+
+    @Test
     public void getsEmptyFilterTemplateWhenEmptyFromDate() {
         transactionSearchParams.setFromDate("");
         assertThat(transactionSearchParams.getFilterTemplates().size(), is(0));

--- a/src/test/java/uk/gov/pay/ledger/transaction/search/common/TransactionSearchParamsTest.java
+++ b/src/test/java/uk/gov/pay/ledger/transaction/search/common/TransactionSearchParamsTest.java
@@ -27,7 +27,7 @@ public class TransactionSearchParamsTest {
     @Test
     public void getsFilterAndQueryMapWhenNotEmptyReference() {
         transactionSearchParams.setReference("test-reference");
-        assertThat(transactionSearchParams.getFilterTemplates().get(0), is(" lower(t.reference) ILIKE :reference"));
+        assertThat(transactionSearchParams.getFilterTemplates().get(0), is(" lower(t.reference) LIKE lower(:reference)"));
         assertThat(transactionSearchParams.getQueryMap().get("reference"), is("%test-reference%"));
     }
 


### PR DESCRIPTION
Context:
Currently ledger searches based on partial reference (the `like` query).
The current behaviour of Connector though is to search by exact mathc for
public api calls and partial reference for selfservice.
In order to mimic the same behaviour in ledger the exact_reference_match query
needs to be introduced (with default false value) which will allow switching between
exact and partial match for reference.

Changes:
* add exact_reference_match to TransactionSearchParams (default true, not added to
query param string
* update getFilterTemplates and getQueryMap methods to support switching between exact
and partial mathch
* cover the changes with unit and integration tests