### PR TITLE
PP-5659 Add btree index to `event_date` column

### DIFF
--- a/src/main/resources/migrations/00031_index_event_date.sql
+++ b/src/main/resources/migrations/00031_index_event_date.sql
@@ -1,0 +1,5 @@
+--liquibase formatted sql
+
+--changeset uk.gov.pay:index_event_date runInTransaction:false
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS event_date_idx ON event USING btree(event_date);


### PR DESCRIPTION
* sorting events requires a full table scan
* index date to allow scripts to be run when:
  * updating legacy transaction and transaction events (used to update live events and card brand label events)
  * requestsing platform level events (observability + communication)