### PR TITLE
PP-5662 Add "card_type": "DEBIT" to PaymentDetailsEntered test

### DIFF
--- a/src/test/java/uk/gov/pay/ledger/util/fixture/QueuePaymentEventFixture.java
+++ b/src/test/java/uk/gov/pay/ledger/util/fixture/QueuePaymentEventFixture.java
@@ -95,6 +95,7 @@ public class QueuePaymentEventFixture implements QueueFixture<QueuePaymentEventF
                                 .put("address_postcode", "N1 3QU")
                                 .put("address_city", "London")
                                 .put("address_country", "GB")
+                                .put("card_type", "DEBIT")
                                 .put("card_brand", "visa")
                                 .put("gateway_transaction_id", gatewayAccountId)
                                 .put("corporate_surcharge", 5)


### PR DESCRIPTION
Add `"card_type": "DEBIT"` to the `PaymentDetailsEntered` event details test fixture because connector will now be sending something like this.

No need to update the test assertions because ledger does not yet return the card type in responses.