### PR TITLE
PP-5893-Add-MDC-Logging-Filter

### DIFF
--- a/src/main/java/uk/gov/pay/ledger/app/LedgerApp.java
+++ b/src/main/java/uk/gov/pay/ledger/app/LedgerApp.java
@@ -15,6 +15,8 @@ import org.jdbi.v3.core.Jdbi;
 import uk.gov.pay.ledger.event.resource.EventResource;
 import uk.gov.pay.ledger.exception.BadRequestExceptionMapper;
 import uk.gov.pay.ledger.exception.JerseyViolationExceptionMapper;
+import uk.gov.pay.ledger.filters.LoggingMDCRequestFilter;
+import uk.gov.pay.ledger.filters.LoggingMDCResponseFilter;
 import uk.gov.pay.ledger.healthcheck.DependentResourceWaitCommand;
 import uk.gov.pay.ledger.healthcheck.HealthCheckResource;
 import uk.gov.pay.ledger.healthcheck.SQSHealthCheck;
@@ -65,8 +67,12 @@ public class LedgerApp extends Application<LedgerConfig> {
         environment.jersey().register(injector.getInstance(TransactionResource.class));
         environment.jersey().register(injector.getInstance(ReportResource.class));
         environment.jersey().register(injector.getInstance(HealthCheckResource.class));
+
         environment.servlets().addFilter("LoggingFilter", new LoggingFilter())
                 .addMappingForUrlPatterns(of(REQUEST), true, "/v1/*");
+        environment.jersey().register(injector.getInstance(LoggingMDCRequestFilter.class));
+        environment.jersey().register(injector.getInstance(LoggingMDCResponseFilter.class));
+
         environment.jersey().register(new BadRequestExceptionMapper());
         environment.jersey().register(new JerseyViolationExceptionMapper());
         environment.healthChecks().register("sqsQueue", injector.getInstance(SQSHealthCheck.class));

--- a/src/main/java/uk/gov/pay/ledger/filters/LoggingMDCRequestFilter.java
+++ b/src/main/java/uk/gov/pay/ledger/filters/LoggingMDCRequestFilter.java
@@ -1,0 +1,32 @@
+package uk.gov.pay.ledger.filters;
+
+import org.slf4j.MDC;
+
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerRequestFilter;
+import java.io.IOException;
+import java.util.Optional;
+
+import static uk.gov.pay.logging.LoggingKeys.LEDGER_EVENT_ID;
+
+public class LoggingMDCRequestFilter implements ContainerRequestFilter {
+
+    public static final String PARENT_TRANSACTION_EXTERNAL_ID = "parent_transaction_external_id";
+    public static final String TRANSACTION_EXTERNAL_ID = "transaction_external_id";
+
+    @Override
+    public void filter(ContainerRequestContext requestContext) throws IOException {
+        getPathParameterFromRequest("eventId", requestContext)
+                .ifPresent(eventId -> MDC.put(LEDGER_EVENT_ID, eventId));
+
+        getPathParameterFromRequest("transactionExternalId", requestContext)
+                .ifPresent(transactionExternalId -> MDC.put(TRANSACTION_EXTERNAL_ID, transactionExternalId));
+
+        getPathParameterFromRequest("parentTransactionExternalId", requestContext)
+                .ifPresent(parentTransactionExternalId -> MDC.put(PARENT_TRANSACTION_EXTERNAL_ID, parentTransactionExternalId));
+    }
+
+    private Optional<String> getPathParameterFromRequest(String parameterName, ContainerRequestContext requestContext) {
+        return Optional.ofNullable(requestContext.getUriInfo().getPathParameters().getFirst(parameterName));
+    }
+}

--- a/src/main/java/uk/gov/pay/ledger/filters/LoggingMDCResponseFilter.java
+++ b/src/main/java/uk/gov/pay/ledger/filters/LoggingMDCResponseFilter.java
@@ -1,0 +1,16 @@
+package uk.gov.pay.ledger.filters;
+
+import org.slf4j.MDC;
+
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerResponseContext;
+import javax.ws.rs.container.ContainerResponseFilter;
+import java.io.IOException;
+
+public class LoggingMDCResponseFilter implements ContainerResponseFilter {
+
+    @Override
+    public void filter(ContainerRequestContext containerRequestContext, ContainerResponseContext containerResponseContext) throws IOException {
+        MDC.clear();
+    }
+}


### PR DESCRIPTION
Description:
- At the moment this doesn't compile as Pay Java Commons doesn't have the static members PARENT_EXTERNAL_ID and TRANSACTION_EXTERNAL_ID
- Adds eventId, parent_external_id and transactionExternalId to MDC