### PR TITLE
PP-5659 Remove ignore from transaction entity live column

### DIFF
--- a/src/main/java/uk/gov/pay/ledger/transaction/entity/TransactionEntity.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/entity/TransactionEntity.java
@@ -41,7 +41,6 @@ public class TransactionEntity {
     private String refundStatus;
     private Long refundAmountRefunded;
     private Long refundAmountAvailable;
-    @JsonIgnore
     private boolean live;
     private TransactionEntity parentTransactionEntity;
     private String gatewayTransactionId;

--- a/src/test/java/uk/gov/pay/ledger/event/model/TransactionEntityFactoryTest.java
+++ b/src/test/java/uk/gov/pay/ledger/event/model/TransactionEntityFactoryTest.java
@@ -69,6 +69,7 @@ public class TransactionEntityFactoryTest {
         assertThat(transactionEntity.getTotalAmount(), is(((Integer)eventDigest.getEventPayload().get("total_amount")).longValue()));
         assertThat(transactionEntity.getFee(), is(((Integer)eventDigest.getEventPayload().get("fee")).longValue()));
         assertThat(transactionEntity.getTransactionType(), is("PAYMENT"));
+        assertThat(transactionEntity.isLive(), is(true));
 
 
         JsonObject transactionDetails = new JsonParser().parse(transactionEntity.getTransactionDetails()).getAsJsonObject();

--- a/src/test/java/uk/gov/pay/ledger/util/fixture/QueuePaymentEventFixture.java
+++ b/src/test/java/uk/gov/pay/ledger/util/fixture/QueuePaymentEventFixture.java
@@ -80,6 +80,7 @@ public class QueuePaymentEventFixture implements QueueFixture<QueuePaymentEventF
                                 .put("gateway_account_id", gatewayAccountId)
                                 .put("payment_provider", "sandbox")
                                 .put("delayed_capture", false)
+                                .put("live", true)
                                 .put("external_metadata", externalMetadata)
                                 .build());
                 break;


### PR DESCRIPTION
* live column not being set correctly as it is explicitly ignored by
JSON object mapper
* remove ignore and verify that it is being set correctly on entity