### PR TITLE
PP-5725 Add Sentry config

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -134,6 +134,11 @@
             <artifactId>jackson-datatype-jsr310</artifactId>
             <version>${jackson.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.dhatim</groupId>
+            <artifactId>dropwizard-sentry</artifactId>
+            <version>1.3.9-1</version>
+        </dependency>
         <!--test dependencies-->
         <dependency>
             <groupId>org.testcontainers</groupId>

--- a/src/main/resources/config/config.yaml
+++ b/src/main/resources/config/config.yaml
@@ -56,6 +56,10 @@ logging:
         additionalFields:
           service-name: "ledger-service"
         includesMdcKeys: [X-Request-Id]
+    - type: sentry
+      threshold: ERROR
+      dsn: ${SENTRY_DSN:-https://example.com@dummy/1}
+      environment: ${ENVIRONMENT}
 
 sqsConfig:
   nonStandardServiceEndpoint: ${AWS_SQS_NON_STANDARD_SERVICE_ENDPOINT:-false}


### PR DESCRIPTION
Add Sentry logging appender so that logs at `ERROR` level and uncaught
exceptions are reported to Sentry. Same implementations as per
alphagov/pay-direct-debit-connector#745

There is a default value for the dsn so that the app will start if the
`SENTRY_DSN` env variable has not been set.