### PR TITLE
PP-5677 Add get payment statistics endpoint

### DIFF
--- a/src/main/java/uk/gov/pay/ledger/report/entity/PaymentsStatisticsResult.java
+++ b/src/main/java/uk/gov/pay/ledger/report/entity/PaymentsStatisticsResult.java
@@ -1,0 +1,47 @@
+package uk.gov.pay.ledger.report.entity;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+import java.util.Objects;
+
+@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+public class PaymentsStatisticsResult {
+    private final long count;
+    private final long grossAmount;
+
+    public PaymentsStatisticsResult(long count, long grossAmount) {
+        this.count = count;
+        this.grossAmount = grossAmount;
+    }
+
+    public long getCount() {
+        return count;
+    }
+
+    public long getGrossAmount() {
+        return grossAmount;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        PaymentsStatisticsResult that = (PaymentsStatisticsResult) o;
+        return count == that.count &&
+                grossAmount == that.grossAmount;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(count, grossAmount);
+    }
+
+    @Override
+    public String toString() {
+        return "PaymentsStatisticsResult{" +
+                "count=" + count +
+                ", grossAmount=" + grossAmount +
+                '}';
+    }
+}

--- a/src/main/java/uk/gov/pay/ledger/report/service/ReportService.java
+++ b/src/main/java/uk/gov/pay/ledger/report/service/ReportService.java
@@ -2,6 +2,7 @@ package uk.gov.pay.ledger.report.service;
 
 import com.google.inject.Inject;
 import uk.gov.pay.ledger.report.dao.ReportDao;
+import uk.gov.pay.ledger.report.entity.PaymentsStatisticsResult;
 import uk.gov.pay.ledger.report.params.PaymentsReportParams;
 import uk.gov.pay.ledger.transaction.state.TransactionState;
 
@@ -20,10 +21,6 @@ public class ReportService {
         this.reportDao = reportDao;
     }
 
-    public Map<String, Long> getPaymentCountsByState(PaymentsReportParams params) {
-        return getPaymentCountsByState(null, params);
-    }
-
     public Map<String, Long> getPaymentCountsByState(String gatewayAccountId, PaymentsReportParams params) {
         if (isNotBlank(gatewayAccountId)) {
             params.setAccountId(gatewayAccountId);
@@ -37,5 +34,13 @@ public class ReportService {
                 responseMap.put(TransactionState.from(result.getState()).getStatus(), result.getCount()));
 
         return responseMap;
+    }
+
+    public PaymentsStatisticsResult getPaymentsStatistics(String gatewayAccountId, PaymentsReportParams params) {
+        if (isNotBlank(gatewayAccountId)) {
+            params.setAccountId(gatewayAccountId);
+        }
+
+        return reportDao.getPaymentsStatistics(params);
     }
 }

--- a/src/test/java/uk/gov/pay/ledger/report/resource/ReportResourceIT.java
+++ b/src/test/java/uk/gov/pay/ledger/report/resource/ReportResourceIT.java
@@ -61,4 +61,33 @@ public class ReportResourceIT {
                 .body("cancelled", is(0))
                 .body("error", is(0));
     }
+
+    @Test
+    public void shouldGetPaymentsStatistics() {
+        String gatewayAccountId = "abc123";
+        aTransactionFixture()
+                .withTotalAmount(1000L)
+                .withState(TransactionState.SUCCESS)
+                .withGatewayAccountId(gatewayAccountId)
+                .withCreatedDate(ZonedDateTime.parse("2019-10-01T10:00:00.000Z"))
+                .insert(rule.getJdbi());
+        aTransactionFixture()
+                .withTotalAmount(2000L)
+                .withState(TransactionState.SUCCESS)
+                .withGatewayAccountId(gatewayAccountId)
+                .withCreatedDate(ZonedDateTime.parse("2019-10-01T10:00:00.000Z"))
+                .insert(rule.getJdbi());
+
+        given().port(port)
+                .contentType(JSON)
+                .get("/v1/report/payments?account_id=" + gatewayAccountId +
+                        "&from_date=2019-10-01T09:00:00.000Z" +
+                        "&to_date=2019-10-01T11:00:00.000Z"
+                )
+                .then()
+                .statusCode(Response.Status.OK.getStatusCode())
+                .contentType(JSON)
+                .body("count", is(2))
+                .body("gross_amount", is(3000));
+    }
 }

--- a/src/test/java/uk/gov/pay/ledger/report/resource/ReportResourceTest.java
+++ b/src/test/java/uk/gov/pay/ledger/report/resource/ReportResourceTest.java
@@ -7,6 +7,7 @@ import org.junit.ClassRule;
 import org.junit.Test;
 import uk.gov.pay.ledger.exception.BadRequestExceptionMapper;
 import uk.gov.pay.ledger.exception.JerseyViolationExceptionMapper;
+import uk.gov.pay.ledger.report.entity.PaymentsStatisticsResult;
 import uk.gov.pay.ledger.report.params.PaymentsReportParams;
 import uk.gov.pay.ledger.report.service.ReportService;
 
@@ -45,7 +46,8 @@ public class ReportResourceTest {
 
     @Test
     public void getPaymentsByState_shouldReturn200IfGatewayAccountIdIsNotProvidedButNotRequiredFlag() {
-        when(mockReportService.getPaymentCountsByState(new PaymentsReportParams())).thenReturn(Map.of("blah", 1L));
+        when(mockReportService.getPaymentCountsByState(null, new PaymentsReportParams()))
+                .thenReturn(Map.of("blah", 1L));
 
         Response response = resources
                 .target("/v1/report/payments_by_state")
@@ -75,6 +77,63 @@ public class ReportResourceTest {
     public void getPaymentsByState_shouldReturn422IfToDateInvalid() {
         Response response = resources
                 .target("/v1/report/payments_by_state")
+                .queryParam("account_id", "abc123")
+                .queryParam("to_date", "invalid")
+                .request()
+                .get();
+
+        assertThat(response.getStatus(), is(422));
+
+        Map responseMap = response.readEntity(Map.class);
+        assertThat(responseMap.get("message"), is(List.of("Invalid attribute value: to_date. Must be a valid date")));
+    }
+
+    @Test
+    public void getPaymentsStatistics_shouldReturn400IfGatewayAccountIsNotProvided() {
+        Response response = resources
+                .target("/v1/report/payments")
+                .request()
+                .get();
+
+        assertThat(response.getStatus(), is(400));
+
+        Map responseMap = response.readEntity(Map.class);
+        assertThat(responseMap.get("message"), is(List.of("Field [account_id] cannot be empty")));
+    }
+
+    @Test
+    public void getPaymentsStatistics_shouldReturn200IfGatewayAccountIdIsNotProvidedButNotRequiredFlag() {
+        when(mockReportService.getPaymentsStatistics(null, new PaymentsReportParams()))
+                .thenReturn(new PaymentsStatisticsResult(200L, 20000L));
+
+        Response response = resources
+                .target("/v1/report/payments")
+                .queryParam("override_account_id_restriction", true)
+                .request()
+                .get();
+
+        Assert.assertThat(response.getStatus(), CoreMatchers.is(200));
+    }
+
+    @Test
+    public void getPaymentsStatistics_shouldReturn422IfFromDateInvalid() {
+        Response response = resources
+                .target("/v1/report/payments")
+                .queryParam("account_id", "abc123")
+                .queryParam("from_date", "invalid")
+                .request()
+                .get();
+
+        assertThat(response.getStatus(), is(422));
+
+        Map responseMap = response.readEntity(Map.class);
+        assertThat(responseMap.get("message"), is(List.of("Invalid attribute value: from_date. Must be a valid date")));
+    }
+
+    @Test
+    public void getPaymentsStatistics_shouldReturn422IfToDateInvalid() {
+        Response response = resources
+                .target("/v1/report/payments")
                 .queryParam("account_id", "abc123")
                 .queryParam("to_date", "invalid")
                 .request()

--- a/src/test/java/uk/gov/pay/ledger/report/service/ReportServiceTest.java
+++ b/src/test/java/uk/gov/pay/ledger/report/service/ReportServiceTest.java
@@ -9,6 +9,7 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.pay.ledger.report.dao.ReportDao;
 import uk.gov.pay.ledger.report.entity.PaymentCountByStateResult;
+import uk.gov.pay.ledger.report.entity.PaymentsStatisticsResult;
 import uk.gov.pay.ledger.report.params.PaymentsReportParams;
 
 import java.util.List;
@@ -88,5 +89,41 @@ public class ReportServiceTest {
 
         assertThat(paymentsReportParamsCaptor.getValue().getAccountId(), is(nullValue()));
         assertThat(response, aMapWithSize(10));
+    }
+
+    @Test
+    public void shouldReturnPaymentsStatistics_whenGatewayAccountIdProvided() {
+        String gatewayAccountId = "1";
+        String fromDate = "2019-10-1T10:00:00.000Z";
+        String toDate = "2019-10-1T11:00:00.000Z";
+        var params = new PaymentsReportParams();
+        params.setFromDate(fromDate);
+        params.setToDate(toDate);
+
+        PaymentsStatisticsResult result = new PaymentsStatisticsResult(5L, 10000L);
+        when(mockReportDao.getPaymentsStatistics(paymentsReportParamsCaptor.capture()))
+                .thenReturn(result);
+
+        PaymentsStatisticsResult paymentsStatistics = reportService.getPaymentsStatistics(gatewayAccountId, params);
+
+        assertThat(paymentsReportParamsCaptor.getValue().getAccountId(), is(gatewayAccountId));
+        assertThat(paymentsReportParamsCaptor.getValue().getFromDate(), is(fromDate));
+        assertThat(paymentsReportParamsCaptor.getValue().getToDate(), is(toDate));
+
+        assertThat(paymentsStatistics, is(result));
+    }
+
+    @Test
+    public void shouldReturnPaymentsStatistics_whenGatewayAccountIdNotProvided() {
+        var params = new PaymentsReportParams();
+
+        PaymentsStatisticsResult result = new PaymentsStatisticsResult(5L, 10000L);
+        when(mockReportDao.getPaymentsStatistics(paymentsReportParamsCaptor.capture()))
+                .thenReturn(result);
+
+        PaymentsStatisticsResult paymentsStatistics = reportService.getPaymentsStatistics(null, params);
+
+        assertThat(paymentsReportParamsCaptor.getValue().getAccountId(), is(nullValue()));
+        assertThat(paymentsStatistics, is(result));
     }
 }


### PR DESCRIPTION
Add an endpoint in the report resource to get some overview payment statistics, optionally by gateway account and filtered by created date.

The endpoint returns the count and the gross total amount of successful payments meeting the filter parameters.