### PR TITLE
PP-5658 Report on card brand label to match Connector

### DIFF
--- a/src/main/java/uk/gov/pay/ledger/transaction/model/TransactionFactory.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/model/TransactionFactory.java
@@ -44,8 +44,9 @@ public class TransactionFactory {
                     safeGetAsString(transactionDetails, "address_county"),
                     safeGetAsString(transactionDetails, "address_country")
             );
+            String cardBrand = safeGetAsString(transactionDetails, "card_brand_label");
 
-            CardDetails cardDetails = CardDetails.from(entity.getCardholderName(), billingAddress, entity.getCardBrand(),
+            CardDetails cardDetails = CardDetails.from(entity.getCardholderName(), billingAddress, cardBrand,
                     entity.getLastDigitsCardNumber(), entity.getFirstDigitsCardNumber(),
                     safeGetAsString(transactionDetails, "expiry_date"));
 

--- a/src/test/java/uk/gov/pay/ledger/pact/TransactionsAndEventApiContractTest.java
+++ b/src/test/java/uk/gov/pay/ledger/pact/TransactionsAndEventApiContractTest.java
@@ -130,9 +130,9 @@ public class TransactionsAndEventApiContractTest {
         String transactionExternalId2 = "someExternalId2";
 
         createPaymentTransactionForSelfserviceSearch(transactionExternalId1, gatewayAccountId,
-                TransactionState.CREATED, "reference1", null);
+                TransactionState.CREATED, "reference1", null, null);
         createPaymentTransactionForSelfserviceSearch(transactionExternalId2, gatewayAccountId,
-                TransactionState.SUBMITTED, "reference2", "visa");
+                TransactionState.SUBMITTED, "reference2", "visa", "Visa");
 
         createARefundTransaction(transactionExternalId2, gatewayAccountId, "refund-transaction-id",
                 150L, "reference", "description",
@@ -282,7 +282,8 @@ public class TransactionsAndEventApiContractTest {
                                                               String gatewayAccountId,
                                                               TransactionState state,
                                                               String reference,
-                                                              String cardBrand) {
+                                                              String cardBrand,
+                                                              String cardBrandLabel) {
         aTransactionFixture()
                 .withExternalId(transactionExternalId)
                 .withGatewayAccountId(gatewayAccountId)
@@ -291,6 +292,7 @@ public class TransactionsAndEventApiContractTest {
                 .withCardholderName(null)
                 .withState(state)
                 .withCardBrand(cardBrand)
+                .withCardBrandLabel(cardBrandLabel)
                 .insert(app.getJdbi());
     }
 }

--- a/src/test/java/uk/gov/pay/ledger/transaction/model/TransactionFactoryTest.java
+++ b/src/test/java/uk/gov/pay/ledger/transaction/model/TransactionFactoryTest.java
@@ -12,9 +12,7 @@ import java.time.ZonedDateTime;
 import java.util.Optional;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.notNullValue;
-import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.*;
 
 public class TransactionFactoryTest {
 
@@ -58,6 +56,7 @@ public class TransactionFactoryTest {
         fullTransactionDetails.addProperty("gateway_transaction_id", "gti_12334");
         fullTransactionDetails.addProperty("corporate_surcharge", 12);
         fullTransactionDetails.addProperty("fee", 5);
+        fullTransactionDetails.addProperty("card_brand_label", "Visa");
         fullTransactionDetails.addProperty("address_line1", "line 1");
         fullTransactionDetails.addProperty("address_line2", "line 2");
         fullTransactionDetails.addProperty("address_postcode", "A11 11BB");
@@ -146,7 +145,7 @@ public class TransactionFactoryTest {
         assertThat(payment.getCardDetails().getLastDigitsCardNumber(), is(lastDigitsCardNumber));
         assertThat(payment.getCardDetails().getFirstDigitsCardNumber(), is(firstDigitsCardNumber));
         assertThat(payment.getCardDetails().getCardHolderName(), is(cardholderName));
-        assertThat(payment.getCardDetails().getCardBrand(), is(cardBrand));
+        assertThat(payment.getCardDetails().getCardBrand(), emptyString());
         assertThat(payment.getCardDetails().getBillingAddress(), nullValue());
         assertThat(payment.getDelayedCapture(), is(false));
         assertThat(payment.getExternalMetadata(), nullValue());
@@ -214,7 +213,7 @@ public class TransactionFactoryTest {
         assertThat(payment.getCardDetails().getLastDigitsCardNumber(), is(lastDigitsCardNumber));
         assertThat(payment.getCardDetails().getFirstDigitsCardNumber(), is(firstDigitsCardNumber));
         assertThat(payment.getCardDetails().getCardHolderName(), is(cardholderName));
-        assertThat(payment.getCardDetails().getCardBrand(), is(cardBrand));
+        assertThat(payment.getCardDetails().getCardBrand(), is("Visa"));
         assertThat(payment.getCardDetails().getBillingAddress(), notNullValue());
         assertThat(payment.getCardDetails().getBillingAddress().getAddressLine1(), is("line 1"));
         assertThat(payment.getCardDetails().getBillingAddress().getAddressLine2(), is("line 2"));

--- a/src/test/java/uk/gov/pay/ledger/transaction/model/TransactionFactoryTest.java
+++ b/src/test/java/uk/gov/pay/ledger/transaction/model/TransactionFactoryTest.java
@@ -12,7 +12,10 @@ import java.time.ZonedDateTime;
 import java.util.Optional;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.emptyString;
 
 public class TransactionFactoryTest {
 

--- a/src/test/java/uk/gov/pay/ledger/transaction/resource/TransactionResourceIT.java
+++ b/src/test/java/uk/gov/pay/ledger/transaction/resource/TransactionResourceIT.java
@@ -481,6 +481,7 @@ public class TransactionResourceIT {
                 .withState(TransactionState.SUCCESS)
                 .withLastDigitsCardNumber("4242")
                 .withCardBrand("visa")
+                .withCardBrandLabel("Visa")
                 .withGatewayAccountId(gatewayAccountId)
                 .withCreatedDate(ZonedDateTime.now(ZoneOffset.UTC).minusHours(1))
                 .insert(rule.getJdbi());
@@ -514,7 +515,7 @@ public class TransactionResourceIT {
                 .body("results[0].parent_transaction.transaction_type", is("PAYMENT"))
                 .body("results[0].parent_transaction.reference", is(payment.getReference()))
                 .body("results[0].parent_transaction.email", is(payment.getEmail()))
-                .body("results[0].parent_transaction.card_details.card_brand", is(payment.getCardBrand()))
+                .body("results[0].parent_transaction.card_details.card_brand", is("Visa"))
                 .body("results[0].parent_transaction.card_details.last_digits_card_number", is(payment.getLastDigitsCardNumber()))
                 .body("results[0].parent_transaction.card_details.cardholder_name", is(payment.getCardholderName()))
                 .body("results[1].transaction_id", is(payment.getExternalId()))

--- a/src/test/java/uk/gov/pay/ledger/util/fixture/TransactionFixture.java
+++ b/src/test/java/uk/gov/pay/ledger/util/fixture/TransactionFixture.java
@@ -62,7 +62,7 @@ public class TransactionFixture implements DbFixture<TransactionFixture, Transac
     private String transactionType = TransactionType.PAYMENT.name();
     private String parentExternalId;
     private String refundedById;
-
+    private String cardBrandLabel;
 
     private TransactionFixture() {
     }
@@ -265,6 +265,11 @@ public class TransactionFixture implements DbFixture<TransactionFixture, Transac
         return this;
     }
 
+    public TransactionFixture withCardBrandLabel(String cardBrandLabel) {
+        this.cardBrandLabel = cardBrandLabel;
+        return this;
+    }
+
     @Override
     public TransactionFixture insert(Jdbi jdbi) {
         JsonObject transactionDetail = getTransactionDetail();
@@ -336,6 +341,9 @@ public class TransactionFixture implements DbFixture<TransactionFixture, Transac
         transactionDetails.addProperty("gateway_transaction_id", gatewayTransactionId);
         transactionDetails.addProperty("corporate_surcharge", corporateCardSurcharge);
         transactionDetails.addProperty("refunded_by", refundedById);
+
+        Optional.ofNullable(cardBrandLabel)
+                .ifPresent(cardBrandLabel -> transactionDetails.addProperty("card_brand_label", cardBrandLabel));
         Optional.ofNullable(externalMetadata)
                 .ifPresent(cd -> transactionDetails.add("external_metadata", externalMetadata));
         Optional.ofNullable(captureSubmittedDate).ifPresent(


### PR DESCRIPTION
Connector responds with with the card brand human readable labels found
in Connector's database. This is now passed through the payment details
entered event and stored in the `card_brand_label` attribute of
transaction details. Send this in favour of the card brand key (which
can still be searched/ filtered as normal).