### PR TITLE
PP-5602 Return 404 for invalid page number

### DIFF
--- a/src/main/java/uk/gov/pay/ledger/transaction/service/TransactionService.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/service/TransactionService.java
@@ -100,6 +100,15 @@ public class TransactionService {
 
         Long total = transactionDao.getTotalForSearch(searchParams);
 
+        long size = searchParams.getDisplaySize();
+        if (total > 0 && searchParams.getDisplaySize() > 0) {
+            long lastPage = (total + size - 1) / size;
+            if (searchParams.getPageNumber() > lastPage || searchParams.getPageNumber() < 1) {
+                throw new WebApplicationException("the requested page not found",
+                        Response.Status.NOT_FOUND);
+            }
+        }
+
         return buildTransactionSearchResponse(searchParams, uriInfo, transactionList, total);
     }
 

--- a/src/test/java/uk/gov/pay/ledger/transaction/service/TransactionServiceTest.java
+++ b/src/test/java/uk/gov/pay/ledger/transaction/service/TransactionServiceTest.java
@@ -160,6 +160,22 @@ public class TransactionServiceTest {
     }
 
     @Test
+    public void searchTransactionsWithoutParent_shouldThrowNotFoundException_forInvalidPaginationParams() {
+        List<TransactionEntity> transactionViewList = TransactionFixture.aTransactionList(gatewayAccountId, 10);
+        when(mockTransactionDao.searchTransactions(any(TransactionSearchParams.class))).thenReturn(transactionViewList);
+        when(mockTransactionDao.getTotalForSearch(any(TransactionSearchParams.class))).thenReturn(10L);
+        thrown.expect(WebApplicationException.class);
+        thrown.expectMessage("the requested page not found");
+
+        searchParams.setPageNumber(2L);
+
+        transactionService.searchTransactions(searchParams, mockUriInfo);
+
+        verify(mockTransactionDao).searchTransactions(searchParams);
+        verify(mockTransactionDao).getTotalForSearch(searchParams);
+    }
+
+    @Test
     public void shouldListTransactionsWithCorrectQueryParamsAndPaginationLinks_whenParentTransactionIsTrue() {
         List<TransactionEntity> transactionViewList = TransactionFixture
                 .aTransactionList(gatewayAccountId, 100);


### PR DESCRIPTION
## WHAT
- Currently we return 200 response and empty results, if `page number` query parameter is set to too high. To maintain functionality on par with connector/publicapi, return 404 when page number is greater than the last page number possible for query params