### PR TITLE
PP-5921 Transaction search resource accepts CSV

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -140,6 +140,16 @@
             <version>${jackson.version}</version>
         </dependency>
         <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>${jackson.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.dataformat</groupId>
+            <artifactId>jackson-dataformat-csv</artifactId>
+            <version>${jackson.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.dhatim</groupId>
             <artifactId>dropwizard-sentry</artifactId>
             <version>1.3.9-2</version>

--- a/src/main/java/uk/gov/pay/ledger/app/LedgerApp.java
+++ b/src/main/java/uk/gov/pay/ledger/app/LedgerApp.java
@@ -21,6 +21,7 @@ import uk.gov.pay.ledger.healthcheck.SQSHealthCheck;
 import uk.gov.pay.ledger.queue.managed.QueueMessageReceiver;
 import uk.gov.pay.ledger.report.resource.ReportResource;
 import uk.gov.pay.ledger.transaction.resource.TransactionResource;
+import uk.gov.pay.ledger.util.csv.CSVMessageBodyWriter;
 import uk.gov.pay.logging.GovUkPayDropwizardRequestJsonLogLayoutFactory;
 import uk.gov.pay.logging.LoggingFilter;
 import uk.gov.pay.logging.LogstashConsoleAppenderFactory;
@@ -70,6 +71,8 @@ public class LedgerApp extends Application<LedgerConfig> {
         environment.jersey().register(new BadRequestExceptionMapper());
         environment.jersey().register(new JerseyViolationExceptionMapper());
         environment.healthChecks().register("sqsQueue", injector.getInstance(SQSHealthCheck.class));
+
+        environment.jersey().register(new CSVMessageBodyWriter());
 
         if(config.getQueueMessageReceiverConfig().isBackgroundProcessingEnabled()) {
             environment.lifecycle().manage(injector.getInstance(QueueMessageReceiver.class));

--- a/src/main/java/uk/gov/pay/ledger/transaction/resource/TransactionResource.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/resource/TransactionResource.java
@@ -69,6 +69,7 @@ public class TransactionResource {
 
     @Path("/")
     @GET
+    @Produces({"application/json", "text/csv"})
     @Timed
     public TransactionSearchResponse search(@Valid
                                             @BeanParam TransactionSearchParams searchParams,

--- a/src/main/java/uk/gov/pay/ledger/transaction/resource/TransactionResource.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/resource/TransactionResource.java
@@ -20,6 +20,7 @@ import javax.ws.rs.DefaultValue;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
+import javax.ws.rs.HeaderParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.WebApplicationException;
@@ -73,12 +74,18 @@ public class TransactionResource {
     @Timed
     public TransactionSearchResponse search(@Valid
                                             @BeanParam TransactionSearchParams searchParams,
+                                            @HeaderParam("Accept") String acceptHeaderType,
                                             @QueryParam("override_account_id_restriction") Boolean overrideAccountRestriction,
                                             @QueryParam("account_id") String gatewayAccountId,
                                             @Context UriInfo uriInfo) {
 
         TransactionSearchParams transactionSearchParams = Optional.ofNullable(searchParams)
                 .orElse(new TransactionSearchParams());
+
+        if (acceptHeaderType != null && acceptHeaderType.equals("text/csv")) {
+            transactionSearchParams.setWithCount(false);
+            transactionSearchParams.overrideMaxDisplaySize(100000L);
+        }
 
         validateSearchParams(transactionSearchParams, gatewayAccountId);
         AccountIdSupplierManager<TransactionSearchResponse> accountIdSupplierManager =

--- a/src/main/java/uk/gov/pay/ledger/transaction/search/common/TransactionSearchParams.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/search/common/TransactionSearchParams.java
@@ -34,8 +34,10 @@ public class TransactionSearchParams {
     private static final String CARD_BRAND_FIELD = "card_brand";
     private static final String STATE_FIELD = "state";
     private static final String TRANSACTION_TYPE_FIELD = "transaction_type";
-    private static final long MAX_DISPLAY_SIZE = 500;
     private static final long DEFAULT_PAGE_NUMBER = 1L;
+
+    private long maxDisplaySize = 500;
+
     @DefaultValue("2")
     @QueryParam("status_version")
     int statusVersion;
@@ -70,12 +72,26 @@ public class TransactionSearchParams {
     private String toDate;
     @QueryParam(TRANSACTION_TYPE_FIELD)
     private TransactionType transactionType;
+    @DefaultValue("true")
+    @QueryParam("with_count")
+    private boolean withCount;
     private Long pageNumber = 1L;
-    private Long displaySize = MAX_DISPLAY_SIZE;
+
+    @DefaultValue("500")
+    @QueryParam("display_size")
+    private Long displaySize = 500L;
     private Map<String, Object> queryMap;
 
     public void setAccountId(String accountId) {
         this.accountId = accountId;
+    }
+
+    public void setWithCount(boolean withCount) {
+        this.withCount = withCount;
+    }
+
+    public boolean withCount() {
+        return this.withCount;
     }
 
     public void setEmail(String email) {
@@ -143,15 +159,13 @@ public class TransactionSearchParams {
         }
     }
 
-    @QueryParam("display_size")
+
     public void setDisplaySize(Long displaySize) {
-        if (displaySize == null || displaySize > MAX_DISPLAY_SIZE) {
-            LOGGER.info("Invalid display_size [{}] for transaction search params. Setting display_size to default [{}]",
-                    displaySize, MAX_DISPLAY_SIZE);
-            this.displaySize = MAX_DISPLAY_SIZE;
-        } else {
-            this.displaySize = displaySize;
-        }
+        this.displaySize = displaySize;
+    }
+
+    public void overrideMaxDisplaySize(Long maxDisplaySize) {
+        this.maxDisplaySize = maxDisplaySize;
     }
 
     public List<String> getFilterTemplates() {
@@ -314,7 +328,11 @@ public class TransactionSearchParams {
     }
 
     public Long getDisplaySize() {
-        return displaySize;
+        if (this.displaySize > this.maxDisplaySize) {
+            return this.maxDisplaySize;
+        } else {
+            return this.displaySize;
+        }
     }
 
     public String getFromDate() {

--- a/src/main/java/uk/gov/pay/ledger/transaction/service/TransactionService.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/service/TransactionService.java
@@ -98,14 +98,18 @@ public class TransactionService {
                 .map(transactionFactory::createTransactionEntity)
                 .collect(Collectors.toList());
 
-        Long total = transactionDao.getTotalForSearch(searchParams);
 
-        long size = searchParams.getDisplaySize();
-        if (total > 0 && searchParams.getDisplaySize() > 0) {
-            long lastPage = (total + size - 1) / size;
-            if (searchParams.getPageNumber() > lastPage || searchParams.getPageNumber() < 1) {
-                throw new WebApplicationException("the requested page not found",
-                        Response.Status.NOT_FOUND);
+        Long total = null;
+        if (searchParams.withCount()) {
+            total = transactionDao.getTotalForSearch(searchParams);
+
+            long size = searchParams.getDisplaySize();
+            if (total > 0 && searchParams.getDisplaySize() > 0) {
+                long lastPage = (total + size - 1) / size;
+                if (searchParams.getPageNumber() > lastPage || searchParams.getPageNumber() < 1) {
+                    throw new WebApplicationException("the requested page not found",
+                            Response.Status.NOT_FOUND);
+                }
             }
         }
 
@@ -118,12 +122,16 @@ public class TransactionService {
                 .map(transactionFactory::createTransactionEntity)
                 .collect(Collectors.toList());
 
-        Long total = transactionDao.getTotalForSearchTransactionAndParent(searchParams);
+        Long total = null;
+        if (searchParams.withCount()) {
+            total = transactionDao.getTotalForSearchTransactionAndParent(searchParams);
+        }
 
         return buildTransactionSearchResponse(searchParams, uriInfo, transactionList, total);
     }
 
-    private TransactionSearchResponse buildTransactionSearchResponse(TransactionSearchParams searchParams, UriInfo uriInfo, List<Transaction> transactionList, Long total) {
+    private TransactionSearchResponse buildTransactionSearchResponse(TransactionSearchParams searchParams, UriInfo uriInfo, List<Transaction> transactionList, Long totalCount) {
+        Long total = Optional.ofNullable(totalCount).orElse(0L);
         PaginationBuilder paginationBuilder = new PaginationBuilder(searchParams, uriInfo);
         paginationBuilder = paginationBuilder.withTotalCount(total).buildResponse();
 

--- a/src/main/java/uk/gov/pay/ledger/util/csv/CSVMessageBodyWriter.java
+++ b/src/main/java/uk/gov/pay/ledger/util/csv/CSVMessageBodyWriter.java
@@ -24,12 +24,13 @@ public class CSVMessageBodyWriter implements MessageBodyWriter<TransactionSearch
 
     @Override
     public boolean isWriteable(Class targetType, Type genericType, Annotation[] annotations, MediaType mediaType) {
-        return true;
+        return targetType == TransactionSearchResponse.class;
     }
 
     @Override
     public long getSize(TransactionSearchResponse data, Class aClass, Type type, Annotation[] annotations, MediaType mediaType) {
-        return 0;
+        // https://docs.oracle.com/javaee/7/api/javax/ws/rs/ext/MessageBodyWriter.html
+        return -1;
     }
 
     @Override
@@ -45,7 +46,7 @@ public class CSVMessageBodyWriter implements MessageBodyWriter<TransactionSearch
 
                 CsvMapper mapper = new CsvMapper();
 
-                // order properties by order of class instead of alphabetically
+                // rank properties by class property order instead of alphabetically
                 mapper.disable(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY);
                 Object sample = results.get(0);
                 CsvSchema schema = mapper.schemaFor(sample.getClass()).withHeader();

--- a/src/main/java/uk/gov/pay/ledger/util/csv/CSVMessageBodyWriter.java
+++ b/src/main/java/uk/gov/pay/ledger/util/csv/CSVMessageBodyWriter.java
@@ -1,0 +1,56 @@
+package uk.gov.pay.ledger.util.csv;
+
+import com.fasterxml.jackson.databind.MapperFeature;
+import com.fasterxml.jackson.dataformat.csv.CsvMapper;
+import com.fasterxml.jackson.dataformat.csv.CsvSchema;
+import uk.gov.pay.ledger.transaction.model.TransactionSearchResponse;
+
+import javax.ws.rs.Produces;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.ext.MessageBodyWriter;
+import javax.ws.rs.ext.Provider;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Provider
+@Produces("text/csv")
+public class CSVMessageBodyWriter implements MessageBodyWriter<TransactionSearchResponse> {
+
+    @Override
+    public boolean isWriteable(Class targetType, Type genericType, Annotation[] annotations, MediaType mediaType) {
+        return true;
+    }
+
+    @Override
+    public long getSize(TransactionSearchResponse data, Class aClass, Type type, Annotation[] annotations, MediaType mediaType) {
+        return 0;
+    }
+
+    @Override
+    public void writeTo(TransactionSearchResponse data, Class aClass, Type type, Annotation[] annotations, MediaType mediaType, MultivaluedMap multivaluedMap, OutputStream outputStream) throws IOException, WebApplicationException {
+        if (data != null) {
+            List<FlatCsvTransaction> results = data
+                    .getTransactionViewList()
+                    .stream()
+                    .map(FlatCsvTransaction::from)
+                    .collect(Collectors.toUnmodifiableList());
+
+            if (!results.isEmpty()) {
+
+                CsvMapper mapper = new CsvMapper();
+
+                // order properties by order of class instead of alphabetically
+                mapper.disable(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY);
+                Object sample = results.get(0);
+                CsvSchema schema = mapper.schemaFor(sample.getClass()).withHeader();
+                mapper.writer(schema).writeValue(outputStream, results);
+            }
+        }
+    }
+}

--- a/src/main/java/uk/gov/pay/ledger/util/csv/FlatCsvTransaction.java
+++ b/src/main/java/uk/gov/pay/ledger/util/csv/FlatCsvTransaction.java
@@ -1,0 +1,246 @@
+package uk.gov.pay.ledger.util.csv;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import uk.gov.pay.ledger.transaction.model.CardDetails;
+import uk.gov.pay.ledger.transaction.model.CardType;
+import uk.gov.pay.ledger.transaction.search.model.TransactionView;
+import uk.gov.pay.ledger.transaction.state.ExternalTransactionState;
+
+import java.text.DecimalFormat;
+import java.time.format.DateTimeFormatter;
+import java.util.Optional;
+
+public class FlatCsvTransaction {
+
+    @JsonProperty("Reference")
+    private String reference;
+
+    @JsonProperty("Description")
+    private String description;
+
+    @JsonProperty("Email")
+    private String email;
+
+    @JsonProperty("Amount")
+    private String amount;
+
+    @JsonProperty("Card Brand")
+    private String cardBrand;
+
+    @JsonProperty("Cardholder Name")
+    private String cardholderName;
+
+    @JsonProperty("Card Expiry Date")
+    private String cardExpiryDate;
+
+    @JsonProperty("Card Number")
+    private String cardNumber;
+
+    @JsonProperty("State")
+    private String state;
+
+    @JsonProperty("Finished")
+    private Boolean finished;
+
+    @JsonProperty("Error Code")
+    private String errorCode;
+
+    @JsonProperty("Error Message")
+    private String errorMessage;
+
+    @JsonProperty("Provider ID")
+    private String providerId;
+
+    @JsonProperty("GOV.UK Payment ID")
+    private String transactionId;
+
+    @JsonProperty("Issued By")
+    private String issuedBy;
+
+    @JsonProperty("Date Created")
+    private String dateCreated;
+
+    @JsonProperty("Time Created")
+    private String timeCreated;
+
+    @JsonProperty("Corporate Card Surcharge")
+    private String corporateSurcharge;
+
+    @JsonProperty("Total Amount")
+    private String totalAmount;
+
+    @JsonProperty("Wallet Type")
+    private String walletType;
+
+    @JsonProperty("Card Type")
+    private String cardType;
+
+    public FlatCsvTransaction() {
+
+    }
+
+    public FlatCsvTransaction(
+            String reference, String description, String email, String amount, String cardBrand, String cardholderName,
+            String cardExpiryDate, String cardNumber, String state, Boolean finished, String errorCode,
+            String errorMessage, String providerId, String transactionId, String issuedBy, String dateCreated,
+            String timeCreated, String corporateSurcharge, String totalAmount, String walletType, String cardType
+    ) {
+        this.reference = reference;
+        this.description = description;
+        this.email = email;
+        this.amount = amount;
+        this.cardBrand = cardBrand;
+        this.cardholderName = cardholderName;
+        this.cardExpiryDate = cardExpiryDate;
+        this.cardNumber = cardNumber;
+        this.state = state;
+        this.finished = finished;
+        this.errorCode = errorCode;
+        this.errorMessage = errorMessage;
+        this.providerId = providerId;
+        this.transactionId = transactionId;
+        this.issuedBy = issuedBy;
+        this.dateCreated = dateCreated;
+        this.timeCreated = timeCreated;
+        this.corporateSurcharge = corporateSurcharge;
+        this.totalAmount = totalAmount;
+        this.walletType = walletType;
+        this.cardType = cardType;
+    }
+
+    private static String penceToCurrency(Long amount) {
+        if (amount != null) {
+            DecimalFormat decimalFormat = new DecimalFormat("#,##0.00");
+            return decimalFormat.format(amount);
+        }
+        return null;
+    }
+
+    public static FlatCsvTransaction from(TransactionView transactionView) {
+
+        String amount = penceToCurrency(transactionView.getAmount());
+        String totalAmount = penceToCurrency(transactionView.getTotalAmount());
+        String corporateSurchargeAmount = penceToCurrency(transactionView.getCorporateCardSurcharge());
+
+        String dateCreated = Optional.ofNullable(transactionView.getCreatedDate())
+                .map(date -> date.format(DateTimeFormatter.ofPattern("dd MMM yyyy")))
+                .orElse(null);
+
+        String timeCreated = Optional.ofNullable(transactionView.getCreatedDate())
+                .map(date -> date.format(DateTimeFormatter.ofPattern("HH:mm:ss")))
+                .orElse(null);
+
+        String cardType = Optional.ofNullable(transactionView.getCardDetails())
+                .map(CardDetails::getCardType)
+                .map(CardType::toString)
+                .orElse(null);
+
+        return new FlatCsvTransaction(
+                transactionView.getReference(),
+                transactionView.getDescription(),
+                transactionView.getEmail(),
+                amount,
+                Optional.ofNullable(transactionView.getCardDetails()).map(CardDetails::getCardBrand).orElse(null),
+                Optional.ofNullable(transactionView.getCardDetails()).map(CardDetails::getCardHolderName).orElse(null),
+                Optional.ofNullable(transactionView.getCardDetails()).map(CardDetails::getExpiryDate).orElse(null),
+                Optional.ofNullable(transactionView.getCardDetails()).map(CardDetails::getLastDigitsCardNumber).orElse(null),
+                Optional.ofNullable(transactionView.getState()).map(ExternalTransactionState::getStatus).orElse(null),
+                Optional.ofNullable(transactionView.getState()).map(ExternalTransactionState::isFinished).orElse(null),
+                Optional.ofNullable(transactionView.getState()).map(ExternalTransactionState::getCode).orElse(null),
+                Optional.ofNullable(transactionView.getState()).map(ExternalTransactionState::getMessage).orElse(null),
+                transactionView.getGatewayTransactionId(),
+                transactionView.getTransactionId(),
+                transactionView.getRefundedBy(),
+                dateCreated,
+                timeCreated,
+                corporateSurchargeAmount,
+                totalAmount,
+                null,
+                cardType
+        );
+    }
+
+    public String getReference() {
+        return reference;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public String getAmount() {
+        return amount;
+    }
+
+    public String getCardBrand() {
+        return cardBrand;
+    }
+
+    public String getCardholderName() {
+        return cardholderName;
+    }
+
+    public String getCardExpiryDate() {
+        return cardExpiryDate;
+    }
+
+    public String getCardNumber() {
+        return cardNumber;
+    }
+
+    public String getState() {
+        return state;
+    }
+
+    public Boolean getFinished() {
+        return finished;
+    }
+
+    public String getErrorCode() {
+        return errorCode;
+    }
+
+    public String getErrorMessage() {
+        return errorMessage;
+    }
+
+    public String getProviderId() {
+        return providerId;
+    }
+
+    public String getTransactionId() {
+        return transactionId;
+    }
+
+    public String getIssuedBy() {
+        return issuedBy;
+    }
+
+    public String getDateCreated() {
+        return dateCreated;
+    }
+
+    public String getTimeCreated() {
+        return timeCreated;
+    }
+
+    public String getCorporateSurcharge() {
+        return corporateSurcharge;
+    }
+
+    public String getTotalAmount() {
+        return totalAmount;
+    }
+
+    public String getCardType() {
+        return cardType;
+    }
+
+    public String getWalletType() {
+        return walletType;
+    }
+}

--- a/src/main/java/uk/gov/pay/ledger/util/csv/FlatCsvTransaction.java
+++ b/src/main/java/uk/gov/pay/ledger/util/csv/FlatCsvTransaction.java
@@ -111,13 +111,12 @@ public class FlatCsvTransaction {
     private static String penceToCurrency(Long amount) {
         if (amount != null) {
             DecimalFormat decimalFormat = new DecimalFormat("#,##0.00");
-            return decimalFormat.format(amount);
+            return decimalFormat.format(amount / 100);
         }
         return null;
     }
 
     public static FlatCsvTransaction from(TransactionView transactionView) {
-
         String amount = penceToCurrency(transactionView.getAmount());
         String totalAmount = penceToCurrency(transactionView.getTotalAmount());
         String corporateSurchargeAmount = penceToCurrency(transactionView.getCorporateCardSurcharge());

--- a/src/test/java/uk/gov/pay/ledger/transaction/resource/TransactionResourceIT.java
+++ b/src/test/java/uk/gov/pay/ledger/transaction/resource/TransactionResourceIT.java
@@ -587,4 +587,33 @@ public class TransactionResourceIT {
                 .statusCode(Response.Status.NOT_FOUND.getStatusCode())
                 .body("message", is("Transaction with id [some-parent-external-id] not found"));
     }
+
+    @Test
+    public void testResourceCSV() {
+        String targetGatewayAccountId = "123";
+        String otherGatewayAccountId = "456";
+
+        aTransactionFixture()
+                .withTransactionType("PAYMENT")
+                .withState(TransactionState.SUBMITTED)
+                .withGatewayAccountId(targetGatewayAccountId)
+                .insert(rule.getJdbi());
+
+        aTransactionFixture()
+                .withTransactionType("PAYMENT")
+                .withState(TransactionState.SUBMITTED)
+                .withGatewayAccountId(otherGatewayAccountId)
+                .insert(rule.getJdbi());
+
+        given().port(port)
+                .accept("text/csv")
+                .get("/v1/transaction?" +
+                        "account_id=" + targetGatewayAccountId +
+                        "&page=1" +
+                        "&display_size=5"
+                )
+                .then()
+                .statusCode(Response.Status.OK.getStatusCode())
+                .contentType("text/csv");
+    }
 }

--- a/src/test/java/uk/gov/pay/ledger/transaction/service/TransactionServiceTest.java
+++ b/src/test/java/uk/gov/pay/ledger/transaction/service/TransactionServiceTest.java
@@ -102,6 +102,7 @@ public class TransactionServiceTest {
     @Test
     public void shouldReturnAListOfTransactionsWithStatusVersion2() {
         searchParams.setStatusVersion(2);
+        searchParams.setWithCount(true);
         List<TransactionEntity> transactionViewList = TransactionFixture.aTransactionList(gatewayAccountId, 4);
         transactionViewList.add(aTransactionFixture().withState(TransactionState.FAILED_REJECTED).toEntity());
         when(mockTransactionDao.searchTransactions(any(TransactionSearchParams.class))).thenReturn(transactionViewList);
@@ -117,6 +118,7 @@ public class TransactionServiceTest {
     @Test
     public void shouldReturnAListOfTransactionsWithStatusVersion1() {
         searchParams.setStatusVersion(1);
+        searchParams.setWithCount(true);
         List<TransactionEntity> transactionViewList = TransactionFixture.aTransactionList(gatewayAccountId, 4);
         transactionViewList.add(aTransactionFixture().withState(TransactionState.FAILED_REJECTED).toEntity());
         when(mockTransactionDao.searchTransactions(any(TransactionSearchParams.class))).thenReturn(transactionViewList);
@@ -129,6 +131,7 @@ public class TransactionServiceTest {
     public void shouldListTransactionsWithAllPaginationLinks() {
         List<TransactionEntity> transactionViewList = TransactionFixture
                 .aTransactionList(gatewayAccountId, 100);
+        searchParams.setWithCount(true);
         searchParams.setPageNumber(3L);
         searchParams.setDisplaySize(10L);
         when(mockTransactionDao.searchTransactions(any(TransactionSearchParams.class))).thenReturn(transactionViewList);
@@ -168,6 +171,7 @@ public class TransactionServiceTest {
         thrown.expectMessage("the requested page not found");
 
         searchParams.setPageNumber(2L);
+        searchParams.setWithCount(true);
 
         transactionService.searchTransactions(searchParams, mockUriInfo);
 
@@ -357,6 +361,7 @@ public class TransactionServiceTest {
     }
 
     private void setAllSearchParams() {
+        searchParams.setWithCount(true);
         searchParams.setEmail("test@email.com");
         searchParams.setCardHolderName("test");
         searchParams.setFromDate("2019-05-01T10:15:30Z");


### PR DESCRIPTION
Reviewing performance profile for backend CSV generation.

* add jackson csv parser dependency
* jersey `MessageBodyWriter` for `text/csv`, interprets `TransactionSearchResponse` object
* map `TransactionView` to flat record that matches our current admin tool CSV columns
* integration test for `text/csv` content type