### PR TITLE
PP-5710 Update event when event details mismatch

### DIFF
--- a/src/main/java/uk/gov/pay/ledger/event/dao/EventDao.java
+++ b/src/main/java/uk/gov/pay/ledger/event/dao/EventDao.java
@@ -52,14 +52,15 @@ public interface EventDao {
             "WHERE resource_type_id = :resourceTypeId " +
             "AND resource_external_id = :resourceExternalId " +
             "AND event_date = :eventDate " +
-            "AND event_type = :eventType")
+            "AND event_type = :eventType " +
+            "AND event_data != CAST(:eventData as jsonb)")
     @GetGeneratedKeys
-    Optional<Long> updateIfExists(@BindBean Event event, @Bind("resourceTypeId") int resourceTypeId);
+    Optional<Long> updateIfExistsAndEventDetailsMismatch(@BindBean Event event, @Bind("resourceTypeId") int resourceTypeId);
 
     @Transaction
     default Optional<Long> updateIfExistsWithResourceTypeId(Event event) {
         int resourceTypeId = getResourceTypeDao().getResourceTypeIdByName(event.getResourceType().name());
-        return updateIfExists(event, resourceTypeId);
+        return updateIfExistsAndEventDetailsMismatch(event, resourceTypeId);
     }
 
     @Transaction

--- a/src/test/java/uk/gov/pay/ledger/event/dao/EventDaoIT.java
+++ b/src/test/java/uk/gov/pay/ledger/event/dao/EventDaoIT.java
@@ -218,9 +218,10 @@ public class EventDaoIT {
     }
 
     @Test
-    public void eventDetailsAreUpdated_IfEventAlreadyExists(){
+    public void eventDetailsAreUpdated_IfEventAlreadyExistsAndEventDetailsMismatch(){
         Event event = anEventFixture()
                 .withResourceExternalId("key-value-test-id")
+                .withEventData("{}")
                 .insert(rule.getJdbi())
                 .toEntity();
         Event event2 = anEventFixture()
@@ -228,7 +229,24 @@ public class EventDaoIT {
                 .withEventData("{\"key\": \"value\"}")
                 .withEventDate(event.getEventDate())
                 .toEntity();
-        eventDao.updateIfExistsWithResourceTypeId(event2);
+        Optional<Long> updateCountOptional = eventDao.updateIfExistsWithResourceTypeId(event2);
         assertThat(eventDao.getById(event.getId()).get().getEventData(), is("{\"key\": \"value\"}"));
+        assertThat(updateCountOptional.isPresent(), is(true));
+    }
+
+    @Test
+    public void eventDetailsAreNotUpdated_IfEventAlreadyExistsAndEventDetailsMatch(){
+        Event event = anEventFixture()
+                .withResourceExternalId("key-value-test-id")
+                .withEventData("{\"key\": \"value\"}")
+                .insert(rule.getJdbi())
+                .toEntity();
+        Event event2 = anEventFixture()
+                .withResourceExternalId(event.getResourceExternalId())
+                .withEventData("{\"key\": \"value\"}")
+                .withEventDate(event.getEventDate())
+                .toEntity();
+        Optional<Long> updateCountOptional = eventDao.updateIfExistsWithResourceTypeId(event2);
+        assertThat(updateCountOptional.isPresent(), is(false));
     }
 }


### PR DESCRIPTION
## WHAT
- Currently, if an event exists in ledger, `event_details` are always updated.
- We would only want to update event, if event_details changes (this is to support events with updated `event_details` due to fixes in connector)