### PR TITLE
PP-5671 Add report service

### DIFF
--- a/src/main/java/uk/gov/pay/ledger/app/LedgerModule.java
+++ b/src/main/java/uk/gov/pay/ledger/app/LedgerModule.java
@@ -13,6 +13,7 @@ import io.dropwizard.setup.Environment;
 import org.jdbi.v3.core.Jdbi;
 import uk.gov.pay.ledger.event.dao.EventDao;
 import uk.gov.pay.ledger.event.dao.ResourceTypeDao;
+import uk.gov.pay.ledger.report.dao.ReportDao;
 import uk.gov.pay.ledger.transaction.dao.TransactionDao;
 
 public class LedgerModule extends AbstractModule {
@@ -61,6 +62,10 @@ public class LedgerModule extends AbstractModule {
     @Singleton
     public TransactionDao provideTransactionDao() {
         return new TransactionDao(jdbi);
+    }
+
+    public ReportDao provideReportDao() {
+        return new ReportDao(jdbi);
     }
 
     @Provides

--- a/src/main/java/uk/gov/pay/ledger/report/entity/PaymentCountByStateResult.java
+++ b/src/main/java/uk/gov/pay/ledger/report/entity/PaymentCountByStateResult.java
@@ -11,6 +11,14 @@ public class PaymentCountByStateResult {
         this.count = count;
     }
 
+    public String getState() {
+        return state;
+    }
+
+    public Long getCount() {
+        return count;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;

--- a/src/main/java/uk/gov/pay/ledger/report/params/PaymentsReportParams.java
+++ b/src/main/java/uk/gov/pay/ledger/report/params/PaymentsReportParams.java
@@ -21,12 +21,24 @@ public class PaymentsReportParams {
     @QueryParam("to_date")
     private String toDate;
 
+    public String getAccountId() {
+        return accountId;
+    }
+
     public void setAccountId(String accountId) {
         this.accountId = accountId;
     }
 
+    public String getFromDate() {
+        return fromDate;
+    }
+
     public void setFromDate(String fromDate) {
         this.fromDate = fromDate;
+    }
+
+    public String getToDate() {
+        return toDate;
     }
 
     public void setToDate(String toDate) {

--- a/src/main/java/uk/gov/pay/ledger/report/service/ReportService.java
+++ b/src/main/java/uk/gov/pay/ledger/report/service/ReportService.java
@@ -1,0 +1,37 @@
+package uk.gov.pay.ledger.report.service;
+
+import com.google.inject.Inject;
+import uk.gov.pay.ledger.report.dao.ReportDao;
+import uk.gov.pay.ledger.report.params.PaymentsReportParams;
+import uk.gov.pay.ledger.transaction.state.TransactionState;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
+
+public class ReportService {
+
+    private final ReportDao reportDao;
+
+    @Inject
+    public ReportService(ReportDao reportDao) {
+        this.reportDao = reportDao;
+    }
+
+    public Map<String, Long> getPaymentCountsByState(String gatewayAccountId, PaymentsReportParams params) {
+        if (isNotBlank(gatewayAccountId)) {
+            params.setAccountId(gatewayAccountId);
+        }
+
+        // return map with all states, with count of 0 if no payments exist for state
+        Map<String, Long> responseMap = new HashMap<>();
+        Arrays.stream(TransactionState.values()).forEach(state -> responseMap.put(state.getStatus() , 0L));
+
+        reportDao.getPaymentCountsByState(params).forEach(result ->
+                responseMap.put(TransactionState.from(result.getState()).getStatus(), result.getCount()));
+
+        return responseMap;
+    }
+}

--- a/src/test/java/uk/gov/pay/ledger/report/service/ReportServiceTest.java
+++ b/src/test/java/uk/gov/pay/ledger/report/service/ReportServiceTest.java
@@ -1,0 +1,92 @@
+package uk.gov.pay.ledger.report.service;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.pay.ledger.report.dao.ReportDao;
+import uk.gov.pay.ledger.report.entity.PaymentCountByStateResult;
+import uk.gov.pay.ledger.report.params.PaymentsReportParams;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.aMapWithSize;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.hasEntry;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.mockito.Mockito.when;
+import static uk.gov.pay.ledger.transaction.state.TransactionState.CREATED;
+import static uk.gov.pay.ledger.transaction.state.TransactionState.ERROR;
+import static uk.gov.pay.ledger.transaction.state.TransactionState.SUCCESS;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ReportServiceTest {
+
+    @Mock
+    private ReportDao mockReportDao;
+
+    @Captor
+    private ArgumentCaptor<PaymentsReportParams> paymentsReportParamsCaptor;
+
+    @InjectMocks
+    private ReportService reportService;
+
+    @Test
+    public void shouldReturnPaymentCountsByState_whenGatewayAccountIdProvided() {
+        String gatewayAccountId = "1";
+        String fromDate = "2019-10-1T10:00:00.000Z";
+        String toDate = "2019-10-1T11:00:00.000Z";
+        var params = new PaymentsReportParams();
+        params.setFromDate(fromDate);
+        params.setToDate(toDate);
+
+        when(mockReportDao.getPaymentCountsByState(paymentsReportParamsCaptor.capture())).thenReturn(List.of(
+                new PaymentCountByStateResult(CREATED.name(), 2L),
+                new PaymentCountByStateResult(SUCCESS.name(), 1L),
+                new PaymentCountByStateResult(ERROR.name(), 3L)
+        ));
+
+        Map<String, Long> response = reportService.getPaymentCountsByState(gatewayAccountId, params);
+
+        assertThat(paymentsReportParamsCaptor.getValue().getAccountId(), is(gatewayAccountId));
+        assertThat(paymentsReportParamsCaptor.getValue().getFromDate(), is(fromDate));
+        assertThat(paymentsReportParamsCaptor.getValue().getToDate(), is(toDate));
+
+        assertThat(response, allOf(
+                aMapWithSize(10),
+                hasEntry("undefined", 0L),
+                hasEntry("created", 2L),
+                hasEntry("started", 0L),
+                hasEntry("submitted", 0L),
+                hasEntry("capturable", 0L),
+                hasEntry("success", 1L),
+                hasEntry("declined", 0L),
+                hasEntry("timedout", 0L),
+                hasEntry("cancelled", 0L),
+                hasEntry("error", 3L)
+        ));
+    }
+
+    @Test
+    public void shouldReturnPaymentCountsByState_whenGatewayAccountIdNotProvided() {
+        var params = new PaymentsReportParams();
+        params.setFromDate("2019-10-1T10:00:00.000Z");
+        params.setToDate("2019-10-1T11:00:00.000Z");
+
+        when(mockReportDao.getPaymentCountsByState(paymentsReportParamsCaptor.capture())).thenReturn(List.of(
+                new PaymentCountByStateResult(CREATED.name(), 2L),
+                new PaymentCountByStateResult(SUCCESS.name(), 1L)
+        ));
+
+        Map<String, Long> response = reportService.getPaymentCountsByState(null, params);
+
+        assertThat(paymentsReportParamsCaptor.getValue().getAccountId(), is(nullValue()));
+        assertThat(response, aMapWithSize(10));
+    }
+}


### PR DESCRIPTION
Add service that calls the report DAO to get the counts by payment
status and from them constructs a Map which can be returned in the body
of the response for the get payment counts by status endpoint.