### PR TITLE
PP-5779 Only project transaction if event inserted

### DIFF
--- a/src/main/java/uk/gov/pay/ledger/queue/EventMessageHandler.java
+++ b/src/main/java/uk/gov/pay/ledger/queue/EventMessageHandler.java
@@ -46,8 +46,10 @@ public class EventMessageHandler {
         CreateEventResponse response = eventService.createIfDoesNotExist(event);
 
         if(response.isSuccessful()) {
-            EventDigest eventDigest = eventService.getEventDigestForResource(event.getResourceExternalId());
-            transactionService.upsertTransactionFor(eventDigest);
+            if (response.getState() == CreateEventResponse.CreateEventState.INSERTED) {
+                EventDigest eventDigest = eventService.getEventDigestForResource(event.getResourceExternalId());
+                transactionService.upsertTransactionFor(eventDigest);
+            }
             eventQueue.markMessageAsProcessed(message);
             LOGGER.info("The event message has been processed. [id={}] [state={}]",
                     message.getId(),

--- a/src/main/java/uk/gov/pay/ledger/transaction/dao/TransactionDao.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/dao/TransactionDao.java
@@ -154,8 +154,7 @@ public class TransactionDao {
                 "refund_amount_refunded = EXCLUDED.refund_amount_refunded, " +
                 "refund_status = EXCLUDED.refund_status, " +
                 "live = EXCLUDED.live, " +
-                "gateway_transaction_id = EXCLUDED.gateway_transaction_id " +
-                "WHERE EXCLUDED.event_count >= transaction.event_count;";
+                "gateway_transaction_id = EXCLUDED.gateway_transaction_id ";
 
     private final Jdbi jdbi;
 

--- a/src/test/java/uk/gov/pay/ledger/transaction/dao/TransactionDaoIT.java
+++ b/src/test/java/uk/gov/pay/ledger/transaction/dao/TransactionDaoIT.java
@@ -170,27 +170,6 @@ public class TransactionDaoIT {
     }
 
     @Test
-    public void shouldNotOverwriteTransactionIfItConsistsOfFewerEvents() {
-        TransactionEntity transaction = aTransactionFixture()
-                .withEventCount(5)
-                .withState(TransactionState.CREATED)
-                .insert(rule.getJdbi())
-                .toEntity();
-
-        TransactionEntity modifiedTransaction = aTransactionFixture()
-                .withExternalId(transaction.getExternalId())
-                .withEventCount(4)
-                .withState(TransactionState.SUBMITTED)
-                .toEntity();
-
-        transactionDao.upsert(modifiedTransaction);
-
-        TransactionEntity retrievedTransaction = transactionDao.findTransactionByExternalId(transaction.getExternalId()).get();
-
-        assertThat(retrievedTransaction.getState(), is(transaction.getState()));
-    }
-
-    @Test
     public void shouldFilterTransactionByExternalIdOrParentExternalIdAndGatewayAccountId() {
         TransactionEntity transaction1 = aTransactionFixture()
                 .withState(TransactionState.CREATED)


### PR DESCRIPTION
Move projecting transaction condition logic to the `EventMessageHandler` service and out of the DAO.

Advantages:
* don't rely on de-normalised `event_count`
* move business logic out of the DAO, these should be easier to
understand
* group all writing transaction logic into one place