### PR TITLE
PP-5681 re-enable fixed msg queue test for telephone payments

### DIFF
--- a/src/test/java/uk/gov/pay/ledger/pact/PaymentNotificationCreatedEventQueueContractTest.java
+++ b/src/test/java/uk/gov/pay/ledger/pact/PaymentNotificationCreatedEventQueueContractTest.java
@@ -85,7 +85,7 @@ public class PaymentNotificationCreatedEventQueueContractTest {
         assertThat(transaction.get().getDescription(), is("New passport application"));
         assertThat(transaction.get().getTransactionDetails(), containsString("\"gateway_transaction_id\": \"providerId\""));
         assertThat(transaction.get().getTransactionDetails(), containsString("\"amount\": 1000"));
-//        assertThat(transaction.get().getTransactionDetails(), containsString("\"expiry_date\": \"11/21\""));
+        assertThat(transaction.get().getTransactionDetails(), containsString("\"expiry_date\": \"11/21\""));
         assertThat(transaction.get().getTransactionDetails(), containsString("\"status\": \"success\""));
         assertThat(transaction.get().getTransactionDetails(), containsString("\"auth_code\": \"authCode\""));
         assertThat(transaction.get().getTransactionDetails(), containsString("\"processor_id\": \"processorId\""));

--- a/src/test/java/uk/gov/pay/ledger/util/fixture/QueuePaymentEventFixture.java
+++ b/src/test/java/uk/gov/pay/ledger/util/fixture/QueuePaymentEventFixture.java
@@ -135,7 +135,7 @@ public class QueuePaymentEventFixture implements QueueFixture<QueuePaymentEventF
                             .put("last_digits_card_number", "4242")
                             .put("first_digits_card_number", "424242")
                             .put("cardholder_name", "J citizen")
-                            // .put("expiry_date", "11/21")
+                            .put("expiry_date", "11/21")
                             .put("card_brand", "visa")
                             .put("gateway_transaction_id", "providerId")
                             .build());


### PR DESCRIPTION
## WHAT
- re-enable card expiry date field to be checked in pact test
- rename card_expiry_date to expiry_date