### PR TITLE
PP-5670: Specify the consumer when running contract test

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,10 +11,10 @@
         <mainClass>uk.gov.pay.ledger.app.LedgerApp</mainClass>
 
         <dropwizard.version>1.3.15</dropwizard.version>
-        <jackson.version>2.9.8</jackson.version>
+        <jackson.version>2.10.0</jackson.version>
         <testcontainers.version>1.12.2</testcontainers.version>
         <postgresql.version>42.2.8</postgresql.version>
-        <pay-java-commons.version>1.0.20191002153026</pay-java-commons.version>
+        <pay-java-commons.version>1.0.20191003132942</pay-java-commons.version>
         <surefire.version>3.0.0-M3</surefire.version>
         <guice.version>4.2.2</guice.version>
         <rest-assured.version>4.1.2</rest-assured.version>
@@ -132,6 +132,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-jsr310</artifactId>
+            <version>${jackson.version}</version>
         </dependency>
         <!--test dependencies-->
         <dependency>
@@ -198,6 +199,18 @@
             <artifactId>awaitility</artifactId>
             <version>4.0.1</version>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>uk.gov.pay</groupId>
+            <artifactId>testing</artifactId>
+            <version>${pay-java-commons.version}</version>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.spotify</groupId>
+                    <artifactId>docker-client</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
     </dependencies>
 

--- a/src/test/java/uk/gov/pay/ledger/pact/ContractTest.java
+++ b/src/test/java/uk/gov/pay/ledger/pact/ContractTest.java
@@ -1,17 +1,12 @@
 package uk.gov.pay.ledger.pact;
 
-import au.com.dius.pact.provider.junit.PactRunner;
-import au.com.dius.pact.provider.junit.Provider;
 import au.com.dius.pact.provider.junit.State;
-import au.com.dius.pact.provider.junit.loader.PactBroker;
-import au.com.dius.pact.provider.junit.loader.PactBrokerAuth;
 import au.com.dius.pact.provider.junit.target.HttpTarget;
 import au.com.dius.pact.provider.junit.target.Target;
 import au.com.dius.pact.provider.junit.target.TestTarget;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
-import org.junit.runner.RunWith;
 import uk.gov.pay.ledger.event.model.SalientEventType;
 import uk.gov.pay.ledger.rule.AppWithPostgresAndSqsRule;
 import uk.gov.pay.ledger.transaction.model.TransactionType;
@@ -27,12 +22,7 @@ import static uk.gov.pay.ledger.util.DatabaseTestHelper.aDatabaseTestHelper;
 import static uk.gov.pay.ledger.util.fixture.EventFixture.anEventFixture;
 import static uk.gov.pay.ledger.util.fixture.TransactionFixture.aTransactionFixture;
 
-@RunWith(PactRunner.class)
-@Provider("ledger")
-@PactBroker(scheme = "https", host = "pact-broker-test.cloudapps.digital", tags = {"${PACT_CONSUMER_TAG}", "test"},
-        authentication = @PactBrokerAuth(username = "${PACT_BROKER_USERNAME}", password = "${PACT_BROKER_PASSWORD}"),
-        consumers = {"publicapi", "selfservice"})
-public class TransactionsAndEventApiContractTest {
+public abstract class ContractTest {
 
     @ClassRule
     public static AppWithPostgresAndSqsRule app = new AppWithPostgresAndSqsRule();

--- a/src/test/java/uk/gov/pay/ledger/pact/ContractTestSuite.java
+++ b/src/test/java/uk/gov/pay/ledger/pact/ContractTestSuite.java
@@ -1,20 +1,27 @@
 package uk.gov.pay.ledger.pact;
 
+import com.google.common.collect.ImmutableSetMultimap;
+import junit.framework.JUnit4TestAdapter;
+import junit.framework.TestSuite;
 import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
+import org.junit.runners.AllTests;
+import uk.gov.pay.commons.testing.pact.provider.CreateTestSuite;
 
-@RunWith(Suite.class)
-
-@Suite.SuiteClasses({
-        TransactionsAndEventApiContractTest.class,
-        PaymentCreatedEventQueueContractTest.class,
-        PaymentDetailsEnteredEventQueueContractTest.class,
-        CaptureConfirmedEventQueueContractTest.class,
-        RefundCreatedByUserEventQueueContractTest.class,
-        RefundSubmittedEventQueueContractTest.class,
-        RefundSucceededEventQueueContractTest.class,
-        CaptureSubmittedEventQueueContractTest.class
-})
+@RunWith(AllTests.class)
 public class ContractTestSuite {
+
+    public static TestSuite suite() {
+        ImmutableSetMultimap.Builder<String, JUnit4TestAdapter> consumerToJUnitTest = ImmutableSetMultimap.builder();
+        consumerToJUnitTest.put("publicapi", new JUnit4TestAdapter(PublicApiContractTest.class));
+        consumerToJUnitTest.put("selfservice", new JUnit4TestAdapter(SelfServiceContractTest.class));
+        consumerToJUnitTest.put("connector", new JUnit4TestAdapter(PaymentCreatedEventQueueContractTest.class));
+        consumerToJUnitTest.put("connector", new JUnit4TestAdapter(PaymentDetailsEnteredEventQueueContractTest.class));
+        consumerToJUnitTest.put("connector", new JUnit4TestAdapter(CaptureConfirmedEventQueueContractTest.class));
+        consumerToJUnitTest.put("connector", new JUnit4TestAdapter(RefundCreatedByUserEventQueueContractTest.class));
+        consumerToJUnitTest.put("connector", new JUnit4TestAdapter(RefundSubmittedEventQueueContractTest.class));
+        consumerToJUnitTest.put("connector", new JUnit4TestAdapter(RefundSucceededEventQueueContractTest.class));
+        consumerToJUnitTest.put("connector", new JUnit4TestAdapter(CaptureSubmittedEventQueueContractTest.class));
+        return CreateTestSuite.create(consumerToJUnitTest.build());
+    }
 
 }

--- a/src/test/java/uk/gov/pay/ledger/pact/PublicApiContractTest.java
+++ b/src/test/java/uk/gov/pay/ledger/pact/PublicApiContractTest.java
@@ -1,0 +1,15 @@
+package uk.gov.pay.ledger.pact;
+
+import au.com.dius.pact.provider.junit.PactRunner;
+import au.com.dius.pact.provider.junit.Provider;
+import au.com.dius.pact.provider.junit.loader.PactBroker;
+import au.com.dius.pact.provider.junit.loader.PactBrokerAuth;
+import org.junit.runner.RunWith;
+
+@RunWith(PactRunner.class)
+@Provider("ledger")
+@PactBroker(scheme = "https", host = "pact-broker-test.cloudapps.digital", tags = {"${PACT_CONSUMER_TAG}", "test"},
+        authentication = @PactBrokerAuth(username = "${PACT_BROKER_USERNAME}", password = "${PACT_BROKER_PASSWORD}"),
+        consumers = {"publicapi"})
+public class PublicApiContractTest extends ContractTest {
+}

--- a/src/test/java/uk/gov/pay/ledger/pact/SelfServiceContractTest.java
+++ b/src/test/java/uk/gov/pay/ledger/pact/SelfServiceContractTest.java
@@ -1,0 +1,15 @@
+package uk.gov.pay.ledger.pact;
+
+import au.com.dius.pact.provider.junit.PactRunner;
+import au.com.dius.pact.provider.junit.Provider;
+import au.com.dius.pact.provider.junit.loader.PactBroker;
+import au.com.dius.pact.provider.junit.loader.PactBrokerAuth;
+import org.junit.runner.RunWith;
+
+@RunWith(PactRunner.class)
+@Provider("ledger")
+@PactBroker(scheme = "https", host = "pact-broker-test.cloudapps.digital", tags = {"${PACT_CONSUMER_TAG}", "test"},
+        authentication = @PactBrokerAuth(username = "${PACT_BROKER_USERNAME}", password = "${PACT_BROKER_PASSWORD}"),
+        consumers = {"selfservice"})
+public class SelfServiceContractTest extends ContractTest {
+}


### PR DESCRIPTION
Currently when a consumer build is kicked off, the provider contract test will
run in its entirety. For example, in a selfservice build, the ledger provider
contract tests will run as well. However, what is run is:

publicapi->ledger
selfservice->ledger
connector->ledger

We really only want to run selfservice->ledger in this case.

This commit will allow a dynamic creation of the test suite to run based on a
CONSUMER system property. This will mean shorter run times when a provider
contract test is run as part of a specific consumer build.