### PR TITLE
PP-5681 insert gateway_transaction_id when creating a payment type

### DIFF
--- a/src/main/java/uk/gov/pay/ledger/transaction/dao/TransactionDao.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/dao/TransactionDao.java
@@ -100,7 +100,8 @@ public class TransactionDao {
                     "refund_amount_available," +
                     "refund_amount_refunded, " +
                     "refund_status, " +
-                    "live" +
+                    "live, " +
+                    "gateway_transaction_id" +
                     ") " +
                     "VALUES (" +
                     ":externalId," +
@@ -125,7 +126,8 @@ public class TransactionDao {
                     ":refundAmountAvailable," +
                     ":refundAmountRefunded," +
                     ":refundStatus," +
-                    ":live" +
+                    ":live, " +
+                    ":gatewayTransactionId" +
             ") " +
             "ON CONFLICT (external_id) " +
             "DO UPDATE SET " +
@@ -151,8 +153,9 @@ public class TransactionDao {
                 "refund_amount_available = EXCLUDED.refund_amount_available, " +
                 "refund_amount_refunded = EXCLUDED.refund_amount_refunded, " +
                 "refund_status = EXCLUDED.refund_status, " +
-                "live = EXCLUDED.live " +
-            "WHERE EXCLUDED.event_count >= transaction.event_count;";
+                "live = EXCLUDED.live, " +
+                "gateway_transaction_id = EXCLUDED.gateway_transaction_id " +
+                "WHERE EXCLUDED.event_count >= transaction.event_count;";
 
     private final Jdbi jdbi;
 

--- a/src/main/java/uk/gov/pay/ledger/transaction/dao/mapper/TransactionMapper.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/dao/mapper/TransactionMapper.java
@@ -41,6 +41,7 @@ public class TransactionMapper implements RowMapper<TransactionEntity> {
                 .withFee(getLongWithNullCheck(rs, "fee"))
                 .withTransactionType(rs.getString("type"))
                 .withLive(rs.getBoolean("live"))
+                .withGatewayTransactionId(rs.getString("gateway_transaction_id"))
                 .build();
     }
 

--- a/src/main/java/uk/gov/pay/ledger/transaction/entity/TransactionEntity.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/entity/TransactionEntity.java
@@ -44,6 +44,7 @@ public class TransactionEntity {
     @JsonIgnore
     private boolean live;
     private TransactionEntity parentTransactionEntity;
+    private String gatewayTransactionId;
 
     public TransactionEntity() {
     }
@@ -74,6 +75,7 @@ public class TransactionEntity {
         this.transactionType = builder.transactionType;
         this.parentTransactionEntity = builder.parentTransactionEntity;
         this.live = builder.live;
+        this.gatewayTransactionId = builder.gatewayTransactionId;
     }
 
     public Long getId() {
@@ -204,6 +206,10 @@ public class TransactionEntity {
         return parentTransactionEntity;
     }
 
+    public String getGatewayTransactionId() {
+        return gatewayTransactionId;
+    }
+
     public static class Builder {
         private Long fee;
         private Long id;
@@ -230,6 +236,7 @@ public class TransactionEntity {
         private String transactionType;
         private boolean live;
         private TransactionEntity parentTransactionEntity;
+        public String gatewayTransactionId;
 
         public Builder() {
         }
@@ -363,5 +370,9 @@ public class TransactionEntity {
             return this;
         }
 
+        public Builder withGatewayTransactionId(String gatewayTransactionId) {
+            this.gatewayTransactionId = gatewayTransactionId;
+            return this;
+        }
     }
 }

--- a/src/main/java/uk/gov/pay/ledger/transaction/search/model/TransactionView.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/search/model/TransactionView.java
@@ -113,6 +113,7 @@ public class TransactionView {
                     .withSettlementSummary(payment.getSettlementSummary())
                     .withMetadata(payment.getExternalMetadata())
                     .withTransactionType(payment.getTransactionType())
+                    .withGatewayTransactionId(payment.getGatewayTransactionId())
                     .build();
         }
 

--- a/src/test/java/uk/gov/pay/ledger/transaction/dao/TransactionDaoIT.java
+++ b/src/test/java/uk/gov/pay/ledger/transaction/dao/TransactionDaoIT.java
@@ -35,6 +35,7 @@ public class TransactionDaoIT {
                 .withExternalMetadata(ImmutableMap.of("key1", "value1", "anotherKey", ImmutableMap.of("nestedKey", "value")))
                 .withTransactionType("PAYMENT")
                 .withLive(true)
+                .withGatewayTransactionId("gateway_transaction_id")
                 .withDefaultTransactionDetails();
         TransactionEntity transactionEntity = fixture.toEntity();
 
@@ -68,6 +69,7 @@ public class TransactionDaoIT {
         assertThat(retrievedTransaction.getRefundAmountAvailable(), is(transactionEntity.getRefundAmountAvailable()));
         assertThat(retrievedTransaction.getRefundAmountRefunded(), is(transactionEntity.getRefundAmountRefunded()));
         assertThat(retrievedTransaction.getRefundStatus(), is(transactionEntity.getRefundStatus()));
+        assertThat(retrievedTransaction.getGatewayTransactionId(), is(transactionEntity.getGatewayTransactionId()));
         assertThat(retrievedTransaction.isLive(), is(true));
     }
 

--- a/src/test/java/uk/gov/pay/ledger/util/fixture/TransactionFixture.java
+++ b/src/test/java/uk/gov/pay/ledger/util/fixture/TransactionFixture.java
@@ -306,9 +306,10 @@ public class TransactionFixture implements DbFixture<TransactionFixture, Transac
                                 "        refund_amount_refunded,\n" +
                                 "        refund_amount_available,\n" +
                                 "        type,\n" +
-                                "        live\n" +
+                                "        live,\n" +
+                                "        gateway_transaction_id\n" +
                                 "    )\n" +
-                                "VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, CAST(? as jsonb), ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?::transaction_type, ?)\n",
+                                "VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, CAST(? as jsonb), ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?::transaction_type, ?, ?)\n",
                         id,
                         externalId,
                         parentExternalId,
@@ -332,7 +333,8 @@ public class TransactionFixture implements DbFixture<TransactionFixture, Transac
                         refundAmountRefunded,
                         refundAmountAvailable,
                         transactionType,
-                        live
+                        live,
+                        gatewayTransactionId
                 )
         );
         return this;
@@ -404,6 +406,7 @@ public class TransactionFixture implements DbFixture<TransactionFixture, Transac
                 .withFee(fee)
                 .withTransactionType(transactionType)
                 .withLive(live)
+                .withGatewayTransactionId(gatewayTransactionId)
                 .build();
     }
 


### PR DESCRIPTION
## WHAT
- insert gateway_transaction_id when creating a telephone payment
- gateway transaction id is an important part of the telephone and thus we need to store it