### PR TITLE
PP-5970 Added `CsvTransactionFactory`

### DIFF
--- a/src/main/java/uk/gov/pay/ledger/transaction/model/CsvTransactionFactory.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/model/CsvTransactionFactory.java
@@ -1,0 +1,217 @@
+package uk.gov.pay.ledger.transaction.model;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.inject.Inject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.gov.pay.ledger.transaction.entity.TransactionEntity;
+import uk.gov.pay.ledger.transaction.state.ExternalTransactionState;
+
+import java.io.IOException;
+import java.text.DecimalFormat;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.TreeSet;
+
+import static java.math.BigDecimal.valueOf;
+import static net.logstash.logback.argument.StructuredArguments.kv;
+import static uk.gov.pay.ledger.util.JsonParser.safeGetAsLong;
+import static uk.gov.pay.ledger.util.JsonParser.safeGetAsString;
+import static uk.gov.pay.logging.LoggingKeys.PAYMENT_EXTERNAL_ID;
+
+public class CsvTransactionFactory {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(CsvTransactionFactory.class);
+    private static final String FIELD_AMOUNT = "Amount";
+    private static final String FIELD_REFERENCE = "Reference";
+    private static final String FIELD_DESC = "Description";
+    private static final String FIELD_DATE_CREATED = "Date Created";
+    private static final String FIELD_TIME_CREATED = "Time Created";
+    private static final String FIELD_EMAIL = "Email";
+    private static final String FIELD_CARD_BRAND = "Card Brand";
+    private static final String FIELD_CARDHOLDER_NAME = "Cardholder Name";
+    private static final String FIELD_CARD_EXPIRY_DATE = "Card Expiry Date";
+    private static final String FIELD_CARD_NUMBER = "Card Number";
+    private static final String FIELD_STATE = "State";
+    private static final String FIELD_FINISHED = "Finished";
+    private static final String FIELD_ERROR_CODE = "Error Code";
+    private static final String FIELD_ERROR_MESSAGE = "Error Message";
+    private static final String FIELD_PROVIDER_ID = "Provider ID";
+    private static final String FIELD_GOVUK_PAYMENT_ID = "GOV.UK Payment ID";
+    private static final String FIELD_ISSUED_BY = "Issued By";
+    private static final String FIELD_CORPORATE_CARD_SURCHARGE = "Corporate Card Surcharge";
+    private static final String FIELD_TOTAL_AMOUNT = "Total Amount";
+    private static final String FIELD_WALLET_TYPE = "Wallet Type";
+    private static final String FIELD_CARD_TYPE = "Card Type";
+    private static final String FIELD_FEE = "Fee";
+    private static final String FIELD_NET = "Net";
+    private ObjectMapper objectMapper;
+
+    @Inject
+    public CsvTransactionFactory(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+
+    public Map<String, Object> toMap(TransactionEntity transactionEntity) {
+        Map<String, Object> result = new HashMap<>();
+
+        try {
+            String dateCreated = parseDateForPattern(transactionEntity.getCreatedDate(),
+                    "dd MMM yyyy");
+            String timeCreated = parseDateForPattern(transactionEntity.getCreatedDate(),
+                    "HH:mm:ss");
+
+            JsonNode transactionDetails = objectMapper.readTree(
+                    Optional.ofNullable(transactionEntity.getTransactionDetails()).orElse("{}"));
+
+            result.put(FIELD_REFERENCE, transactionEntity.getReference());
+            result.put(FIELD_DESC, transactionEntity.getDescription());
+            result.put(FIELD_EMAIL, transactionEntity.getEmail());
+            result.put(FIELD_AMOUNT, penceToCurrency(transactionEntity.getAmount()));
+            result.put(FIELD_CARD_BRAND, transactionEntity.getCardBrand());
+            result.put(FIELD_CARDHOLDER_NAME, transactionEntity.getCardholderName());
+            result.put(FIELD_CARD_EXPIRY_DATE, safeGetAsString(transactionDetails, "expiry_date"));
+            result.put(FIELD_CARD_NUMBER, transactionEntity.getLastDigitsCardNumber());
+            result.put(FIELD_PROVIDER_ID, transactionEntity.getGatewayTransactionId());
+            result.put(FIELD_GOVUK_PAYMENT_ID, transactionEntity.getExternalId());
+            result.put(FIELD_ISSUED_BY, safeGetAsString(transactionDetails, "user_email"));
+            result.put(FIELD_DATE_CREATED, dateCreated);
+            result.put(FIELD_TIME_CREATED, timeCreated);
+            result.put(FIELD_CORPORATE_CARD_SURCHARGE,
+                    penceToCurrency(safeGetAsLong(transactionDetails, "corporate_surcharge")));
+            result.put(FIELD_TOTAL_AMOUNT, penceToCurrency(transactionEntity.getTotalAmount()));
+            result.put(FIELD_WALLET_TYPE, safeGetAsString(transactionDetails, "wallet_type"));
+            result.put(FIELD_CARD_TYPE, safeGetAsString(transactionDetails, "card_type"));
+
+            if (transactionEntity.getState() != null) {
+                ExternalTransactionState state = ExternalTransactionState.from(transactionEntity.getState(), 2);
+                result.put(FIELD_STATE, state.getStatus());
+                result.put(FIELD_FINISHED, state.isFinished());
+                result.put(FIELD_ERROR_CODE, state.getCode());
+                result.put(FIELD_ERROR_MESSAGE, state.getMessage());
+            }
+
+            result.put(FIELD_FEE, penceToCurrency(transactionEntity.getFee()));
+            result.put(FIELD_NET, penceToCurrency(transactionEntity.getNetAmount()));
+
+            Optional<Map<String, Object>> externalMetadata = getExternalMetadata(transactionEntity.getTransactionDetails());
+
+            externalMetadata.ifPresent(metadata ->
+                    metadata.forEach((key, value) ->
+                            result.put(String.format("%s (metadata)", key), value)));
+        } catch (IOException e) {
+            LOGGER.error("Error during the parsing transaction entity data [{}] [errorMessage={}]",
+                    transactionEntity.getExternalId(), e.getMessage());
+        }
+
+        return result;
+    }
+
+    public Map<String, Object> getCsvHeaders(List<TransactionEntity> transactions) {
+        LinkedHashMap<String, Object> headers = new LinkedHashMap<>();
+
+        headers.put(FIELD_REFERENCE, FIELD_REFERENCE);
+        headers.put(FIELD_DESC, FIELD_DESC);
+        headers.put(FIELD_EMAIL, FIELD_EMAIL);
+        headers.put(FIELD_AMOUNT, FIELD_AMOUNT);
+        headers.put(FIELD_CARD_BRAND, FIELD_CARD_BRAND);
+        headers.put(FIELD_CARDHOLDER_NAME, FIELD_CARDHOLDER_NAME);
+        headers.put(FIELD_CARD_EXPIRY_DATE, FIELD_CARD_EXPIRY_DATE);
+        headers.put(FIELD_CARD_NUMBER, FIELD_CARD_NUMBER);
+        headers.put(FIELD_STATE, FIELD_STATE);
+        headers.put(FIELD_FINISHED, FIELD_FINISHED);
+        headers.put(FIELD_ERROR_CODE, FIELD_ERROR_CODE);
+        headers.put(FIELD_ERROR_MESSAGE, FIELD_ERROR_MESSAGE);
+        headers.put(FIELD_PROVIDER_ID, FIELD_PROVIDER_ID);
+        headers.put(FIELD_GOVUK_PAYMENT_ID, FIELD_GOVUK_PAYMENT_ID);
+        headers.put(FIELD_ISSUED_BY, FIELD_ISSUED_BY);
+        headers.put(FIELD_DATE_CREATED, FIELD_DATE_CREATED);
+        headers.put(FIELD_TIME_CREATED, FIELD_TIME_CREATED);
+        headers.put(FIELD_CORPORATE_CARD_SURCHARGE, FIELD_CORPORATE_CARD_SURCHARGE);
+        headers.put(FIELD_TOTAL_AMOUNT, FIELD_TOTAL_AMOUNT);
+        headers.put(FIELD_WALLET_TYPE, FIELD_WALLET_TYPE);
+
+        if (isStripeTransaction(transactions.get(0))) {
+            headers.put(FIELD_FEE, FIELD_FEE);
+            headers.put(FIELD_NET, FIELD_NET);
+        }
+
+        Set<String> metadataHeaders = deriveMetadataHeaders(transactions);
+        metadataHeaders.forEach(key -> headers.put(key, key));
+
+        headers.put(FIELD_CARD_TYPE, FIELD_CARD_TYPE);
+        return headers;
+    }
+
+    private boolean isStripeTransaction(TransactionEntity aTransaction) {
+        try {
+            JsonNode transactionDetails = objectMapper.readTree(Optional.ofNullable(
+                    aTransaction.getTransactionDetails()).orElse("{}"));
+            String paymentProvider = safeGetAsString(transactionDetails, "payment_provider");
+
+            return "stripe".equals(paymentProvider);
+        } catch (IOException e) {
+            LOGGER.error("Error parsing transaction for Stripe specific CSV headers [{}] [errorMessage={}]",
+                    kv(PAYMENT_EXTERNAL_ID, aTransaction.getExternalId()),
+                    e.getMessage());
+            return false;
+        }
+    }
+
+    private String penceToCurrency(Long amount) {
+        if (amount != null) {
+            DecimalFormat decimalFormat = new DecimalFormat("#,##0.00");
+            return decimalFormat.format(valueOf(amount).divide(valueOf(100L)));
+        }
+        return null;
+    }
+
+    private String parseDateForPattern(ZonedDateTime dateTime, String pattern) {
+        return Optional.ofNullable(dateTime)
+                .map(date -> date.format(DateTimeFormatter.ofPattern(pattern)))
+                .orElse(null);
+    }
+
+    private Optional<Map<String, Object>> getExternalMetadata(String transactionDetails)
+            throws IOException {
+
+        JsonNode transactionDetailsJsonNode = objectMapper.readTree(
+                Optional.ofNullable(transactionDetails).orElse("{}"));
+
+        Map<String, Object> metadata = null;
+        if (transactionDetailsJsonNode.has("external_metadata")) {
+            metadata = objectMapper.readValue(
+                    objectMapper.treeAsTokens(transactionDetailsJsonNode.get("external_metadata")),
+                    new TypeReference<Map<String, Object>>() {
+                    });
+        }
+        return Optional.ofNullable(metadata);
+    }
+
+    private Set<String> deriveMetadataHeaders(List<TransactionEntity> transactions) {
+        Set<String> metadataHeaders = new TreeSet<>();
+        transactions.forEach(transactionEntity -> {
+            try {
+                Optional<Map<String, Object>> externalMetadata = getExternalMetadata(
+                        transactionEntity.getTransactionDetails());
+
+                externalMetadata.ifPresent(metadata ->
+                        metadata.forEach((key, value) ->
+                                metadataHeaders.add(String.format("%s (metadata)", key))));
+            } catch (IOException e) {
+                LOGGER.error("Error parsing transaction for metadata headers [{}] [errorMessage={}]",
+                        kv(PAYMENT_EXTERNAL_ID, transactionEntity.getExternalId()),
+                        e.getMessage());
+            }
+        });
+        return metadataHeaders;
+    }
+}

--- a/src/test/java/uk/gov/pay/ledger/transaction/model/CsvTransactionFactoryTest.java
+++ b/src/test/java/uk/gov/pay/ledger/transaction/model/CsvTransactionFactoryTest.java
@@ -1,0 +1,190 @@
+package uk.gov.pay.ledger.transaction.model;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableMap;
+import com.google.gson.GsonBuilder;
+import org.junit.Before;
+import org.junit.Test;
+import uk.gov.pay.ledger.transaction.entity.TransactionEntity;
+import uk.gov.pay.ledger.transaction.state.TransactionState;
+import uk.gov.pay.ledger.util.fixture.TransactionFixture;
+
+import java.time.ZonedDateTime;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static uk.gov.pay.ledger.util.fixture.TransactionFixture.aTransactionFixture;
+
+public class CsvTransactionFactoryTest {
+
+    private CsvTransactionFactory csvTransactionFactory;
+    private TransactionFixture transactionFixture;
+
+    @Before
+    public void setUp() {
+        ObjectMapper objectMapper = new ObjectMapper();
+        csvTransactionFactory = new CsvTransactionFactory(objectMapper);
+
+        transactionFixture = aTransactionFixture()
+                .withState(TransactionState.FAILED_REJECTED)
+                .withAmount(100L)
+                .withCreatedDate(ZonedDateTime.parse("2018-03-12T16:25:01.123456Z"))
+                .withTotalAmount(123L)
+                .withTransactionDetails(
+                        new GsonBuilder().create()
+                                .toJson(ImmutableMap.builder()
+                                        .put("expiry_date", "10/24")
+                                        .put("user_email", "refundedbyuser@example.org")
+                                        .put("corporate_surcharge", 23)
+                                        .put("wallet_type", "APPLE")
+                                        .put("card_type", "DEBIT")
+                                        .build())
+                );
+    }
+
+    @Test
+    public void toMapShouldReturnMapWithCorrectCsvData() {
+
+        TransactionEntity transactionEntity = transactionFixture.toEntity();
+
+        Map<String, Object> csvDataMap = csvTransactionFactory.toMap(transactionEntity);
+
+        assertThat(csvDataMap.get("Reference"), is(transactionEntity.getReference()));
+        assertThat(csvDataMap.get("Description"), is(transactionEntity.getDescription()));
+        assertThat(csvDataMap.get("Email"), is(transactionEntity.getEmail()));
+        assertThat(csvDataMap.get("Amount"), is("1.00"));
+        assertThat(csvDataMap.get("Card Brand"), is(transactionEntity.getCardBrand()));
+        assertThat(csvDataMap.get("Cardholder Name"), is(transactionEntity.getCardholderName()));
+        assertThat(csvDataMap.get("Card Expiry Date"), is("10/24"));
+        assertThat(csvDataMap.get("Card Number"), is(transactionEntity.getLastDigitsCardNumber()));
+        assertThat(csvDataMap.get("State"), is("declined"));
+        assertThat(csvDataMap.get("Finished"), is(true));
+        assertThat(csvDataMap.get("Error Code"), is("P0010"));
+        assertThat(csvDataMap.get("Error Message"), is("Payment method rejected"));
+        assertThat(csvDataMap.get("Provider ID"), is(transactionEntity.getGatewayTransactionId()));
+        assertThat(csvDataMap.get("GOV.UK Payment ID"), is(transactionEntity.getExternalId()));
+        assertThat(csvDataMap.get("Issued By"), is("refundedbyuser@example.org"));
+        assertThat(csvDataMap.get("Date Created"), is("12 Mar 2018"));
+        assertThat(csvDataMap.get("Time Created"), is("16:25:01"));
+        assertThat(csvDataMap.get("Corporate Card Surcharge"), is("0.23"));
+        assertThat(csvDataMap.get("Total Amount"), is("1.23"));
+        assertThat(csvDataMap.get("Card Type"), is("DEBIT"));
+        assertThat(csvDataMap.get("Wallet Type"), is("APPLE"));
+    }
+
+    @Test
+    public void toMapShouldIncludeExternalMetadataFields() {
+        TransactionEntity transactionEntity = transactionFixture.withTransactionDetails(
+                new GsonBuilder().create().toJson(ImmutableMap.builder()
+                        .put("external_metadata",
+                                ImmutableMap.builder()
+                                        .put("key-1", "value-1").put("key-2", "value-2").build())
+                        .build()
+                )).toEntity();
+
+        Map<String, Object> csvDataMap = csvTransactionFactory.toMap(transactionEntity);
+
+        assertThat(csvDataMap.get("key-1 (metadata)"), is("value-1"));
+        assertThat(csvDataMap.get("key-2 (metadata)"), is("value-2"));
+    }
+
+    @Test
+    public void toMapShouldIncludeFeeAndNetAmountForStripePayments() {
+        TransactionEntity transactionEntity = transactionFixture.withNetAmount(594)
+                .withPaymentProvider("stripe")
+                .withFee(6).toEntity();
+
+        Map<String, Object> csvDataMap = csvTransactionFactory.toMap(transactionEntity);
+
+        assertThat(csvDataMap.get("Net"), is("5.94"));
+        assertThat(csvDataMap.get("Fee"), is("0.06"));
+    }
+
+    @Test
+    public void getCsvHeadersShouldReturnMapWithCorrectCsvHeaders() {
+        TransactionEntity transactionEntity = transactionFixture.withNetAmount(594)
+                .withState(TransactionState.FAILED_REJECTED)
+                .withPaymentProvider("sandbox")
+                .withFee(6).toEntity();
+
+        List transactionEntities = List.of(transactionEntity);
+
+        LinkedHashMap<String, Object> csvHeaders = (LinkedHashMap<String, Object>) csvTransactionFactory.getCsvHeaders(transactionEntities);
+
+        assertThat(csvHeaders.get("Reference"), is(notNullValue()));
+        assertThat(csvHeaders.get("Description"), is(notNullValue()));
+        assertThat(csvHeaders.get("Email"), is(notNullValue()));
+        assertThat(csvHeaders.get("Amount"), is(notNullValue()));
+        assertThat(csvHeaders.get("Card Brand"), is(notNullValue()));
+        assertThat(csvHeaders.get("Cardholder Name"), is(notNullValue()));
+        assertThat(csvHeaders.get("Card Expiry Date"), is(notNullValue()));
+        assertThat(csvHeaders.get("Card Number"), is(notNullValue()));
+        assertThat(csvHeaders.get("State"), is(notNullValue()));
+        assertThat(csvHeaders.get("Finished"), is(notNullValue()));
+        assertThat(csvHeaders.get("Error Code"), is(notNullValue()));
+        assertThat(csvHeaders.get("Error Message"), is(notNullValue()));
+        assertThat(csvHeaders.get("Provider ID"), is(notNullValue()));
+        assertThat(csvHeaders.get("GOV.UK Payment ID"), is(notNullValue()));
+        assertThat(csvHeaders.get("Issued By"), is(notNullValue()));
+        assertThat(csvHeaders.get("Date Created"), is(notNullValue()));
+        assertThat(csvHeaders.get("Time Created"), is(notNullValue()));
+        assertThat(csvHeaders.get("Corporate Card Surcharge"), is(notNullValue()));
+        assertThat(csvHeaders.get("Wallet Type"), is(notNullValue()));
+        assertThat(csvHeaders.get("Card Type"), is(notNullValue()));
+
+        // Stripe specific should not available for other payment providers
+        assertThat(csvHeaders.get("Net"), is(nullValue()));
+        assertThat(csvHeaders.get("Fee"), is(nullValue()));
+    }
+
+    @Test
+    public void getCsvHeadersShouldIncludeExternalMetadataFieldsInHeader() {
+        TransactionEntity transactionEntity = transactionFixture.withTransactionDetails(
+                new GsonBuilder().create().toJson(ImmutableMap.builder()
+                        .put("external_metadata",
+                                ImmutableMap.builder()
+                                        .put("key-1", "value-1").put("key-2", "value-2").build())
+                        .build()
+                )).toEntity();
+
+        TransactionEntity anotherTransactionEntity = transactionFixture.withTransactionDetails(
+                new GsonBuilder().create().toJson(ImmutableMap.builder()
+                        .put("external_metadata",
+                                ImmutableMap.builder().put("key-0", "value-0").build())
+                        .build()
+                )).toEntity();
+
+        List transactionEntities = List.of(transactionEntity, anotherTransactionEntity);
+
+        Map<String, Object> csvHeaders = csvTransactionFactory.getCsvHeaders(transactionEntities);
+
+        assertThat(csvHeaders.get("key-0 (metadata)"), is(notNullValue()));
+        assertThat(csvHeaders.get("key-1 (metadata)"), is(notNullValue()));
+        assertThat(csvHeaders.get("key-2 (metadata)"), is(notNullValue()));
+    }
+
+    @Test
+    public void getCsvHeadersShouldIncludeFeeAndNetForStripePayments() {
+        TransactionEntity transactionEntity = transactionFixture.withNetAmount(594)
+                .withFee(6)
+                .withTransactionDetails(
+                        new GsonBuilder().create()
+                                .toJson(ImmutableMap.builder()
+                                        .put("payment_provider", "stripe")
+                                        .build())
+                )
+                .toEntity();
+
+        List transactionEntities = List.of(transactionEntity);
+
+        Map<String, Object> csvHeaders = csvTransactionFactory.getCsvHeaders(transactionEntities);
+
+        assertThat(csvHeaders.get("Net"), is(notNullValue()));
+        assertThat(csvHeaders.get("Fee"), is(notNullValue()));
+    }
+}


### PR DESCRIPTION
## WHAT 
Prep to use `Map` for CSV data instead of POJO.

- Added new class `CsvTransactionFactory` to process DB transactions and convert the same to Map (CSV field name, value) for CSV endpooint. Currently we create plain object with annotations.
- Also derives headers (including metadata & Stripe specific ) for CSV as Map
   - Uses `LinkedHashMap` for CSV header to keep the column ordering when generating CSV response