### PR TITLE
PP-4573 Bump Surefire Version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
         <testcontainers.version>1.12.4</testcontainers.version>
         <postgresql.version>42.2.9</postgresql.version>
         <pay-java-commons.version>1.0.20191211153458</pay-java-commons.version>
-        <surefire.version>3.0.0-M3</surefire.version>
+        <surefire.version>3.0.0-M4</surefire.version>
         <guice.version>4.2.2</guice.version>
         <rest-assured.version>4.1.2</rest-assured.version>
         <PACT_BROKER_URL/>


### PR DESCRIPTION
- Bumps the version of the maven surefire plugin from 3.0.0-M3 to
3.0.0-M4 for investigation to why it is failing on master.