### PR TITLE
PP-5657 DAO filter to search on parent transaction

### DIFF
--- a/src/test/java/uk/gov/pay/ledger/transaction/search/common/TransactionSearchParamsTest.java
+++ b/src/test/java/uk/gov/pay/ledger/transaction/search/common/TransactionSearchParamsTest.java
@@ -2,6 +2,9 @@ package uk.gov.pay.ledger.transaction.search.common;
 
 import org.junit.Before;
 import org.junit.Test;
+import uk.gov.pay.ledger.transaction.model.TransactionType;
+
+import java.util.List;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
@@ -61,6 +64,113 @@ public class TransactionSearchParamsTest {
     public void getsFilterTemplateWhenValidToDate() {
         transactionSearchParams.setToDate("2018-09-22T10:14:16.067Z");
         assertThat(transactionSearchParams.getFilterTemplates().get(0), is(" t.created_date < :to_date"));
+    }
+
+    @Test
+    public void getFilterTemplateWithParentTxnSearch_shouldReturnFilterWithReferenceSearch() {
+        transactionSearchParams.setReference("test-reference");
+        assertThat(transactionSearchParams.getFilterTemplatesWithParentTransactionSearch().get(0),
+                is(" (lower(t.reference) like lower(:reference) or lower(parent.reference) like lower(:reference))"));
+        assertThat(transactionSearchParams.getQueryMap().get("reference"), is("%test-reference%"));
+    }
+
+    @Test
+    public void getFilterTemplateWithParentTxnSearch_shouldReturnFilterWithExactReferenceSearch() {
+        transactionSearchParams.setReference("test-reference");
+        transactionSearchParams.setExactReferenceMatch(true);
+        assertThat(transactionSearchParams.getFilterTemplatesWithParentTransactionSearch().get(0),
+                is(" (lower(t.reference) = lower(:reference) or lower(parent.reference) = lower(:reference))"));
+        assertThat(transactionSearchParams.getQueryMap().get("reference"), is("test-reference"));
+    }
+
+    @Test
+    public void getFilterTemplateWithParentTxnSearch_shouldReturnFilterWithEmail() {
+        transactionSearchParams.setEmail("test-email");
+        assertThat(transactionSearchParams.getFilterTemplatesWithParentTransactionSearch().get(0),
+                is(" (lower(t.email) like lower(:email) or lower(parent.email) like lower(:email))"));
+        assertThat(transactionSearchParams.getQueryMap().get("email"), is("%test-email%"));
+    }
+
+    @Test
+    public void getFilterTemplateWithParentTxnSearch_shouldReturnFilterWithCardholderName() {
+        transactionSearchParams.setCardHolderName("test-name");
+        assertThat(transactionSearchParams.getFilterTemplatesWithParentTransactionSearch().get(0),
+                is(" (lower(t.cardholder_name) like lower(:cardholder_name) or lower(parent.cardholder_name) like lower(:cardholder_name))"));
+        assertThat(transactionSearchParams.getQueryMap().get("cardholder_name"), is("%test-name%"));
+    }
+
+    @Test
+    public void getFilterTemplateWithParentTxnSearch_shouldReturnFilterWithLastDigitsCardNumber() {
+        transactionSearchParams.setLastDigitsCardNumber("123456");
+        assertThat(transactionSearchParams.getFilterTemplatesWithParentTransactionSearch().get(0),
+                is(" (t.last_digits_card_number = :last_digits_card_number or parent.last_digits_card_number = :last_digits_card_number)"));
+        assertThat(transactionSearchParams.getQueryMap().get("last_digits_card_number"), is("123456"));
+    }
+
+    @Test
+    public void getFilterTemplateWithParentTxnSearch_shouldReturnFilterWithCardBrand() {
+        transactionSearchParams.setCardBrands(new CommaDelimitedSetParameter("visa,mastercard"));
+        assertThat(transactionSearchParams.getFilterTemplatesWithParentTransactionSearch().get(0),
+                is(" (lower(t.card_brand) IN (<card_brand>) or lower(parent.card_brand) IN (<card_brand>))"));
+        List<String> cardBrand = (List<String>) transactionSearchParams.getQueryMap().get("card_brand");
+        assertThat(cardBrand.get(0), is("visa"));
+        assertThat(cardBrand.get(1), is("mastercard"));
+    }
+
+    @Test
+    public void getFilterTemplateWithParentTxnSearch_shouldReturnFilterWithFromDate() {
+        transactionSearchParams.setFromDate("2018-09-22T10:14:16.067Z");
+        assertThat(transactionSearchParams.getFilterTemplatesWithParentTransactionSearch().get(0), is(" t.created_date > :from_date"));
+        assertThat(transactionSearchParams.getQueryMap().get("from_date").toString(), is("2018-09-22T10:14:16.067Z"));
+    }
+
+    @Test
+    public void getFilterTemplateWithParentTxnSearch_shouldReturnFilterWithToDate() {
+        transactionSearchParams.setToDate("2018-09-22T10:14:16.067Z");
+        assertThat(transactionSearchParams.getFilterTemplatesWithParentTransactionSearch().get(0), is(" t.created_date < :to_date"));
+        assertThat(transactionSearchParams.getQueryMap().get("to_date").toString(), is("2018-09-22T10:14:16.067Z"));
+    }
+
+    @Test
+    public void getFilterTemplateWithParentTxnSearch_shouldReturnFilterWithGatewayAccountId() {
+        transactionSearchParams.setAccountId("1");
+        assertThat(transactionSearchParams.getFilterTemplatesWithParentTransactionSearch().get(0), is(" t.gateway_account_id = :account_id"));
+        assertThat(transactionSearchParams.getQueryMap().get("account_id"), is("1"));
+    }
+
+    @Test
+    public void getFilterTemplateWithParentTxnSearch_shouldReturnFilterWithType() {
+        transactionSearchParams.setTransactionType(TransactionType.PAYMENT);
+        assertThat(transactionSearchParams.getFilterTemplatesWithParentTransactionSearch().get(0), is(" t.type = :transaction_type::transaction_type"));
+        assertThat(transactionSearchParams.getQueryMap().get("transaction_type"), is(TransactionType.PAYMENT));
+    }
+
+    @Test
+    public void getFilterTemplateWithParentTxnSearch_shouldReturnFilterWithFirstDigitsCardNumber() {
+        transactionSearchParams.setFirstDigitsCardNumber("1234");
+        assertThat(transactionSearchParams.getFilterTemplatesWithParentTransactionSearch().get(0), is(" t.first_digits_card_number = :first_digits_card_number"));
+        assertThat(transactionSearchParams.getQueryMap().get("first_digits_card_number"), is("1234"));
+    }
+
+    @Test
+    public void getFilterTemplateWithParentTxnSearch_shouldReturnFilterWithState() {
+        transactionSearchParams.setState("success");
+        assertThat(transactionSearchParams.getFilterTemplatesWithParentTransactionSearch().get(0), is(" t.state IN (<state>)"));
+        assertThat(((List) transactionSearchParams.getQueryMap().get("state")).get(0), is("SUCCESS"));
+    }
+
+    @Test
+    public void getFilterTemplateWithParentTxnSearch_shouldReturnFilterWithPaymentState() {
+        transactionSearchParams.setPaymentStates(new CommaDelimitedSetParameter("success"));
+        assertThat(transactionSearchParams.getFilterTemplatesWithParentTransactionSearch().get(0), is("( (t.state IN (<payment_states>) AND t.type =  'PAYMENT'::transaction_type))"));
+        assertThat(((List) transactionSearchParams.getQueryMap().get("payment_states")).get(0), is("SUCCESS"));
+    }
+
+    @Test
+    public void getFilterTemplateWithParentTxnSearch_shouldReturnFilterWithRefundState() {
+        transactionSearchParams.setRefundStates(new CommaDelimitedSetParameter("success"));
+        assertThat(transactionSearchParams.getFilterTemplatesWithParentTransactionSearch().get(0), is("( (t.state IN (<refund_states>) AND t.type =  'REFUND'::transaction_type))"));
+        assertThat(((List) transactionSearchParams.getQueryMap().get("refund_states")).get(0), is("SUCCESS"));
     }
 
     @Test


### PR DESCRIPTION
## WHAT
We have transaction search view in selfservice microservice which allows to search for refunds by card_type, reference, email, and last_digits_card_number of corresponding payment.
Selfservice service also presents `payment` related info for refunds records.

Current search endpoint (`v1/transaction?query_params`) in ledger doesn't return payment related information for `refund` transactions.

This change is part of `adding payment transaction info  to refunds transaction / searching refunds by fields available on payment transaction` when search is from selfservice.