### PR TITLE
PP-5970 Assertions for CSV data

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -232,6 +232,12 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-csv</artifactId>
+            <version>1.7</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/uk/gov/pay/ledger/util/csv/FlatCsvTransaction.java
+++ b/src/main/java/uk/gov/pay/ledger/util/csv/FlatCsvTransaction.java
@@ -10,6 +10,8 @@ import java.text.DecimalFormat;
 import java.time.format.DateTimeFormatter;
 import java.util.Optional;
 
+import static java.math.BigDecimal.valueOf;
+
 public class FlatCsvTransaction {
 
     @JsonProperty("Reference")
@@ -111,7 +113,7 @@ public class FlatCsvTransaction {
     private static String penceToCurrency(Long amount) {
         if (amount != null) {
             DecimalFormat decimalFormat = new DecimalFormat("#,##0.00");
-            return decimalFormat.format(amount / 100);
+            return decimalFormat.format(valueOf(amount).divide(valueOf(100L)));
         }
         return null;
     }


### PR DESCRIPTION
## WHAT
- Added a new test library to parse CSV data
- Added assertions for CSV headers and data (includes standard columns). Metadata/Stripe specific columns to be added once Ledger is able to generate CSV with these headers