### PR TITLE
PP-5565 Handle exception if transaction data is corrupt

### DIFF
--- a/src/main/java/uk/gov/pay/ledger/transaction/dao/mapper/TransactionMapper.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/dao/mapper/TransactionMapper.java
@@ -24,7 +24,7 @@ public class TransactionMapper implements RowMapper<TransactionEntity> {
                 .withAmount(getLongWithNullCheck(rs, "amount"))
                 .withReference(rs.getString("reference"))
                 .withDescription(rs.getString("description"))
-                .withState(TransactionState.valueOf(rs.getString("state")))
+                .withState(TransactionState.from(rs.getString("state")))
                 .withEmail(rs.getString("email"))
                 .withCardholderName(rs.getString("cardholder_name"))
                 .withCreatedDate(getZonedDateTime(rs, "created_date").orElse(null))

--- a/src/main/java/uk/gov/pay/ledger/transaction/dao/mapper/TransactionWithParentMapper.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/dao/mapper/TransactionWithParentMapper.java
@@ -74,7 +74,7 @@ public class TransactionWithParentMapper implements RowMapper<TransactionEntity>
     private TransactionState getState(ResultSet rs, String columnName) throws SQLException {
         String state = rs.getString(columnName);
         return Optional.ofNullable(state)
-                .map(TransactionState::valueOf)
+                .map(TransactionState::from)
                 .orElse(null);
     }
 


### PR DESCRIPTION
If an unknown transaction state is stored in the database `valueOf` will
throw an exception. Use `from` String exposed on `TransactionState`
which should handle no mapping.