### PR TITLE
PP-5893: Manually clear keys

### DIFF
--- a/src/main/java/uk/gov/pay/ledger/filters/LoggingMDCResponseFilter.java
+++ b/src/main/java/uk/gov/pay/ledger/filters/LoggingMDCResponseFilter.java
@@ -6,11 +6,16 @@ import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.container.ContainerResponseContext;
 import javax.ws.rs.container.ContainerResponseFilter;
 import java.io.IOException;
+import java.util.List;
+
+import static uk.gov.pay.ledger.filters.LoggingMDCRequestFilter.PARENT_TRANSACTION_EXTERNAL_ID;
+import static uk.gov.pay.ledger.filters.LoggingMDCRequestFilter.TRANSACTION_EXTERNAL_ID;
+import static uk.gov.pay.logging.LoggingKeys.LEDGER_EVENT_ID;
 
 public class LoggingMDCResponseFilter implements ContainerResponseFilter {
 
     @Override
     public void filter(ContainerRequestContext containerRequestContext, ContainerResponseContext containerResponseContext) throws IOException {
-        MDC.clear();
+        List.of(LEDGER_EVENT_ID, TRANSACTION_EXTERNAL_ID, PARENT_TRANSACTION_EXTERNAL_ID).forEach(MDC::remove);
     }
 }


### PR DESCRIPTION
We shouldn't use MDC.clear as LoggingMDCResponseFilter happens before the
LoggingFilter
(https://github.com/alphagov/pay-java-commons/blob/master/logging/src/main/java/uk/gov/pay/logging/LoggingFilter.java)
is called. This would remove the x_request_id needed in the LoggingFilter.