### PR TITLE
PP-5779 Revert "PP-5710 Update event"

### DIFF
--- a/src/main/java/uk/gov/pay/ledger/event/dao/EventDao.java
+++ b/src/main/java/uk/gov/pay/ledger/event/dao/EventDao.java
@@ -47,22 +47,6 @@ public interface EventDao {
     @GetGeneratedKeys
     Optional<Long> insertIfDoesNotExist(@BindBean Event event, @Bind("resourceTypeId") int resourceTypeId);
 
-    @SqlUpdate("UPDATE event " +
-            "SET event_data = CAST(:eventData as jsonb) " +
-            "WHERE resource_type_id = :resourceTypeId " +
-            "AND resource_external_id = :resourceExternalId " +
-            "AND event_date = :eventDate " +
-            "AND event_type = :eventType " +
-            "AND event_data != CAST(:eventData as jsonb)")
-    @GetGeneratedKeys
-    Optional<Long> updateIfExistsAndEventDetailsMismatch(@BindBean Event event, @Bind("resourceTypeId") int resourceTypeId);
-
-    @Transaction
-    default Optional<Long> updateIfExistsWithResourceTypeId(Event event) {
-        int resourceTypeId = getResourceTypeDao().getResourceTypeIdByName(event.getResourceType().name());
-        return updateIfExistsAndEventDetailsMismatch(event, resourceTypeId);
-    }
-
     @Transaction
     default Long insertEventWithResourceTypeId(Event event) {
         int resourceTypeId = getResourceTypeDao().getResourceTypeIdByName(event.getResourceType().name());

--- a/src/main/java/uk/gov/pay/ledger/event/service/EventService.java
+++ b/src/main/java/uk/gov/pay/ledger/event/service/EventService.java
@@ -22,18 +22,10 @@ public class EventService {
         return EventDigest.fromEventList(events);
     }
 
-    private CreateEventResponse updateExistingEvent(Event event) {
-        try {
-            return new CreateEventResponse(eventDao.updateIfExistsWithResourceTypeId(event));
-        } catch (Exception e) {
-            return new CreateEventResponse(e);
-        }
-    }
-
-    public CreateEventResponse createOrUpdateIfExists(Event event) {
+    public CreateEventResponse createIfDoesNotExist(Event event) {
         try {
             Optional<Long> status = eventDao.insertEventIfDoesNotExistWithResourceTypeId(event);
-            return status.isPresent() ? new CreateEventResponse(status) : updateExistingEvent(event);
+            return new CreateEventResponse(status);
         } catch (Exception e) {
             return new CreateEventResponse(e);
         }

--- a/src/main/java/uk/gov/pay/ledger/queue/EventMessageHandler.java
+++ b/src/main/java/uk/gov/pay/ledger/queue/EventMessageHandler.java
@@ -43,7 +43,7 @@ public class EventMessageHandler {
 
     void processSingleMessage(EventMessage message) throws QueueException {
         Event event = message.getEvent();
-        CreateEventResponse response = eventService.createOrUpdateIfExists(event);
+        CreateEventResponse response = eventService.createIfDoesNotExist(event);
 
         if(response.isSuccessful()) {
             EventDigest eventDigest = eventService.getEventDigestForResource(event.getResourceExternalId());

--- a/src/test/java/uk/gov/pay/ledger/event/dao/EventDaoIT.java
+++ b/src/test/java/uk/gov/pay/ledger/event/dao/EventDaoIT.java
@@ -205,6 +205,7 @@ public class EventDaoIT {
                 .toEntity();
 
         List<Event> eventList = eventDao.findEventsForExternalIds(Set.of("external-id-1", "external-id-2"));
+
         assertThat(eventList.size(), is(2));
 
         assertThat(eventList.get(0).getResourceExternalId(), is(event1.getResourceExternalId()));
@@ -215,38 +216,5 @@ public class EventDaoIT {
     public void findEventsForExternalIds_ShouldReturnEmptyListIfNoRecordsFound() {
         List<Event> eventList = eventDao.findEventsForExternalIds(Set.of("some-ext-id-1", "some-ext-id-2"));
         assertThat(eventList.size(), is(0));
-    }
-
-    @Test
-    public void eventDetailsAreUpdated_IfEventAlreadyExistsAndEventDetailsMismatch(){
-        Event event = anEventFixture()
-                .withResourceExternalId("key-value-test-id")
-                .withEventData("{}")
-                .insert(rule.getJdbi())
-                .toEntity();
-        Event event2 = anEventFixture()
-                .withResourceExternalId(event.getResourceExternalId())
-                .withEventData("{\"key\": \"value\"}")
-                .withEventDate(event.getEventDate())
-                .toEntity();
-        Optional<Long> updateCountOptional = eventDao.updateIfExistsWithResourceTypeId(event2);
-        assertThat(eventDao.getById(event.getId()).get().getEventData(), is("{\"key\": \"value\"}"));
-        assertThat(updateCountOptional.isPresent(), is(true));
-    }
-
-    @Test
-    public void eventDetailsAreNotUpdated_IfEventAlreadyExistsAndEventDetailsMatch(){
-        Event event = anEventFixture()
-                .withResourceExternalId("key-value-test-id")
-                .withEventData("{\"key\": \"value\"}")
-                .insert(rule.getJdbi())
-                .toEntity();
-        Event event2 = anEventFixture()
-                .withResourceExternalId(event.getResourceExternalId())
-                .withEventData("{\"key\": \"value\"}")
-                .withEventDate(event.getEventDate())
-                .toEntity();
-        Optional<Long> updateCountOptional = eventDao.updateIfExistsWithResourceTypeId(event2);
-        assertThat(updateCountOptional.isPresent(), is(false));
     }
 }

--- a/src/test/java/uk/gov/pay/ledger/event/service/EventServiceTest.java
+++ b/src/test/java/uk/gov/pay/ledger/event/service/EventServiceTest.java
@@ -100,7 +100,7 @@ public class EventServiceTest {
     public void createIfDoesNotExistReturnsSuccessfulCreatedResponse() {
         when(mockEventDao.insertEventIfDoesNotExistWithResourceTypeId(event)).thenReturn(Optional.of(1L));
 
-        CreateEventResponse response = eventService.createOrUpdateIfExists(event);
+        CreateEventResponse response = eventService.createIfDoesNotExist(event);
 
         assertTrue(response.isSuccessful());
         assertThat(response.getState(), is(CreateEventResponse.CreateEventState.INSERTED));
@@ -110,31 +110,21 @@ public class EventServiceTest {
     public void createIfDoesNotExistReturnsSuccessfulIgnoredResponse() {
         when(mockEventDao.insertEventIfDoesNotExistWithResourceTypeId(event)).thenReturn(Optional.empty());
 
-        CreateEventResponse response = eventService.createOrUpdateIfExists(event);
+        CreateEventResponse response = eventService.createIfDoesNotExist(event);
 
         assertTrue(response.isSuccessful());
         assertThat(response.getState(), is(CreateEventResponse.CreateEventState.IGNORED));
     }
 
     @Test
-    public void createOrUpdateIfExistsReturnsNotSuccessfulResponse() {
+    public void createIfDoesNotExistReturnsNotSuccessfulResponse() {
         when(mockEventDao.insertEventIfDoesNotExistWithResourceTypeId(event))
                 .thenThrow(new RuntimeException("forced failure"));
 
-        CreateEventResponse response = eventService.createOrUpdateIfExists(event);
+        CreateEventResponse response = eventService.createIfDoesNotExist(event);
 
         assertFalse(response.isSuccessful());
         assertThat(response.getState(), is(CreateEventResponse.CreateEventState.ERROR));
         assertThat(response.getErrorMessage(), is("forced failure"));
-    }
-
-    @Test
-    public void createOrUpdateIfExistsUpdatesExistingEvent() {
-        when(mockEventDao.insertEventIfDoesNotExistWithResourceTypeId(event)).thenReturn(Optional.empty());
-        when(mockEventDao.updateIfExistsWithResourceTypeId(event)).thenReturn(Optional.of(1L));
-        eventService.createOrUpdateIfExists(event);
-        CreateEventResponse response = eventService.createOrUpdateIfExists(event);
-        assertTrue(response.isSuccessful());
-        assertThat(response.getState(), is(CreateEventResponse.CreateEventState.INSERTED));
     }
 }

--- a/src/test/java/uk/gov/pay/ledger/queue/EventMessageHandlerTest.java
+++ b/src/test/java/uk/gov/pay/ledger/queue/EventMessageHandlerTest.java
@@ -8,8 +8,8 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.pay.ledger.event.model.Event;
 import uk.gov.pay.ledger.event.model.EventDigest;
-import uk.gov.pay.ledger.event.model.response.CreateEventResponse;
 import uk.gov.pay.ledger.event.service.EventService;
+import uk.gov.pay.ledger.event.model.response.CreateEventResponse;
 import uk.gov.pay.ledger.transaction.service.TransactionService;
 
 import java.util.List;
@@ -50,7 +50,8 @@ public class EventMessageHandlerTest {
         EventMessage message = mock(EventMessage.class);
 
         when(eventQueue.retrieveEvents()).thenReturn(List.of(message));
-        when(eventService.createOrUpdateIfExists(any())).thenReturn(createEventResponse);
+        when(eventService.createIfDoesNotExist(any())).thenReturn(createEventResponse);
+
     }
 
     @Test


### PR DESCRIPTION
## WHAT
- Event updates were allowed so backfill process could send new fields in JSON. Now that backfill is complete revert event overwrites as this is not expected behaviour of ledger.

Ledger either inserts a new event if not exists or ignores an existing event