### PR TITLE
Revert "Bump mockito-core from 3.1.0 to 3.2.0"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -171,7 +171,7 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>3.2.0</version>
+            <version>3.1.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
Reverts alphagov/pay-ledger#429

Ledger build has been failing - reverting this commit.