### PR TITLE
PP-5170 Store New Event Details Data

### DIFF
--- a/src/main/java/uk/gov/pay/ledger/event/dao/EventDao.java
+++ b/src/main/java/uk/gov/pay/ledger/event/dao/EventDao.java
@@ -47,6 +47,21 @@ public interface EventDao {
     @GetGeneratedKeys
     Optional<Long> insertIfDoesNotExist(@BindBean Event event, @Bind("resourceTypeId") int resourceTypeId);
 
+    @SqlUpdate("UPDATE event " +
+            "SET event_data = CAST(:eventData as jsonb) " +
+            "WHERE resource_type_id = :resourceTypeId " +
+            "AND resource_external_id = :resourceExternalId " +
+            "AND event_date = :eventDate " +
+            "AND event_type = :eventType")
+    @GetGeneratedKeys
+    Optional<Long> updateIfExists(@BindBean Event event, @Bind("resourceTypeId") int resourceTypeId);
+
+    @Transaction
+    default Optional<Long> updateIfExistsWithResourceTypeId(Event event) {
+        int resourceTypeId = getResourceTypeDao().getResourceTypeIdByName(event.getResourceType().name());
+        return updateIfExists(event, resourceTypeId);
+    }
+
     @Transaction
     default Long insertEventWithResourceTypeId(Event event) {
         int resourceTypeId = getResourceTypeDao().getResourceTypeIdByName(event.getResourceType().name());

--- a/src/main/java/uk/gov/pay/ledger/event/service/EventService.java
+++ b/src/main/java/uk/gov/pay/ledger/event/service/EventService.java
@@ -22,15 +22,6 @@ public class EventService {
         return EventDigest.fromEventList(events);
     }
 
-    public CreateEventResponse createIfDoesNotExist(Event event) {
-        try {
-            Optional<Long> status = eventDao.insertEventIfDoesNotExistWithResourceTypeId(event);
-            return new CreateEventResponse(status);
-        } catch (Exception e) {
-            return new CreateEventResponse(e);
-        }
-    }
-
     private CreateEventResponse updateExistingEvent(Event event) {
         try {
             return new CreateEventResponse(eventDao.updateIfExistsWithResourceTypeId(event));

--- a/src/main/java/uk/gov/pay/ledger/event/service/EventService.java
+++ b/src/main/java/uk/gov/pay/ledger/event/service/EventService.java
@@ -30,4 +30,21 @@ public class EventService {
             return new CreateEventResponse(e);
         }
     }
+
+    private CreateEventResponse updateExistingEvent(Event event) {
+        try {
+            return new CreateEventResponse(eventDao.updateIfExistsWithResourceTypeId(event));
+        } catch (Exception e) {
+            return new CreateEventResponse(e);
+        }
+    }
+
+    public CreateEventResponse createOrUpdateIfExists(Event event) {
+        try {
+            Optional<Long> status = eventDao.insertEventIfDoesNotExistWithResourceTypeId(event);
+            return status.isPresent() ? new CreateEventResponse(status) : updateExistingEvent(event);
+        } catch (Exception e) {
+            return new CreateEventResponse(e);
+        }
+    }
 }

--- a/src/main/java/uk/gov/pay/ledger/queue/EventMessageHandler.java
+++ b/src/main/java/uk/gov/pay/ledger/queue/EventMessageHandler.java
@@ -43,7 +43,7 @@ public class EventMessageHandler {
 
     void processSingleMessage(EventMessage message) throws QueueException {
         Event event = message.getEvent();
-        CreateEventResponse response = eventService.createIfDoesNotExist(event);
+        CreateEventResponse response = eventService.createOrUpdateIfExists(event);
 
         if(response.isSuccessful()) {
             EventDigest eventDigest = eventService.getEventDigestForResource(event.getResourceExternalId());

--- a/src/test/java/uk/gov/pay/ledger/event/dao/EventDaoIT.java
+++ b/src/test/java/uk/gov/pay/ledger/event/dao/EventDaoIT.java
@@ -12,6 +12,7 @@ import uk.gov.pay.ledger.util.DatabaseTestHelper;
 import java.io.IOException;
 import java.sql.Timestamp;
 import java.time.ZonedDateTime;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -205,7 +206,6 @@ public class EventDaoIT {
                 .toEntity();
 
         List<Event> eventList = eventDao.findEventsForExternalIds(Set.of("external-id-1", "external-id-2"));
-
         assertThat(eventList.size(), is(2));
 
         assertThat(eventList.get(0).getResourceExternalId(), is(event1.getResourceExternalId()));
@@ -216,5 +216,20 @@ public class EventDaoIT {
     public void findEventsForExternalIds_ShouldReturnEmptyListIfNoRecordsFound() {
         List<Event> eventList = eventDao.findEventsForExternalIds(Set.of("some-ext-id-1", "some-ext-id-2"));
         assertThat(eventList.size(), is(0));
+    }
+
+    @Test
+    public void eventDetailsAreUpdated_IfEventAlreadyExists(){
+        Event event = anEventFixture()
+                .withResourceExternalId("key-value-test-id")
+                .insert(rule.getJdbi())
+                .toEntity();
+        Event event2 = anEventFixture()
+                .withResourceExternalId(event.getResourceExternalId())
+                .withEventData("{\"key\": \"value\"}")
+                .withEventDate(event.getEventDate())
+                .toEntity();
+        eventDao.updateIfExistsWithResourceTypeId(event2);
+        assertThat(eventDao.getById(event.getId()).get().getEventData(), is("{\"key\": \"value\"}"));
     }
 }

--- a/src/test/java/uk/gov/pay/ledger/event/dao/EventDaoIT.java
+++ b/src/test/java/uk/gov/pay/ledger/event/dao/EventDaoIT.java
@@ -12,7 +12,6 @@ import uk.gov.pay.ledger.util.DatabaseTestHelper;
 import java.io.IOException;
 import java.sql.Timestamp;
 import java.time.ZonedDateTime;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;

--- a/src/test/java/uk/gov/pay/ledger/event/service/EventServiceTest.java
+++ b/src/test/java/uk/gov/pay/ledger/event/service/EventServiceTest.java
@@ -100,7 +100,7 @@ public class EventServiceTest {
     public void createIfDoesNotExistReturnsSuccessfulCreatedResponse() {
         when(mockEventDao.insertEventIfDoesNotExistWithResourceTypeId(event)).thenReturn(Optional.of(1L));
 
-        CreateEventResponse response = eventService.createIfDoesNotExist(event);
+        CreateEventResponse response = eventService.createOrUpdateIfExists(event);
 
         assertTrue(response.isSuccessful());
         assertThat(response.getState(), is(CreateEventResponse.CreateEventState.INSERTED));
@@ -110,21 +110,31 @@ public class EventServiceTest {
     public void createIfDoesNotExistReturnsSuccessfulIgnoredResponse() {
         when(mockEventDao.insertEventIfDoesNotExistWithResourceTypeId(event)).thenReturn(Optional.empty());
 
-        CreateEventResponse response = eventService.createIfDoesNotExist(event);
+        CreateEventResponse response = eventService.createOrUpdateIfExists(event);
 
         assertTrue(response.isSuccessful());
         assertThat(response.getState(), is(CreateEventResponse.CreateEventState.IGNORED));
     }
 
     @Test
-    public void createIfDoesNotExistReturnsNotSuccessfulResponse() {
+    public void createOrUpdateIfExistsReturnsNotSuccessfulResponse() {
         when(mockEventDao.insertEventIfDoesNotExistWithResourceTypeId(event))
                 .thenThrow(new RuntimeException("forced failure"));
 
-        CreateEventResponse response = eventService.createIfDoesNotExist(event);
+        CreateEventResponse response = eventService.createOrUpdateIfExists(event);
 
         assertFalse(response.isSuccessful());
         assertThat(response.getState(), is(CreateEventResponse.CreateEventState.ERROR));
         assertThat(response.getErrorMessage(), is("forced failure"));
+    }
+
+    @Test
+    public void createOrUpdateIfExistsUpdatesExistingEvent() {
+        when(mockEventDao.insertEventIfDoesNotExistWithResourceTypeId(event)).thenReturn(Optional.empty());
+        when(mockEventDao.updateIfExistsWithResourceTypeId(event)).thenReturn(Optional.of(1L));
+        eventService.createOrUpdateIfExists(event);
+        CreateEventResponse response = eventService.createOrUpdateIfExists(event);
+        assertTrue(response.isSuccessful());
+        assertThat(response.getState(), is(CreateEventResponse.CreateEventState.INSERTED));
     }
 }

--- a/src/test/java/uk/gov/pay/ledger/queue/EventMessageHandlerTest.java
+++ b/src/test/java/uk/gov/pay/ledger/queue/EventMessageHandlerTest.java
@@ -8,8 +8,8 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.pay.ledger.event.model.Event;
 import uk.gov.pay.ledger.event.model.EventDigest;
-import uk.gov.pay.ledger.event.service.EventService;
 import uk.gov.pay.ledger.event.model.response.CreateEventResponse;
+import uk.gov.pay.ledger.event.service.EventService;
 import uk.gov.pay.ledger.transaction.service.TransactionService;
 
 import java.util.List;
@@ -50,8 +50,7 @@ public class EventMessageHandlerTest {
         EventMessage message = mock(EventMessage.class);
 
         when(eventQueue.retrieveEvents()).thenReturn(List.of(message));
-        when(eventService.createIfDoesNotExist(any())).thenReturn(createEventResponse);
-
+        when(eventService.createOrUpdateIfExists(any())).thenReturn(createEventResponse);
     }
 
     @Test


### PR DESCRIPTION
- When we receive a new event from the queue, sometimes that event already
exists but with less information that the newer version of the event,
currently the behaviour of ledger is to not store this information, this
commit fixes that by updating the previous record with the new event
information if there is a disparity between the two.