### PR TITLE
PP-5670: Specify consumer when running provider test

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -86,7 +86,7 @@ pipeline {
           env.PACT_TAG = gitBranchName()
         }
         ws('contract-tests-wp') {
-          runPactProviderTests("pay-connector", "${env.PACT_TAG}")
+          runPactProviderTests("pay-connector", "${env.PACT_TAG}", "ledger")
         }
       }
       post {


### PR DESCRIPTION
This will cause only the ledger->connector test to run during a ledger build.