### PR TITLE
bau: use fixed gateway account id

### DIFF
--- a/src/test/java/uk/gov/pay/ledger/pact/PaymentDetailsEnteredEventQueueContractTest.java
+++ b/src/test/java/uk/gov/pay/ledger/pact/PaymentDetailsEnteredEventQueueContractTest.java
@@ -46,6 +46,7 @@ public class PaymentDetailsEnteredEventQueueContractTest {
                 .withResourceExternalId(externalId)
                 .withEventDate(eventDate)
                 .withEventType(paymentDetailsEnteredEventName)
+                .withGatewayAccountId("I0YI1")
                 .withDefaultEventDataForEventType(paymentDetailsEnteredEventName);
 
         Map<String, String> metadata = new HashMap<>();


### PR DESCRIPTION
The gateway account id is by default random
(https://github.com/alphagov/pay-ledger/blob/master/src/test/java/uk/gov/pay/ledger/util/fixture/QueuePaymentEventFixture.java#L23)
which causes the published pact to be different each time. This isn't ideal as
the pact hasn't really changed and it affects deploys of ledger because a
connector build has to be run to verify the changed pact.