### PR TITLE
PP-5991 Events ticker for dashboard

### DIFF
--- a/src/main/java/uk/gov/pay/ledger/event/dao/EventDao.java
+++ b/src/main/java/uk/gov/pay/ledger/event/dao/EventDao.java
@@ -10,13 +10,17 @@ import org.jdbi.v3.sqlobject.statement.SqlQuery;
 import org.jdbi.v3.sqlobject.statement.SqlUpdate;
 import org.jdbi.v3.sqlobject.transaction.Transaction;
 import uk.gov.pay.ledger.event.dao.mapper.EventMapper;
+import uk.gov.pay.ledger.event.dao.mapper.EventTickerMapper;
 import uk.gov.pay.ledger.event.model.Event;
+import uk.gov.pay.ledger.event.model.EventTicker;
 
+import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
 @RegisterRowMapper(EventMapper.class)
+@RegisterRowMapper(EventTickerMapper.class)
 public interface EventDao {
     @CreateSqlObject
     ResourceTypeDao getResourceTypeDao();
@@ -73,4 +77,10 @@ public interface EventDao {
             " AND e.resource_type_id = rt.id" +
             " ORDER BY e.event_date ASC")
     List<Event> findEventsForExternalIds(@BindList("externalIds") Set<String> externalIds);
+
+    @SqlQuery("SELECT e.id, e.event_type, t.type, e.resource_external_id, e.event_date, t.card_brand, " +
+            "t.transaction_details->'payment_provider', t.gateway_account_id, t.type " +
+            "FROM event e LEFT JOIN transaction t ON e.resource_external_id = t.external_id " +
+            "WHERE e.event_date >= :fromDate AND t.live ORDER BY e.event_date DESC")
+    List<EventTicker> findEventsTickerFromDate(@Bind("fromDate") ZonedDateTime fromDate);
 }

--- a/src/main/java/uk/gov/pay/ledger/event/dao/mapper/EventTickerMapper.java
+++ b/src/main/java/uk/gov/pay/ledger/event/dao/mapper/EventTickerMapper.java
@@ -2,7 +2,6 @@ package uk.gov.pay.ledger.event.dao.mapper;
 
 import org.jdbi.v3.core.mapper.RowMapper;
 import org.jdbi.v3.core.statement.StatementContext;
-import uk.gov.pay.ledger.event.model.Event;
 import uk.gov.pay.ledger.event.model.EventTicker;
 import uk.gov.pay.ledger.event.model.ResourceType;
 
@@ -10,13 +9,14 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
+import java.util.Locale;
 
 public class EventTickerMapper implements RowMapper<EventTicker> {
 
     @Override
     public EventTicker map(ResultSet resultSet, StatementContext statementContext) throws SQLException {
         return new EventTicker(resultSet.getLong("id"),
-                ResourceType.valueOf(resultSet.getString("type").toUpperCase()),
+                ResourceType.valueOf(resultSet.getString("type").toUpperCase(Locale.UK)),
                 resultSet.getString("resource_external_id"),
                 ZonedDateTime.ofInstant(resultSet.getTimestamp("event_date").toInstant(), ZoneOffset.UTC),
                 resultSet.getString("event_type")

--- a/src/main/java/uk/gov/pay/ledger/event/dao/mapper/EventTickerMapper.java
+++ b/src/main/java/uk/gov/pay/ledger/event/dao/mapper/EventTickerMapper.java
@@ -1,0 +1,25 @@
+package uk.gov.pay.ledger.event.dao.mapper;
+
+import org.jdbi.v3.core.mapper.RowMapper;
+import org.jdbi.v3.core.statement.StatementContext;
+import uk.gov.pay.ledger.event.model.Event;
+import uk.gov.pay.ledger.event.model.EventTicker;
+import uk.gov.pay.ledger.event.model.ResourceType;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+
+public class EventTickerMapper implements RowMapper<EventTicker> {
+
+    @Override
+    public EventTicker map(ResultSet resultSet, StatementContext statementContext) throws SQLException {
+        return new EventTicker(resultSet.getLong("id"),
+                ResourceType.valueOf(resultSet.getString("type").toUpperCase()),
+                resultSet.getString("resource_external_id"),
+                ZonedDateTime.ofInstant(resultSet.getTimestamp("event_date").toInstant(), ZoneOffset.UTC),
+                resultSet.getString("event_type")
+        );
+    }
+}

--- a/src/main/java/uk/gov/pay/ledger/event/model/EventTicker.java
+++ b/src/main/java/uk/gov/pay/ledger/event/model/EventTicker.java
@@ -69,8 +69,12 @@ public class EventTicker {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
         EventTicker event = (EventTicker) o;
         return Objects.equals(id, event.id) &&
                 resourceType == event.resourceType &&

--- a/src/main/java/uk/gov/pay/ledger/event/model/EventTicker.java
+++ b/src/main/java/uk/gov/pay/ledger/event/model/EventTicker.java
@@ -1,0 +1,86 @@
+package uk.gov.pay.ledger.event.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import uk.gov.pay.ledger.event.model.serializer.MicrosecondPrecisionDateTimeSerializer;
+
+import java.time.ZonedDateTime;
+import java.util.Objects;
+
+@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+public class EventTicker {
+
+    @JsonIgnore
+    private Long id;
+    private ResourceType resourceType;
+    private String resourceExternalId;
+    @JsonSerialize(using = MicrosecondPrecisionDateTimeSerializer.class)
+    private ZonedDateTime eventDate;
+    private String eventType;
+
+    public EventTicker() { }
+
+    public EventTicker(Long id, ResourceType resourceType, String resourceExternalId,
+                       ZonedDateTime eventDate, String eventType) {
+        this.id = id;
+        this.resourceType = resourceType;
+        this.resourceExternalId = resourceExternalId;
+        this.eventDate = eventDate;
+        this.eventType = eventType;
+    }
+
+    public EventTicker(ResourceType resourceType, String resourceExternalId, ZonedDateTime eventDate,
+                       String eventType) {
+        this(null, resourceType, resourceExternalId, eventDate, eventType);
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public ResourceType getResourceType() {
+        return resourceType;
+    }
+
+    public String getResourceExternalId() {
+        return resourceExternalId;
+    }
+
+    public ZonedDateTime getEventDate() {
+        return eventDate;
+    }
+
+    public String getEventType() {
+        return eventType;
+    }
+
+    @Override
+    public String toString() {
+        return "Event{" +
+                "id=" + id +
+                ", resourceType=" + resourceType +
+                ", resourceExternalId='" + resourceExternalId + '\'' +
+                ", eventDate=" + eventDate +
+                ", eventType=" + eventType +
+                '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        EventTicker event = (EventTicker) o;
+        return Objects.equals(id, event.id) &&
+                resourceType == event.resourceType &&
+                Objects.equals(resourceExternalId, event.resourceExternalId) &&
+                Objects.equals(eventDate, event.eventDate) &&
+                Objects.equals(eventType, event.eventType);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, resourceType, resourceExternalId, eventDate, eventType);
+    }
+}

--- a/src/main/java/uk/gov/pay/ledger/event/resource/EventResource.java
+++ b/src/main/java/uk/gov/pay/ledger/event/resource/EventResource.java
@@ -6,13 +6,20 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.pay.ledger.event.dao.EventDao;
 import uk.gov.pay.ledger.event.model.Event;
+import uk.gov.pay.ledger.event.model.EventTicker;
+import uk.gov.pay.ledger.exception.ValidationException;
+import static org.apache.commons.lang3.StringUtils.isBlank;
 
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
+import javax.ws.rs.QueryParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Response;
+
+import java.time.ZonedDateTime;
+import java.util.List;
 
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 
@@ -36,5 +43,16 @@ public class EventResource {
         LOGGER.info("Get event request: {}", eventId);
         return eventDao.getById(eventId)
                 .orElseThrow(() -> new WebApplicationException(Response.Status.NOT_FOUND));
+    }
+
+    @Path("/ticker")
+    @GET
+    @Timed
+    public List<EventTicker> eventTickerList(@QueryParam("from_date") String fromDate) {
+        if(isBlank(fromDate)) {
+            throw new ValidationException("from_date is mandatory to receive event ticker");
+        }
+
+        return eventDao.findEventsTickerFromDate(ZonedDateTime.parse(fromDate));
     }
 }

--- a/src/test/java/uk/gov/pay/ledger/event/dao/EventDaoIT.java
+++ b/src/test/java/uk/gov/pay/ledger/event/dao/EventDaoIT.java
@@ -1,6 +1,5 @@
 package uk.gov.pay.ledger.event.dao;
 
-import au.com.dius.pact.provider.junit.target.TestTarget;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.Before;
@@ -9,8 +8,6 @@ import org.junit.Test;
 import uk.gov.pay.ledger.event.model.Event;
 import uk.gov.pay.ledger.event.model.EventTicker;
 import uk.gov.pay.ledger.rule.AppWithPostgresAndSqsRule;
-import uk.gov.pay.ledger.transaction.entity.TransactionEntity;
-import uk.gov.pay.ledger.transaction.model.Transaction;
 import uk.gov.pay.ledger.util.DatabaseTestHelper;
 
 import java.io.IOException;
@@ -225,7 +222,7 @@ public class EventDaoIT {
 
     @Test
     public void findEventsTickerFromDate_ShouldGetAllEventsFromDateSpecified() {
-        TransactionEntity transaction = aTransactionFixture()
+        aTransactionFixture()
                 .withExternalId("external-id-1")
                 .withLive(true)
                 .insert(rule.getJdbi())
@@ -240,7 +237,7 @@ public class EventDaoIT {
                 .withEventDate(event1.getEventDate().minusDays(1))
                 .insert(rule.getJdbi())
                 .toEntity();
-        Event event3 = anEventFixture()
+        anEventFixture()
                 .withResourceExternalId("external-id-1")
                 .withEventDate(event2.getEventDate().minusDays(1))
                 .insert(rule.getJdbi())

--- a/src/test/java/uk/gov/pay/ledger/event/resource/EventResourceIT.java
+++ b/src/test/java/uk/gov/pay/ledger/event/resource/EventResourceIT.java
@@ -11,6 +11,7 @@ import static io.restassured.RestAssured.given;
 import static io.restassured.http.ContentType.JSON;
 import static org.hamcrest.CoreMatchers.is;
 import static uk.gov.pay.ledger.util.fixture.EventFixture.anEventFixture;
+import static uk.gov.pay.ledger.util.fixture.TransactionFixture.aTransactionFixture;
 
 public class EventResourceIT {
     @ClassRule
@@ -35,5 +36,36 @@ public class EventResourceIT {
                 .body("sqs_message_id", is(event.getSqsMessageId()))
                 .body("event_type", is(event.getEventType().toString()))
                 .body("event_data", is(event.getEventData()));
+    }
+
+    @Test
+    public void shouldGetEvenTicker() {
+        aTransactionFixture()
+                .withExternalId("an-external-id")
+                .withLive(true)
+                .insert(rule.getJdbi())
+                .toEntity();
+
+        Event event = anEventFixture()
+                .withResourceExternalId("an-external-id")
+                .insert(rule.getJdbi())
+                .toEntity();
+
+        anEventFixture()
+                .withResourceExternalId("an-external-id")
+                .withEventDate(event.getEventDate().minusHours(1))
+                .insert(rule.getJdbi())
+                .toEntity();
+
+        given().port(port)
+                .contentType(JSON)
+                .queryParam("from_date", event.getEventDate().minusMinutes(1).toString())
+                .get("/v1/event/ticker")
+                .then()
+                .statusCode(Response.Status.OK.getStatusCode())
+                .contentType(JSON)
+                .body("[0].resource_external_id", is("an-external-id"))
+                .body("[0].event_type", is("PAYMENT_CREATED"))
+                .body("size()", is(1));
     }
 }


### PR DESCRIPTION
"Administrative" list all events endpoint - used to drive a payment events ticker.

This will fetch events within a specified timeframe selecting only for `live` transactions. 

Future improvements: 
* Allow selecting by individual gateway accounts 
* Limit the consumer from selecting a large number of events (or a long timespan) 

These events can then be formatted and displayed as payments are processed (rough draft):

![Screen Shot 2019-12-31 at 18 07 17](https://user-images.githubusercontent.com/2844572/71676068-2565ad00-2d77-11ea-913e-d11905839ba8.png)
