### PR TITLE
PP-5657 Resource validation for search with parent transaction

### DIFF
--- a/src/main/java/uk/gov/pay/ledger/transaction/resource/TransactionResource.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/resource/TransactionResource.java
@@ -79,12 +79,12 @@ public class TransactionResource {
         TransactionSearchParams transactionSearchParams = Optional.ofNullable(searchParams)
                 .orElse(new TransactionSearchParams());
 
-        validateSearchParams(transactionSearchParams);
+        validateSearchParams(transactionSearchParams, gatewayAccountId);
         AccountIdSupplierManager<TransactionSearchResponse> accountIdSupplierManager =
                 AccountIdSupplierManager.of(overrideAccountRestriction, gatewayAccountId);
 
         return accountIdSupplierManager
-                .withSupplier((accountId) -> transactionService.searchTransactions(gatewayAccountId, transactionSearchParams, uriInfo))
+                .withSupplier(accountId -> transactionService.searchTransactions(gatewayAccountId, transactionSearchParams, uriInfo))
                 .withPrivilegedSupplier(() -> transactionService.searchTransactions(transactionSearchParams, uriInfo))
                 .validateAndGet();
     }

--- a/src/main/java/uk/gov/pay/ledger/transaction/search/common/TransactionSearchParamsValidator.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/search/common/TransactionSearchParamsValidator.java
@@ -1,22 +1,28 @@
 package uk.gov.pay.ledger.transaction.search.common;
 
 import uk.gov.pay.ledger.exception.UnparsableDateException;
+import uk.gov.pay.ledger.exception.ValidationException;
 
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeParseException;
 
+import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
 public class TransactionSearchParamsValidator {
     private static final String FROM_DATE_FIELD = "from_date";
     private static final String TO_DATE_FIELD = "to_date";
 
-    public static void validateSearchParams(TransactionSearchParams searchParams) {
+    public static void validateSearchParams(TransactionSearchParams searchParams, String gatewayAccountId) {
         if (isNotBlank(searchParams.getFromDate())) {
             validateDate(FROM_DATE_FIELD, searchParams.getFromDate());
         }
         if (isNotBlank(searchParams.getToDate())) {
             validateDate(TO_DATE_FIELD, searchParams.getToDate());
+        }
+
+        if(searchParams.getWithParentTransaction() && isBlank(gatewayAccountId)){
+            throw new ValidationException("gateway_account_id is mandatory to search with parent transaction");
         }
     }
 

--- a/src/main/java/uk/gov/pay/ledger/transaction/service/TransactionService.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/service/TransactionService.java
@@ -88,11 +88,11 @@ public class TransactionService {
         if (searchParams.getWithParentTransaction()) {
             return searchTransactionsAndParent(searchParams, uriInfo);
         } else {
-            return searchTransactionsWithOutParent(searchParams, uriInfo);
+            return searchTransactionsWithoutParent(searchParams, uriInfo);
         }
     }
 
-    private TransactionSearchResponse searchTransactionsWithOutParent(TransactionSearchParams searchParams, UriInfo uriInfo) {
+    private TransactionSearchResponse searchTransactionsWithoutParent(TransactionSearchParams searchParams, UriInfo uriInfo) {
         List<Transaction> transactionList = transactionDao.searchTransactions(searchParams)
                 .stream()
                 .map(transactionFactory::createTransactionEntity)

--- a/src/test/java/uk/gov/pay/ledger/transaction/search/common/TransactionSearchParamsValidatorTest.java
+++ b/src/test/java/uk/gov/pay/ledger/transaction/search/common/TransactionSearchParamsValidatorTest.java
@@ -5,6 +5,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import uk.gov.pay.ledger.exception.UnparsableDateException;
+import uk.gov.pay.ledger.exception.ValidationException;
 
 public class TransactionSearchParamsValidatorTest {
 
@@ -23,7 +24,7 @@ public class TransactionSearchParamsValidatorTest {
         searchParams.setFromDate("wrong-date");
         thrown.expect(UnparsableDateException.class);
         thrown.expectMessage("Input from_date (wrong-date) is wrong format");
-        TransactionSearchParamsValidator.validateSearchParams(searchParams);
+        TransactionSearchParamsValidator.validateSearchParams(searchParams, null);
     }
 
     @Test
@@ -31,13 +32,27 @@ public class TransactionSearchParamsValidatorTest {
         searchParams.setToDate("wrong-date");
         thrown.expect(UnparsableDateException.class);
         thrown.expectMessage("Input to_date (wrong-date) is wrong format");
-        TransactionSearchParamsValidator.validateSearchParams(searchParams);
+        TransactionSearchParamsValidator.validateSearchParams(searchParams,null);
     }
 
     @Test
     public void shouldNotThrowException_whenValidDateFormats() {
         searchParams.setFromDate("2019-05-01T10:15:30Z");
         searchParams.setToDate("2019-05-01T10:15:30Z");
-        TransactionSearchParamsValidator.validateSearchParams(searchParams);
+        TransactionSearchParamsValidator.validateSearchParams(searchParams,null);
+    }
+
+    @Test
+    public void shouldNotThrowException_whenGatewayAccountIdAvailableAndWithParentTransactionIsTrue() {
+        searchParams.setWithParentTransaction(true);
+        TransactionSearchParamsValidator.validateSearchParams(searchParams,"account-id");
+    }
+
+    @Test
+    public void shouldThrowException_whenGatewayAccountIdIsNotAvailableAndWithParentTransactionIsTrue() {
+        searchParams.setWithParentTransaction(true);
+        thrown.expect(ValidationException.class);
+        thrown.expectMessage("gateway_account_id is mandatory to search with parent transaction");
+        TransactionSearchParamsValidator.validateSearchParams(searchParams,"");
     }
 }

--- a/src/test/java/uk/gov/pay/ledger/transaction/service/TransactionServiceTest.java
+++ b/src/test/java/uk/gov/pay/ledger/transaction/service/TransactionServiceTest.java
@@ -153,6 +153,9 @@ public class TransactionServiceTest {
         setAllSearchParams();
 
         TransactionSearchResponse transactionSearchResponse = transactionService.searchTransactions(searchParams, mockUriInfo);
+
+        verify(mockTransactionDao).searchTransactions(searchParams);
+        verify(mockTransactionDao).getTotalForSearch(searchParams);
         assertCorrectPaginationQueryParams(transactionSearchResponse);
     }
 


### PR DESCRIPTION
## WHAT
- Validation for gateway_account_id when `with_parent_transaction` is true. This prevents querying with parent transaction without gateway_account_id
- added resource test