### PR TITLE
PP-5657 Search on parent transaction - service method

### DIFF
--- a/src/main/java/uk/gov/pay/ledger/transaction/model/Refund.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/model/Refund.java
@@ -3,6 +3,7 @@ package uk.gov.pay.ledger.transaction.model;
 import uk.gov.pay.ledger.transaction.state.TransactionState;
 
 import java.time.ZonedDateTime;
+import java.util.Optional;
 
 public class Refund extends Transaction {
     private final String reference;
@@ -12,6 +13,7 @@ public class Refund extends Transaction {
     private final Integer eventCount;
     private final String refundedBy;
     private final String parentExternalId;
+    private final Optional<Transaction> parentTransaction;
 
     public Refund(Builder builder) {
         super(builder.id, builder.gatewayAccountId, builder.amount, builder.externalId);
@@ -22,6 +24,7 @@ public class Refund extends Transaction {
         this.eventCount = builder.eventCount;
         this.refundedBy = builder.refundedBy;
         this.parentExternalId = builder.parentExternalId;
+        this.parentTransaction = builder.parentTransaction;
     }
 
     public String getReference() {
@@ -52,6 +55,10 @@ public class Refund extends Transaction {
         return parentExternalId;
     }
 
+    public Optional<Transaction> getParentTransaction() {
+        return parentTransaction;
+    }
+
     @Override
     public TransactionType getTransactionType() {
         return TransactionType.REFUND;
@@ -69,6 +76,7 @@ public class Refund extends Transaction {
         private Long amount;
         private String externalId;
         private String parentExternalId;
+        private Optional<Transaction> parentTransaction;
 
         public Builder() {
         }
@@ -129,6 +137,11 @@ public class Refund extends Transaction {
 
         public Builder withParentExternalId(String parentExternalId) {
             this.parentExternalId = parentExternalId;
+            return this;
+        }
+
+        public Builder withParentTransaction(Optional<Transaction> transaction) {
+            this.parentTransaction = transaction;
             return this;
         }
     }

--- a/src/main/java/uk/gov/pay/ledger/transaction/model/TransactionFactory.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/model/TransactionFactory.java
@@ -97,6 +97,9 @@ public class TransactionFactory {
         try {
             JsonNode transactionDetails = objectMapper.readTree(Optional.ofNullable(entity.getTransactionDetails()).orElse("{}"));
 
+            Optional<Transaction> parentTransaction = Optional.ofNullable(entity.getParentTransactionEntity())
+                    .map(this::createTransactionEntity);
+
             return new Refund.Builder()
                     .withGatewayAccountId(entity.getGatewayAccountId())
                     .withAmount(entity.getAmount())
@@ -108,6 +111,7 @@ public class TransactionFactory {
                     .withEventCount(entity.getEventCount())
                     .withRefundedBy(safeGetAsString(transactionDetails, "refunded_by"))
                     .withParentExternalId(entity.getParentExternalId())
+                    .withParentTransaction(parentTransaction)
                     .build();
 
         } catch (IOException e) {

--- a/src/main/java/uk/gov/pay/ledger/transaction/search/common/TransactionSearchParams.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/search/common/TransactionSearchParams.java
@@ -42,6 +42,9 @@ public class TransactionSearchParams {
     @DefaultValue("false")
     @QueryParam("exact_reference_match")
     private boolean exactReferenceMatch;
+    @DefaultValue("false")
+    @QueryParam("with_parent_transaction")
+    private boolean withParentTransaction;
     private String accountId;
     @QueryParam("email")
     private String email;
@@ -125,6 +128,10 @@ public class TransactionSearchParams {
 
     public void setStatusVersion(int statusVersion) {
         this.statusVersion = statusVersion;
+    }
+
+    public void setWithParentTransaction(boolean withParentTransaction) {
+        this.withParentTransaction = withParentTransaction;
     }
 
     @QueryParam("page")
@@ -324,6 +331,10 @@ public class TransactionSearchParams {
 
     public int getStatusVersion() {
         return statusVersion;
+    }
+
+    public boolean getWithParentTransaction() {
+        return withParentTransaction;
     }
 
     public String buildQueryParamString(Long forPage) {

--- a/src/main/java/uk/gov/pay/ledger/transaction/search/model/TransactionView.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/search/model/TransactionView.java
@@ -51,6 +51,7 @@ public class TransactionView {
     private Map<String, Object> metadata;
     private String refundedBy;
     private TransactionType transactionType;
+    private TransactionView parentTransaction;
 
     public TransactionView(Builder builder) {
         this.id = builder.id;
@@ -78,6 +79,7 @@ public class TransactionView {
         this.metadata = builder.metadata;
         this.refundedBy = builder.refundedBy;
         this.transactionType = builder.transactionType;
+        this.parentTransaction = builder.parentTransaction;
     }
 
     public TransactionView() {
@@ -127,6 +129,7 @@ public class TransactionView {
                 .withCreatedDate(refund.getCreatedDate())
                 .withRefundedBy(refund.getRefundedBy())
                 .withTransactionType(refund.getTransactionType())
+                .withParentTransaction(refund.getParentTransaction().map(parentTransaction -> from(parentTransaction, statusVersion)).orElse(null))
                 .build();
     }
 
@@ -245,7 +248,12 @@ public class TransactionView {
         return transactionType;
     }
 
+    public TransactionView getParentTransaction() {
+        return parentTransaction;
+    }
+
     public static class Builder {
+        private TransactionView parentTransaction;
         private Long id;
         private String gatewayAccountId;
         private Long amount;
@@ -404,5 +412,11 @@ public class TransactionView {
             this.transactionType = transactionType;
             return this;
         }
+
+        public Builder withParentTransaction(TransactionView parentTransaction) {
+            this.parentTransaction = parentTransaction;
+            return this;
+        }
+
     }
 }

--- a/src/test/java/uk/gov/pay/ledger/transaction/model/TransactionFactoryTest.java
+++ b/src/test/java/uk/gov/pay/ledger/transaction/model/TransactionFactoryTest.java
@@ -122,8 +122,82 @@ public class TransactionFactoryTest {
 
     @Test
     public void createsPaymentFromTransactionEntityWithFullData() {
-        var payment = (Payment) transactionFactory.createTransactionEntity(fullDataObject);
+        Payment payment = (Payment) transactionFactory.createTransactionEntity(fullDataObject);
 
+        assertCorrectPaymentTransactionWithFullData(payment);
+    }
+
+    @Test
+    public void createsPaymentFromTransactionEntityWithMinimalData() {
+        Payment payment = (Payment) transactionFactory.createTransactionEntity(minimalDataObject);
+
+        assertThat(payment.getGatewayAccountId(), is(gatewayAccountId));
+        assertThat(payment.getAmount(), is(amount));
+        assertThat(payment.getExternalId(), is(externalId));
+        assertThat(payment.getReference(), is(reference));
+        assertThat(payment.getDescription(), is(description));
+        assertThat(payment.getState(), is(state));
+        assertThat(payment.getLanguage(), nullValue());
+        assertThat(payment.getReturnUrl(), nullValue());
+        assertThat(payment.getEmail(), is(email));
+        assertThat(payment.getPaymentProvider(), nullValue());
+        assertThat(payment.getCreatedDate(), is(createdDate));
+        assertThat(payment.getCardDetails(), notNullValue());
+        assertThat(payment.getCardDetails().getLastDigitsCardNumber(), is(lastDigitsCardNumber));
+        assertThat(payment.getCardDetails().getFirstDigitsCardNumber(), is(firstDigitsCardNumber));
+        assertThat(payment.getCardDetails().getCardHolderName(), is(cardholderName));
+        assertThat(payment.getCardDetails().getCardBrand(), is(cardBrand));
+        assertThat(payment.getCardDetails().getBillingAddress(), nullValue());
+        assertThat(payment.getDelayedCapture(), is(false));
+        assertThat(payment.getExternalMetadata(), nullValue());
+        assertThat(payment.getEventCount(), is(eventCount));
+        assertThat(payment.getGatewayTransactionId(), nullValue());
+        assertThat(payment.getCorporateCardSurcharge(), nullValue());
+        assertThat(payment.getFee(), nullValue());
+        assertThat(payment.getNetAmount(), is(netAmount));
+        assertThat(payment.getTotalAmount(), is(totalAmount));
+        assertThat(payment.getRefundSummary(), notNullValue());
+        assertThat(payment.getRefundSummary().getStatus(), is(refundStatus));
+        assertThat(payment.getRefundSummary().getAmountAvailable(), is(refundAmountAvailable));
+        assertThat(payment.getRefundSummary().getAmountRefunded(), is(refundAmountRefunded));
+        assertThat(payment.getSettlementSummary(), notNullValue());
+        assertThat(payment.getSettlementSummary().getCapturedDate(), is(Optional.empty()));
+        assertThat(payment.getSettlementSummary().getSettlementSubmittedTime(), is(Optional.empty()));
+    }
+
+    @Test
+    public void createsRefundFromTransactionEntityWithMinimalData() {
+        Payment payment = (Payment) transactionFactory.createTransactionEntity(fullDataObject);
+        TransactionEntity refund = new TransactionEntity.Builder()
+                .withTransactionType("REFUND")
+                .withId(id)
+                .withGatewayAccountId(gatewayAccountId)
+                .withExternalId(externalId)
+                .withParentExternalId("parent-ext-id")
+                .withAmount(amount)
+                .withReference(reference)
+                .withState(state)
+                .withCreatedDate(createdDate)
+                .withEventCount(eventCount)
+                .withParentTransactionEntity(fullDataObject)
+                .withTransactionDetails("{\"refunded_by\": \"some_user_id\"}")
+                .build();
+        Refund refundEntity = (Refund) transactionFactory.createTransactionEntity(refund);
+
+        assertThat(refundEntity.getGatewayAccountId(), is(gatewayAccountId));
+        assertThat(refundEntity.getAmount(), is(amount));
+        assertThat(refundEntity.getExternalId(), is(externalId));
+        assertThat(refundEntity.getParentExternalId(), is("parent-ext-id"));
+        assertThat(refundEntity.getRefundedBy(), is("some_user_id"));
+        assertThat(refundEntity.getReference(), is(reference));
+        assertThat(refundEntity.getState(), is(state));
+        assertThat(refundEntity.getCreatedDate(), is(createdDate));
+        assertThat(refundEntity.getEventCount(), is(eventCount));
+
+        assertCorrectPaymentTransactionWithFullData((Payment) refundEntity.getParentTransaction().get());
+    }
+
+    private void assertCorrectPaymentTransactionWithFullData(Payment payment) {
         assertThat(payment.getGatewayAccountId(), is(gatewayAccountId));
         assertThat(payment.getAmount(), is(amount));
         assertThat(payment.getExternalId(), is(externalId));
@@ -163,72 +237,5 @@ public class TransactionFactoryTest {
         assertThat(payment.getSettlementSummary(), notNullValue());
         assertThat(payment.getSettlementSummary().getCapturedDate(), is(Optional.of("2017-09-09")));
         assertThat(payment.getSettlementSummary().getSettlementSubmittedTime(), is(Optional.of("2017-09-09T08:35:45.695Z")));
-    }
-
-    @Test
-    public void createsPaymentFromTransactionEntityWithMinimalData() {
-        var payment = (Payment) transactionFactory.createTransactionEntity(minimalDataObject);
-
-        assertThat(payment.getGatewayAccountId(), is(gatewayAccountId));
-        assertThat(payment.getAmount(), is(amount));
-        assertThat(payment.getExternalId(), is(externalId));
-        assertThat(payment.getReference(), is(reference));
-        assertThat(payment.getDescription(), is(description));
-        assertThat(payment.getState(), is(state));
-        assertThat(payment.getLanguage(), nullValue());
-        assertThat(payment.getReturnUrl(), nullValue());
-        assertThat(payment.getEmail(), is(email));
-        assertThat(payment.getPaymentProvider(), nullValue());
-        assertThat(payment.getCreatedDate(), is(createdDate));
-        assertThat(payment.getCardDetails(), notNullValue());
-        assertThat(payment.getCardDetails().getLastDigitsCardNumber(), is(lastDigitsCardNumber));
-        assertThat(payment.getCardDetails().getFirstDigitsCardNumber(), is(firstDigitsCardNumber));
-        assertThat(payment.getCardDetails().getCardHolderName(), is(cardholderName));
-        assertThat(payment.getCardDetails().getCardBrand(), is(cardBrand));
-        assertThat(payment.getCardDetails().getBillingAddress(), nullValue());
-        assertThat(payment.getDelayedCapture(), is(false));
-        assertThat(payment.getExternalMetadata(), nullValue());
-        assertThat(payment.getEventCount(), is(eventCount));
-        assertThat(payment.getGatewayTransactionId(), nullValue());
-        assertThat(payment.getCorporateCardSurcharge(), nullValue());
-        assertThat(payment.getFee(), nullValue());
-        assertThat(payment.getNetAmount(), is(netAmount));
-        assertThat(payment.getTotalAmount(), is(totalAmount));
-        assertThat(payment.getRefundSummary(), notNullValue());
-        assertThat(payment.getRefundSummary().getStatus(), is(refundStatus));
-        assertThat(payment.getRefundSummary().getAmountAvailable(), is(refundAmountAvailable));
-        assertThat(payment.getRefundSummary().getAmountRefunded(), is(refundAmountRefunded));
-        assertThat(payment.getSettlementSummary(), notNullValue());
-        assertThat(payment.getSettlementSummary().getCapturedDate(), is(Optional.empty()));
-        assertThat(payment.getSettlementSummary().getSettlementSubmittedTime(), is(Optional.empty()));
-    }
-
-    @Test
-    public void createsRefundFromTransactionEntityWithMinimalData() {
-        var refund = new TransactionEntity.Builder()
-                .withTransactionType("REFUND")
-                .withId(id)
-                .withGatewayAccountId(gatewayAccountId)
-                .withExternalId(externalId)
-                .withParentExternalId("parent-ext-id")
-                .withAmount(amount)
-                .withReference(reference)
-                .withState(state)
-                .withCreatedDate(createdDate)
-                .withEventCount(eventCount)
-                .withTransactionDetails("{\"refunded_by\": \"some_user_id\"}")
-                .build();
-        var refundEntity = (Refund) transactionFactory.createTransactionEntity(refund);
-
-        assertThat(refundEntity.getGatewayAccountId(), is(gatewayAccountId));
-        assertThat(refundEntity.getAmount(), is(amount));
-        assertThat(refundEntity.getExternalId(), is(externalId));
-        assertThat(refundEntity.getParentExternalId(), is("parent-ext-id"));
-        assertThat(refundEntity.getRefundedBy(), is("some_user_id"));
-        assertThat(refundEntity.getReference(), is(reference));
-        assertThat(refundEntity.getState(), is(state));
-        assertThat(refundEntity.getCreatedDate(), is(createdDate));
-        assertThat(refundEntity.getEventCount(), is(eventCount));
-
     }
 }


### PR DESCRIPTION
## WHAT
- Updates service method to search for transactions with parent when `withParentTransaction` query param is `true`.
- Refund transaction also includes parent transaction information