### PR TITLE
PP-5657 DAO method to search on parent transaction

### DIFF
--- a/src/main/java/uk/gov/pay/ledger/transaction/dao/TransactionDao.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/dao/TransactionDao.java
@@ -42,7 +42,7 @@ public class TransactionDao {
             "FROM transaction t " +
             ":searchExtraFields ";
 
-    private static final String SEARCH_TRANSACTIONS_WITH_PARENT_TX = "select " +
+    private static final String SEARCH_TRANSACTIONS_WITH_PARENT_TRANSACTION = "select " +
             " t.*," +
             " parent.id as parent_id, " +
             " parent.gateway_account_id as parent_gateway_account_id, " +
@@ -72,7 +72,7 @@ public class TransactionDao {
             ":searchExtraFields " +
             "ORDER BY t.created_date DESC OFFSET :offset LIMIT :limit";
 
-    private static final String COUNT_TRANSACTIONS_WITH_PARENT_TX = "select " +
+    private static final String COUNT_TRANSACTIONS_WITH_PARENT_TRANSACTION = "select " +
             " count(1) " +
             " from transaction t left outer join transaction parent " +
             " on t.parent_external_id = parent.external_id " +
@@ -221,7 +221,7 @@ public class TransactionDao {
 
     public List<TransactionEntity> searchTransactionsAndParent(TransactionSearchParams searchParams) {
         return jdbi.withHandle(handle -> {
-            Query query = handle.createQuery(createSearchTemplate(searchParams.getFilterTemplatesWithParentTransactionSearch(), SEARCH_TRANSACTIONS_WITH_PARENT_TX));
+            Query query = handle.createQuery(createSearchTemplate(searchParams.getFilterTemplatesWithParentTransactionSearch(), SEARCH_TRANSACTIONS_WITH_PARENT_TRANSACTION));
             searchParams.getQueryMap().forEach(bindSearchParameter(query));
             query.bind("offset", searchParams.getOffset());
             query.bind("limit", searchParams.getDisplaySize());
@@ -234,7 +234,7 @@ public class TransactionDao {
 
     public Long getTotalForSearchTransactionAndParent(TransactionSearchParams searchParams) {
         return jdbi.withHandle(handle -> {
-            Query query = handle.createQuery(createSearchTemplate(searchParams.getFilterTemplatesWithParentTransactionSearch(), COUNT_TRANSACTIONS_WITH_PARENT_TX));
+            Query query = handle.createQuery(createSearchTemplate(searchParams.getFilterTemplatesWithParentTransactionSearch(), COUNT_TRANSACTIONS_WITH_PARENT_TRANSACTION));
             searchParams.getQueryMap().forEach(bindSearchParameter(query));
             return query
                     .mapTo(Long.class)

--- a/src/main/java/uk/gov/pay/ledger/transaction/dao/TransactionDao.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/dao/TransactionDao.java
@@ -5,6 +5,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.jdbi.v3.core.Jdbi;
 import org.jdbi.v3.core.statement.Query;
 import uk.gov.pay.ledger.transaction.dao.mapper.TransactionMapper;
+import uk.gov.pay.ledger.transaction.dao.mapper.TransactionWithParentMapper;
 import uk.gov.pay.ledger.transaction.entity.TransactionEntity;
 import uk.gov.pay.ledger.transaction.model.TransactionType;
 import uk.gov.pay.ledger.transaction.search.common.TransactionSearchParams;
@@ -41,6 +42,42 @@ public class TransactionDao {
             "FROM transaction t " +
             ":searchExtraFields ";
 
+    private static final String SEARCH_TRANSACTIONS_WITH_PARENT_TX = "select " +
+            " t.*," +
+            " parent.id as parent_id, " +
+            " parent.gateway_account_id as parent_gateway_account_id, " +
+            " parent.external_id as parent_external_id, " +
+            " parent.parent_external_id as parent_parent_external_id," +
+            " parent.amount as parent_amount, " +
+            " parent.reference as parent_reference," +
+            " parent.description as parent_description, " +
+            " parent.state as parent_state," +
+            " parent.email as parent_email," +
+            " parent.cardholder_name as parent_cardholder_name," +
+            " parent.created_date as parent_created_date, " +
+            " parent.transaction_details as parent_transaction_details," +
+            " parent.event_count as parent_event_count," +
+            " parent.card_brand as parent_card_brand," +
+            " parent.last_digits_card_number as parent_last_digits_card_number," +
+            " parent.first_digits_card_number as parent_first_digits_card_number, " +
+            " parent.net_amount as parent_net_amount, " +
+            " parent.total_amount as parent_total_amount," +
+            " parent.refund_status as parent_refund_status," +
+            " parent.refund_amount_refunded as parent_refund_amount_refunded," +
+            " parent.refund_amount_available as parent_refund_amount_available, " +
+            " parent.fee as parent_fee," +
+            " parent.type as parent_type " +
+            " from transaction t left outer join transaction parent " +
+            " on t.parent_external_id = parent.external_id " +
+            ":searchExtraFields " +
+            "ORDER BY t.created_date DESC OFFSET :offset LIMIT :limit";
+
+    private static final String COUNT_TRANSACTIONS_WITH_PARENT_TX = "select " +
+            " count(1) " +
+            " from transaction t left outer join transaction parent " +
+            " on t.parent_external_id = parent.external_id " +
+            ":searchExtraFields ";
+
     private static final String UPSERT_STRING =
             "INSERT INTO transaction(" +
                     "external_id," +
@@ -63,8 +100,8 @@ public class TransactionDao {
                     "refund_amount_available," +
                     "refund_amount_refunded, " +
                     "refund_status" +
-            ") " +
-            "VALUES (" +
+                    ") " +
+                    "VALUES (" +
                     ":externalId," +
                     ":parentExternalId," +
                     ":gatewayAccountId," +
@@ -147,7 +184,7 @@ public class TransactionDao {
                         .bind("gatewayAccountId", gatewayAccountId)
                         .map(new TransactionMapper())
                         .stream().collect(Collectors.toList())
-                        );
+        );
     }
 
     public List<TransactionEntity> findTransactionByParentIdAndGatewayAccountId(String parentExternalId, String gatewayAccountId) {
@@ -162,7 +199,7 @@ public class TransactionDao {
 
     public List<TransactionEntity> searchTransactions(TransactionSearchParams searchParams) {
         return jdbi.withHandle(handle -> {
-            Query query = handle.createQuery(createSearchTemplate(searchParams, SEARCH_TRANSACTIONS));
+            Query query = handle.createQuery(createSearchTemplate(searchParams.getFilterTemplates(), SEARCH_TRANSACTIONS));
             searchParams.getQueryMap().forEach(bindSearchParameter(query));
             query.bind("offset", searchParams.getOffset());
             query.bind("limit", searchParams.getDisplaySize());
@@ -174,7 +211,30 @@ public class TransactionDao {
 
     public Long getTotalForSearch(TransactionSearchParams searchParams) {
         return jdbi.withHandle(handle -> {
-            Query query = handle.createQuery(createSearchTemplate(searchParams, COUNT_TRANSACTIONS));
+            Query query = handle.createQuery(createSearchTemplate(searchParams.getFilterTemplates(), COUNT_TRANSACTIONS));
+            searchParams.getQueryMap().forEach(bindSearchParameter(query));
+            return query
+                    .mapTo(Long.class)
+                    .findOnly();
+        });
+    }
+
+    public List<TransactionEntity> searchTransactionsAndParent(TransactionSearchParams searchParams) {
+        return jdbi.withHandle(handle -> {
+            Query query = handle.createQuery(createSearchTemplate(searchParams.getFilterTemplatesWithParentTransactionSearch(), SEARCH_TRANSACTIONS_WITH_PARENT_TX));
+            searchParams.getQueryMap().forEach(bindSearchParameter(query));
+            query.bind("offset", searchParams.getOffset());
+            query.bind("limit", searchParams.getDisplaySize());
+
+            return query
+                    .map(new TransactionWithParentMapper())
+                    .list();
+        });
+    }
+
+    public Long getTotalForSearchTransactionAndParent(TransactionSearchParams searchParams) {
+        return jdbi.withHandle(handle -> {
+            Query query = handle.createQuery(createSearchTemplate(searchParams.getFilterTemplatesWithParentTransactionSearch(), COUNT_TRANSACTIONS_WITH_PARENT_TX));
             searchParams.getQueryMap().forEach(bindSearchParameter(query));
             return query
                     .mapTo(Long.class)
@@ -183,10 +243,10 @@ public class TransactionDao {
     }
 
     private String createSearchTemplate(
-            TransactionSearchParams searchParams,
+            List<String> filterTemplates,
             String baseQueryString
-            ) {
-        String searchClauseTemplate = String.join(" AND ", searchParams.getFilterTemplates());
+    ) {
+        String searchClauseTemplate = String.join(" AND ", filterTemplates);
         searchClauseTemplate = StringUtils.isNotBlank(searchClauseTemplate) ?
                 "WHERE " + searchClauseTemplate :
                 "";

--- a/src/main/java/uk/gov/pay/ledger/transaction/dao/mapper/TransactionWithParentMapper.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/dao/mapper/TransactionWithParentMapper.java
@@ -56,7 +56,7 @@ public class TransactionWithParentMapper implements RowMapper<TransactionEntity>
                 .withCardholderName(rs.getString("cardholder_name"))
                 .withCreatedDate(getZonedDateTime(rs, "created_date").orElse(null))
                 .withTransactionDetails(rs.getString("transaction_details"))
-                .withEventCount(rs.getInt("event_count"))
+                .withEventCount(getIntegerWithNullCheck(rs, "event_count"))
                 .withCardBrand(rs.getString("card_brand"))
                 .withLastDigitsCardNumber(rs.getString("last_digits_card_number"))
                 .withFirstDigitsCardNumber(rs.getString("first_digits_card_number"))
@@ -80,6 +80,11 @@ public class TransactionWithParentMapper implements RowMapper<TransactionEntity>
 
     private Long getLongWithNullCheck(ResultSet rs, String columnName) throws SQLException {
         long value = rs.getLong(columnName);
+        return rs.wasNull() ? null : value;
+    }
+
+    private Integer getIntegerWithNullCheck(ResultSet rs, String columnName) throws SQLException {
+        int value = rs.getInt(columnName);
         return rs.wasNull() ? null : value;
     }
 

--- a/src/main/java/uk/gov/pay/ledger/transaction/dao/mapper/TransactionWithParentMapper.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/dao/mapper/TransactionWithParentMapper.java
@@ -1,0 +1,92 @@
+package uk.gov.pay.ledger.transaction.dao.mapper;
+
+import org.jdbi.v3.core.mapper.RowMapper;
+import org.jdbi.v3.core.statement.StatementContext;
+import uk.gov.pay.ledger.transaction.entity.TransactionEntity;
+import uk.gov.pay.ledger.transaction.state.TransactionState;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.util.Optional;
+
+public class TransactionWithParentMapper implements RowMapper<TransactionEntity> {
+
+    @Override
+    public TransactionEntity map(ResultSet rs, StatementContext ctx) throws SQLException {
+
+        TransactionEntity parentTransactionEntity = new TransactionEntity.Builder()
+                .withId(getLongWithNullCheck(rs, "parent_id"))
+                .withGatewayAccountId(rs.getString("parent_gateway_account_id"))
+                .withExternalId(rs.getString("parent_external_id"))
+                .withParentExternalId(rs.getString("parent_parent_external_id"))
+                .withAmount(getLongWithNullCheck(rs, "parent_amount"))
+                .withReference(rs.getString("parent_reference"))
+                .withDescription(rs.getString("parent_description"))
+                .withState(getState(rs, "parent_state"))
+                .withEmail(rs.getString("parent_email"))
+                .withCardholderName(rs.getString("parent_cardholder_name"))
+                .withCreatedDate(getZonedDateTime(rs, "parent_created_date").orElse(null))
+                .withTransactionDetails(rs.getString("parent_transaction_details"))
+                .withEventCount(rs.getInt("parent_event_count"))
+                .withCardBrand(rs.getString("parent_card_brand"))
+                .withLastDigitsCardNumber(rs.getString("parent_last_digits_card_number"))
+                .withFirstDigitsCardNumber(rs.getString("parent_first_digits_card_number"))
+                .withNetAmount(getLongWithNullCheck(rs, "parent_net_amount"))
+                .withTotalAmount(getLongWithNullCheck(rs, "parent_total_amount"))
+                .withRefundStatus(rs.getString("parent_refund_status"))
+                .withRefundAmountRefunded(getLongWithNullCheck(rs, "parent_refund_amount_refunded"))
+                .withRefundAmountAvailable(getLongWithNullCheck(rs, "parent_refund_amount_available"))
+                .withFee(getLongWithNullCheck(rs, "parent_fee"))
+                .withTransactionType(rs.getString("parent_type"))
+                .build();
+
+        return new TransactionEntity.Builder()
+                .withId(rs.getLong("id"))
+                .withGatewayAccountId(rs.getString("gateway_account_id"))
+                .withExternalId(rs.getString("external_id"))
+                .withParentExternalId(rs.getString("parent_external_id"))
+                .withAmount(getLongWithNullCheck(rs, "amount"))
+                .withReference(rs.getString("reference"))
+                .withDescription(rs.getString("description"))
+                .withState(getState(rs, "state"))
+                .withEmail(rs.getString("email"))
+                .withCardholderName(rs.getString("cardholder_name"))
+                .withCreatedDate(getZonedDateTime(rs, "created_date").orElse(null))
+                .withTransactionDetails(rs.getString("transaction_details"))
+                .withEventCount(rs.getInt("event_count"))
+                .withCardBrand(rs.getString("card_brand"))
+                .withLastDigitsCardNumber(rs.getString("last_digits_card_number"))
+                .withFirstDigitsCardNumber(rs.getString("first_digits_card_number"))
+                .withNetAmount(getLongWithNullCheck(rs, "net_amount"))
+                .withTotalAmount(getLongWithNullCheck(rs, "total_amount"))
+                .withRefundStatus(rs.getString("refund_status"))
+                .withRefundAmountRefunded(getLongWithNullCheck(rs, "refund_amount_refunded"))
+                .withRefundAmountAvailable(getLongWithNullCheck(rs, "refund_amount_available"))
+                .withFee(getLongWithNullCheck(rs, "fee"))
+                .withTransactionType(rs.getString("type"))
+                .withParentTransactionEntity(parentTransactionEntity)
+                .build();
+    }
+
+    private TransactionState getState(ResultSet rs, String columnName) throws SQLException {
+        String state = rs.getString(columnName);
+        return Optional.ofNullable(state)
+                .map(TransactionState::valueOf)
+                .orElse(null);
+    }
+
+    private Long getLongWithNullCheck(ResultSet rs, String columnName) throws SQLException {
+        long value = rs.getLong(columnName);
+        return rs.wasNull() ? null : value;
+    }
+
+    private Optional<ZonedDateTime> getZonedDateTime(ResultSet rs, String columnLabel) throws SQLException {
+        Timestamp timestamp = rs.getTimestamp(columnLabel);
+
+        return Optional.ofNullable(timestamp)
+                .map(t -> ZonedDateTime.ofInstant(t.toInstant(), ZoneOffset.UTC));
+    }
+}

--- a/src/main/java/uk/gov/pay/ledger/transaction/entity/TransactionEntity.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/entity/TransactionEntity.java
@@ -41,6 +41,7 @@ public class TransactionEntity {
     private String refundStatus;
     private Long refundAmountRefunded;
     private Long refundAmountAvailable;
+    private TransactionEntity parentTransactionEntity;
 
     public TransactionEntity() {
     }
@@ -69,6 +70,7 @@ public class TransactionEntity {
         this.refundAmountAvailable = builder.refundAmountAvailable;
         this.fee = builder.fee;
         this.transactionType = builder.transactionType;
+        this.parentTransactionEntity = builder.parentTransactionEntity;
     }
 
     public Long getId() {
@@ -191,6 +193,10 @@ public class TransactionEntity {
         return transactionType;
     }
 
+    public TransactionEntity getParentTransactionEntity() {
+        return parentTransactionEntity;
+    }
+
     public static class Builder {
         private Long fee;
         private Long id;
@@ -215,6 +221,7 @@ public class TransactionEntity {
         private Long refundAmountRefunded;
         private Long refundAmountAvailable;
         private String transactionType;
+        private TransactionEntity parentTransactionEntity;
 
         public Builder() {
         }
@@ -337,5 +344,11 @@ public class TransactionEntity {
             this.transactionType = transactionType;
             return this;
         }
+
+        public Builder withParentTransactionEntity(TransactionEntity parentTransactionEntity) {
+            this.parentTransactionEntity = parentTransactionEntity;
+            return this;
+        }
+
     }
 }

--- a/src/test/java/uk/gov/pay/ledger/transaction/dao/TransactionDaoSearchIT.java
+++ b/src/test/java/uk/gov/pay/ledger/transaction/dao/TransactionDaoSearchIT.java
@@ -513,12 +513,13 @@ public class TransactionDaoSearchIT {
     @Test
     public void searchTransactionsAndParent_shouldSearchByGatewayAccountIdOnTransactionAndParentTransaction() {
         transactionFixture = insertTransaction();
-        TransactionFixture transactionFixtureChild = insertChildTransaction(transactionFixture,
+        TransactionFixture transactionFixtureChild = insertRefundChildTransaction(transactionFixture,
                 now(ZoneOffset.UTC).plusDays(1));
         TransactionFixture transactionThatShouldBeExcluded = insertTransaction();
 
         searchParams.setAccountId(transactionFixture.getGatewayAccountId());
         List<TransactionEntity> transactionList = transactionDao.searchTransactionsAndParent(searchParams);
+        assertThat(transactionList.size(), is(2));
 
         assertTransactionEquals(transactionList.get(0), transactionFixtureChild);
         assertTransactionEquals(transactionList.get(0).getParentTransactionEntity(), transactionFixture);
@@ -533,7 +534,7 @@ public class TransactionDaoSearchIT {
         transactionFixture = aTransactionFixture()
                 .withEmail("test-email")
                 .insert(rule.getJdbi());
-        TransactionFixture transactionFixtureChild = insertChildTransaction(transactionFixture,
+        TransactionFixture transactionFixtureChild = insertRefundChildTransaction(transactionFixture,
                 now(ZoneOffset.UTC).plusDays(1));
 
         TransactionSearchParams searchParams = new TransactionSearchParams();
@@ -541,6 +542,7 @@ public class TransactionDaoSearchIT {
         searchParams.setEmail("test");
 
         List<TransactionEntity> transactionList = transactionDao.searchTransactionsAndParent(searchParams);
+        assertThat(transactionList.size(), is(2));
 
         assertTransactionEquals(transactionList.get(0), transactionFixtureChild);
         assertTransactionEquals(transactionList.get(0).getParentTransactionEntity(), transactionFixture);
@@ -555,12 +557,13 @@ public class TransactionDaoSearchIT {
         transactionFixture = aTransactionFixture()
                 .withReference("reference")
                 .insert(rule.getJdbi());
-        TransactionFixture transactionFixtureChild = insertChildTransaction(transactionFixture,
+        TransactionFixture transactionFixtureChild = insertRefundChildTransaction(transactionFixture,
                 now(ZoneOffset.UTC).plusDays(1));
 
         searchParams.setAccountId(transactionFixture.getGatewayAccountId());
         searchParams.setReference("ref");
         List<TransactionEntity> transactionList = transactionDao.searchTransactionsAndParent(searchParams);
+        assertThat(transactionList.size(), is(2));
 
         assertTransactionEquals(transactionList.get(0), transactionFixtureChild);
         assertTransactionEquals(transactionList.get(0).getParentTransactionEntity(), transactionFixture);
@@ -575,7 +578,7 @@ public class TransactionDaoSearchIT {
         transactionFixture = aTransactionFixture()
                 .withReference("reference")
                 .insert(rule.getJdbi());
-        TransactionFixture transactionFixtureChild = insertChildTransaction(transactionFixture,
+        TransactionFixture transactionFixtureChild = insertRefundChildTransaction(transactionFixture,
                 now(ZoneOffset.UTC).plusDays(1));
         TransactionFixture transactionToExclude = aTransactionFixture()
                 .withReference("reference2")
@@ -586,6 +589,7 @@ public class TransactionDaoSearchIT {
         searchParams.setExactReferenceMatch(true);
         searchParams.setReference("reference");
         List<TransactionEntity> transactionList = transactionDao.searchTransactionsAndParent(searchParams);
+        assertThat(transactionList.size(), is(2));
 
         assertTransactionEquals(transactionList.get(0), transactionFixtureChild);
         assertTransactionEquals(transactionList.get(0).getParentTransactionEntity(), transactionFixture);
@@ -600,12 +604,13 @@ public class TransactionDaoSearchIT {
         transactionFixture = aTransactionFixture()
                 .withCardholderName("Mr Test")
                 .insert(rule.getJdbi());
-        TransactionFixture transactionFixtureChild = insertChildTransaction(transactionFixture,
+        TransactionFixture transactionFixtureChild = insertRefundChildTransaction(transactionFixture,
                 now(ZoneOffset.UTC).plusDays(1));
 
         searchParams.setAccountId(transactionFixture.getGatewayAccountId());
         searchParams.setCardHolderName("mr");
         List<TransactionEntity> transactionList = transactionDao.searchTransactionsAndParent(searchParams);
+        assertThat(transactionList.size(), is(2));
 
         assertTransactionEquals(transactionList.get(0), transactionFixtureChild);
         assertTransactionEquals(transactionList.get(0).getParentTransactionEntity(), transactionFixture);
@@ -620,12 +625,13 @@ public class TransactionDaoSearchIT {
         transactionFixture = aTransactionFixture()
                 .withLastDigitsCardNumber("4242")
                 .insert(rule.getJdbi());
-        TransactionFixture transactionFixtureChild = insertChildTransaction(transactionFixture,
+        TransactionFixture transactionFixtureChild = insertRefundChildTransaction(transactionFixture,
                 now(ZoneOffset.UTC).plusDays(1));
 
         searchParams.setAccountId(transactionFixture.getGatewayAccountId());
         searchParams.setLastDigitsCardNumber("4242");
         List<TransactionEntity> transactionList = transactionDao.searchTransactionsAndParent(searchParams);
+        assertThat(transactionList.size(), is(2));
 
         assertTransactionEquals(transactionList.get(0), transactionFixtureChild);
         assertTransactionEquals(transactionList.get(0).getParentTransactionEntity(), transactionFixture);
@@ -640,14 +646,16 @@ public class TransactionDaoSearchIT {
         transactionFixture = aTransactionFixture()
                 .withCardBrand("visa")
                 .insert(rule.getJdbi());
-        TransactionFixture transactionFixtureChild = insertChildTransaction(transactionFixture,
+        TransactionFixture transactionFixtureChild = insertRefundChildTransaction(transactionFixture,
                 now(ZoneOffset.UTC).plusDays(2));
 
         searchParams.setAccountId(transactionFixture.getGatewayAccountId());
         searchParams.setCardBrands(new CommaDelimitedSetParameter("visa"));
 
         List<TransactionEntity> transactionList = transactionDao.searchTransactionsAndParent(searchParams);
+        assertThat(transactionList.size(), is(2));
         assertTransactionEquals(transactionList.get(0), transactionFixtureChild);
+        assertTransactionEquals(transactionList.get(0).getParentTransactionEntity(), transactionFixture);
         assertTransactionEquals(transactionList.get(1), transactionFixture);
 
         Long total = transactionDao.getTotalForSearchTransactionAndParent(searchParams);
@@ -659,12 +667,13 @@ public class TransactionDaoSearchIT {
         transactionFixture = aTransactionFixture()
                 .withCreatedDate(now(ZoneOffset.UTC).minusDays(1))
                 .insert(rule.getJdbi());
-        TransactionFixture transactionFixtureChild = insertChildTransaction(transactionFixture,
+        TransactionFixture transactionFixtureChild = insertRefundChildTransaction(transactionFixture,
                 now(ZoneOffset.UTC).plusDays(1));
 
         searchParams.setAccountId(transactionFixture.getGatewayAccountId());
         searchParams.setFromDate(now(ZoneOffset.UTC).toString());
         List<TransactionEntity> transactionList = transactionDao.searchTransactionsAndParent(searchParams);
+        assertThat(transactionList.size(), is(1));
 
         assertTransactionEquals(transactionList.get(0), transactionFixtureChild);
         assertTransactionEquals(transactionList.get(0).getParentTransactionEntity(), transactionFixture);
@@ -678,12 +687,13 @@ public class TransactionDaoSearchIT {
         transactionFixture = aTransactionFixture()
                 .withCreatedDate(now(ZoneOffset.UTC).minusDays(1))
                 .insert(rule.getJdbi());
-        TransactionFixture transactionFixtureChild = insertChildTransaction(transactionFixture,
+        TransactionFixture transactionFixtureChild = insertRefundChildTransaction(transactionFixture,
                 now(ZoneOffset.UTC).plusDays(1));
 
         searchParams.setAccountId(transactionFixture.getGatewayAccountId());
         searchParams.setToDate(now(ZoneOffset.UTC).toString());
         List<TransactionEntity> transactionList = transactionDao.searchTransactionsAndParent(searchParams);
+        assertThat(transactionList.size(), is(1));
 
         assertTransactionEquals(transactionList.get(0), transactionFixture);
 
@@ -714,7 +724,7 @@ public class TransactionDaoSearchIT {
     @Test
     public void searchTransactionsAndParent_withOffsetAndPageSize() {
         transactionFixture = insertTransaction();
-        TransactionFixture transactionFixtureChild = insertChildTransaction(transactionFixture,
+        TransactionFixture transactionFixtureChild = insertRefundChildTransaction(transactionFixture,
                 now(ZoneOffset.UTC).plusDays(1));
         TransactionFixture transactionFixture2 = aTransactionFixture()
                 .withGatewayAccountId(transactionFixture.getGatewayAccountId())
@@ -727,6 +737,7 @@ public class TransactionDaoSearchIT {
         searchParams.setPageNumber(2L);
 
         List<TransactionEntity> transactionList = transactionDao.searchTransactionsAndParent(searchParams);
+        assertThat(transactionList.size(), is(1));
         assertTransactionEquals(transactionList.get(0), transactionFixtureChild);
 
         Long total = transactionDao.getTotalForSearchTransactionAndParent(searchParams);
@@ -740,13 +751,14 @@ public class TransactionDaoSearchIT {
                 .withGatewayAccountId(transactionFixture.getGatewayAccountId())
                 .withTransactionType("PAYMENT")
                 .insert(rule.getJdbi());
-        insertChildTransaction(transactionFixture, now(ZoneOffset.UTC).plusDays(2));
+        insertRefundChildTransaction(transactionFixture, now(ZoneOffset.UTC).plusDays(2));
 
         TransactionSearchParams searchParams = new TransactionSearchParams();
         searchParams.setAccountId(transactionFixture.getGatewayAccountId());
         searchParams.setPaymentStates(new CommaDelimitedSetParameter("created"));
 
         List<TransactionEntity> transactionList = transactionDao.searchTransactionsAndParent(searchParams);
+        assertThat(transactionList.size(), is(1));
         assertTransactionEquals(transactionList.get(0), transactionFixture);
 
         Long total = transactionDao.getTotalForSearchTransactionAndParent(searchParams);
@@ -759,13 +771,14 @@ public class TransactionDaoSearchIT {
         aTransactionFixture().withState(TransactionState.FAILED_REJECTED)
                 .withGatewayAccountId(transactionFixture.getGatewayAccountId())
                 .insert(rule.getJdbi());
-        TransactionFixture transactionFixtureChild = insertChildTransaction(transactionFixture,
+        TransactionFixture transactionFixtureChild = insertRefundChildTransaction(transactionFixture,
                 now(ZoneOffset.UTC).plusDays(2));
 
         searchParams.setAccountId(transactionFixture.getGatewayAccountId());
         searchParams.setRefundStates(new CommaDelimitedSetParameter("created"));
 
         List<TransactionEntity> transactionList = transactionDao.searchTransactionsAndParent(searchParams);
+        assertThat(transactionList.size(), is(1));
         assertTransactionEquals(transactionList.get(0), transactionFixtureChild);
 
         Long total = transactionDao.getTotalForSearchTransactionAndParent(searchParams);
@@ -777,13 +790,14 @@ public class TransactionDaoSearchIT {
         transactionFixture = aTransactionFixture()
                 .withFirstDigitsCardNumber("424242")
                 .insert(rule.getJdbi());
-        TransactionFixture transactionFixtureChild = insertChildTransaction(transactionFixture,
+        TransactionFixture transactionFixtureChild = insertRefundChildTransaction(transactionFixture,
                 now(ZoneOffset.UTC).plusDays(2));
 
         searchParams.setAccountId(transactionFixture.getGatewayAccountId());
         searchParams.setFirstDigitsCardNumber("424242");
 
         List<TransactionEntity> transactionList = transactionDao.searchTransactionsAndParent(searchParams);
+        assertThat(transactionList.size(), is(1));
         assertTransactionEquals(transactionList.get(0), transactionFixture);
 
         Long total = transactionDao.getTotalForSearchTransactionAndParent(searchParams);
@@ -817,7 +831,7 @@ public class TransactionDaoSearchIT {
                 .insert(rule.getJdbi());
     }
 
-    private TransactionFixture insertChildTransaction(TransactionFixture parentTransactionFixture, ZonedDateTime createdDate) {
+    private TransactionFixture insertRefundChildTransaction(TransactionFixture parentTransactionFixture, ZonedDateTime createdDate) {
         return aTransactionFixture()
                 .withParentExternalId(parentTransactionFixture.getExternalId())
                 .withGatewayAccountId(parentTransactionFixture.getGatewayAccountId())

--- a/src/test/java/uk/gov/pay/ledger/util/fixture/TransactionFixture.java
+++ b/src/test/java/uk/gov/pay/ledger/util/fixture/TransactionFixture.java
@@ -442,6 +442,10 @@ public class TransactionFixture implements DbFixture<TransactionFixture, Transac
         return delayedCapture;
     }
 
+    public String getParentExternalId() {
+        return parentExternalId;
+    }
+
     public TransactionFixture withDefaultCardDetails(boolean includeCardDetails) {
         if (includeCardDetails) {
             Address billingAddress = new Address("line1", "line2", "AB1 2CD",


### PR DESCRIPTION
## WHAT
- Search for transaction and on parent transaction too so refunds can be returned in the search
- When query parameters `reference, email_address, cardholder_name, last_four_digits_card_number, card_brand` are available,
  should also search on parent transaction
- For other query parameters, apply filter only on transaction