### PR TITLE
PP-5666: add additional field validation for payment created pact test

### DIFF
--- a/src/test/java/uk/gov/pay/ledger/pact/PaymentCreatedEventQueueContractTest.java
+++ b/src/test/java/uk/gov/pay/ledger/pact/PaymentCreatedEventQueueContractTest.java
@@ -81,6 +81,12 @@ public class PaymentCreatedEventQueueContractTest {
         assertThat(transaction.get().getTransactionDetails(), containsString("\"language\": \"en\""));
         assertThat(transaction.get().getTransactionDetails(), containsString("\"delayed_capture\": false"));
         assertThat(transaction.get().getTransactionDetails(), containsString("\"external_metadata\": {\"key\": \"value\"}"));
+        assertThat(transaction.get().getEmail(), is("j.doe@example.org"));
+        assertThat(transaction.get().getCardholderName(), is("J citizen"));
+        assertThat(transaction.get().getTransactionDetails(), containsString("\"address_line1\": \"12 Rouge Avenue\""));
+        assertThat(transaction.get().getTransactionDetails(), containsString("\"address_postcode\": \"N1 3QU\""));
+        assertThat(transaction.get().getTransactionDetails(), containsString("\"address_city\": \"London\""));
+        assertThat(transaction.get().getTransactionDetails(), containsString("\"address_country\": \"GB\""));
     }
 
     public void setMessage(byte[] messageContents) {

--- a/src/test/java/uk/gov/pay/ledger/util/fixture/QueuePaymentEventFixture.java
+++ b/src/test/java/uk/gov/pay/ledger/util/fixture/QueuePaymentEventFixture.java
@@ -82,6 +82,12 @@ public class QueuePaymentEventFixture implements QueueFixture<QueuePaymentEventF
                                 .put("delayed_capture", false)
                                 .put("live", true)
                                 .put("external_metadata", externalMetadata)
+                                .put("email", "j.doe@example.org")
+                                .put("cardholder_name", "J citizen")
+                                .put("address_line1", "12 Rouge Avenue")
+                                .put("address_postcode", "N1 3QU")
+                                .put("address_city", "London")
+                                .put("address_country", "GB")
                                 .build());
                 break;
             case "PAYMENT_DETAILS_ENTERED":


### PR DESCRIPTION
The https://github.com/alphagov/pay-connector/pull/1829 change
adds additional data to PaymentCreated message.

Change:
* update pact test to include additional fields in the message