### PR TITLE
PP-5744 Enable E2E tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -111,7 +111,7 @@ pipeline {
         }
       }
     }
-    /*stage('Tests') {
+    stage('Tests') {
       failFast true
       stages {
         stage('End-to-End Tests') {
@@ -126,7 +126,7 @@ pipeline {
             }
         }
       }
-    }*/
+    }
     stage('Docker Tag') {
       steps {
         script {


### PR DESCRIPTION
## WHAT
- We now have publicapi and selfservice using ledger in CI environment and Selfservice uses ledger in all environments
- Run E2E tests on master build and optionally run them on PR builds to catch regression 