### PR TITLE
PP-5967 Add user_email to refund view

### DIFF
--- a/src/main/java/uk/gov/pay/ledger/transaction/model/Refund.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/model/Refund.java
@@ -12,6 +12,7 @@ public class Refund extends Transaction {
     private final ZonedDateTime createdDate;
     private final Integer eventCount;
     private final String refundedBy;
+    private final String refundedByUserEmail;
     private final String parentExternalId;
     private final Optional<Transaction> parentTransaction;
 
@@ -23,6 +24,7 @@ public class Refund extends Transaction {
         this.createdDate = builder.createdDate;
         this.eventCount = builder.eventCount;
         this.refundedBy = builder.refundedBy;
+        this.refundedByUserEmail = builder.refundedByUserEmail;
         this.parentExternalId = builder.parentExternalId;
         this.parentTransaction = builder.parentTransaction;
     }
@@ -64,6 +66,10 @@ public class Refund extends Transaction {
         return TransactionType.REFUND;
     }
 
+    public String getRefundedByUserEmail() {
+        return refundedByUserEmail;
+    }
+
     public static class Builder {
         private String reference;
         private String description;
@@ -71,6 +77,7 @@ public class Refund extends Transaction {
         private ZonedDateTime createdDate;
         private Integer eventCount;
         private String refundedBy;
+        private String refundedByUserEmail;
         private Long id;
         private String gatewayAccountId;
         private Long amount;
@@ -132,6 +139,11 @@ public class Refund extends Transaction {
 
         public Builder withRefundedBy(String refundedBy) {
             this.refundedBy = refundedBy;
+            return this;
+        }
+
+        public Builder withRefundedByUserEmail(String refundedByUserEmail) {
+            this.refundedByUserEmail = refundedByUserEmail;
             return this;
         }
 

--- a/src/main/java/uk/gov/pay/ledger/transaction/model/TransactionFactory.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/model/TransactionFactory.java
@@ -112,6 +112,7 @@ public class TransactionFactory {
                     .withCreatedDate(entity.getCreatedDate())
                     .withEventCount(entity.getEventCount())
                     .withRefundedBy(safeGetAsString(transactionDetails, "refunded_by"))
+                    .withRefundedByUserEmail(safeGetAsString(transactionDetails, "user_email"))
                     .withParentExternalId(entity.getParentExternalId())
                     .withParentTransaction(parentTransaction)
                     .build();

--- a/src/main/java/uk/gov/pay/ledger/transaction/search/model/TransactionView.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/search/model/TransactionView.java
@@ -50,6 +50,7 @@ public class TransactionView {
     private SettlementSummary settlementSummary;
     private Map<String, Object> metadata;
     private String refundedBy;
+    private String refundedByUserEmail;
     private TransactionType transactionType;
     private TransactionView parentTransaction;
 
@@ -78,6 +79,7 @@ public class TransactionView {
         this.settlementSummary = builder.settlementSummary;
         this.metadata = builder.metadata;
         this.refundedBy = builder.refundedBy;
+        this.refundedByUserEmail = builder.refundedByUserEmail;
         this.transactionType = builder.transactionType;
         this.parentTransaction = builder.parentTransaction;
     }
@@ -129,6 +131,7 @@ public class TransactionView {
                 .withParentExternalId(refund.getParentExternalId())
                 .withCreatedDate(refund.getCreatedDate())
                 .withRefundedBy(refund.getRefundedBy())
+                .withRefundedByUserEmail(refund.getRefundedByUserEmail())
                 .withTransactionType(refund.getTransactionType())
                 .withParentTransaction(refund.getParentTransaction().map(parentTransaction -> from(parentTransaction, statusVersion)).orElse(null))
                 .build();
@@ -198,6 +201,10 @@ public class TransactionView {
 
     public String getGatewayTransactionId() {
         return gatewayTransactionId;
+    }
+
+    public String getRefundedByUserEmail() {
+        return refundedByUserEmail;
     }
 
     @Override
@@ -279,6 +286,7 @@ public class TransactionView {
         private SettlementSummary settlementSummary;
         private Map<String, Object> metadata;
         private String refundedBy;
+        private String refundedByUserEmail;
         private TransactionType transactionType;
         private List<Link> links = new ArrayList<>();
 
@@ -406,6 +414,11 @@ public class TransactionView {
 
         public Builder withRefundedBy(String refundedBy) {
             this.refundedBy = refundedBy;
+            return this;
+        }
+
+        public Builder withRefundedByUserEmail(String refundedByUserEmail) {
+            this.refundedByUserEmail = refundedByUserEmail;
             return this;
         }
 

--- a/src/test/java/uk/gov/pay/ledger/transaction/model/TransactionFactoryTest.java
+++ b/src/test/java/uk/gov/pay/ledger/transaction/model/TransactionFactoryTest.java
@@ -182,7 +182,7 @@ public class TransactionFactoryTest {
                 .withCreatedDate(createdDate)
                 .withEventCount(eventCount)
                 .withParentTransactionEntity(fullDataObject)
-                .withTransactionDetails("{\"refunded_by\": \"some_user_id\"}")
+                .withTransactionDetails("{\"refunded_by\": \"some_user_id\", \"user_email\": \"test@example.com\"}")
                 .build();
         Refund refundEntity = (Refund) transactionFactory.createTransactionEntity(refund);
 
@@ -191,6 +191,7 @@ public class TransactionFactoryTest {
         assertThat(refundEntity.getExternalId(), is(externalId));
         assertThat(refundEntity.getParentExternalId(), is("parent-ext-id"));
         assertThat(refundEntity.getRefundedBy(), is("some_user_id"));
+        assertThat(refundEntity.getRefundedByUserEmail(), is("test@example.com"));
         assertThat(refundEntity.getReference(), is(reference));
         assertThat(refundEntity.getState(), is(state));
         assertThat(refundEntity.getCreatedDate(), is(createdDate));

--- a/src/test/java/uk/gov/pay/ledger/transaction/resource/TransactionResourceIT.java
+++ b/src/test/java/uk/gov/pay/ledger/transaction/resource/TransactionResourceIT.java
@@ -110,12 +110,14 @@ public class TransactionResourceIT {
     public void shouldGetRefundTransaction() {
         var now = ZonedDateTime.parse("2019-07-31T14:52:07.073Z");
         var refundedBy = "some_user_id";
+        var refundedByUserEmail = "test@example.com";
 
         transactionFixture = aTransactionFixture()
                 .withTransactionType("REFUND")
                 .withState(TransactionState.SUCCESS)
                 .withCreatedDate(now)
                 .withRefundedById(refundedBy)
+                .withRefundedByUserEmail(refundedByUserEmail)
                 .withDefaultTransactionDetails();
         transactionFixture.insert(rule.getJdbi());
 
@@ -130,7 +132,8 @@ public class TransactionResourceIT {
                 .body("amount", is(transactionFixture.getAmount().intValue()))
                 .body("reference", is(transactionFixture.getReference()))
                 .body("created_date", is(now.toString()))
-                .body("refunded_by", is(refundedBy));
+                .body("refunded_by", is(refundedBy))
+                .body("refunded_by_user_email", is(refundedByUserEmail));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/ledger/util/fixture/TransactionFixture.java
+++ b/src/test/java/uk/gov/pay/ledger/util/fixture/TransactionFixture.java
@@ -66,6 +66,7 @@ public class TransactionFixture implements DbFixture<TransactionFixture, Transac
     private String refundedById;
     private String cardBrandLabel;
     private boolean live;
+    private String refundedByUserEmail;
 
     private TransactionFixture() {
     }
@@ -353,6 +354,7 @@ public class TransactionFixture implements DbFixture<TransactionFixture, Transac
         transactionDetails.addProperty("gateway_transaction_id", gatewayTransactionId);
         transactionDetails.addProperty("corporate_surcharge", corporateCardSurcharge);
         transactionDetails.addProperty("refunded_by", refundedById);
+        transactionDetails.addProperty("user_email", refundedByUserEmail);
         transactionDetails.addProperty("card_type", String.valueOf(CREDIT));
         Optional.ofNullable(cardBrandLabel)
                 .ifPresent(cardBrandLabel -> transactionDetails.addProperty("card_brand_label", cardBrandLabel));
@@ -523,6 +525,11 @@ public class TransactionFixture implements DbFixture<TransactionFixture, Transac
 
     public TransactionFixture withRefundedById(String refundedById) {
         this.refundedById = refundedById;
+        return this;
+    }
+
+    public TransactionFixture withRefundedByUserEmail(String refundedByUserEmail) {
+        this.refundedByUserEmail = refundedByUserEmail;
         return this;
     }
 }


### PR DESCRIPTION
## WHAT

- Ledger now receives `user_email` for refund transactions which is stored in `transaction_details` DB column.
- This change returns user_email as `refunded_by_user_email` in refund transaction endpoint and to be used by CSV endpoint