### PR TITLE
PP-5991 Timeseries transaction volumes by hour

### DIFF
--- a/src/main/java/uk/gov/pay/ledger/report/dao/ReportDao.java
+++ b/src/main/java/uk/gov/pay/ledger/report/dao/ReportDao.java
@@ -74,12 +74,12 @@ public class ReportDao {
     public List<TimeseriesReportSlice> getTransactionsVolumeByTimeseries(ZonedDateTime fromDate, ZonedDateTime toDate) {
         return jdbi.withHandle(handle -> handle.createQuery("SELECT " +
                     "date_trunc('hour', t.created_date) as timestamp, " +
-                    "COUNT(1) as all_payments, " +
-                    "COUNT(1) filter (WHERE t.state IN ('ERROR', 'ERROR_GATEWAY')) as errored_payments, " +
-                    "COUNT(1) filter (WHERE t.state IN ('SUCCESS')) as completed_payments, " +
+                    "COUNT(*) as all_payments, " +
+                    "COUNT(*) filter (WHERE t.state IN ('ERROR', 'ERROR_GATEWAY')) as errored_payments, " +
+                    "COUNT(*) filter (WHERE t.state IN ('SUCCESS')) as completed_payments, " +
                     "SUM(t.amount) as amount, SUM(t.net_amount) as net_amount, SUM(t.total_amount) as total_amount, SUM(t.fee) as fee " +
                     "FROM transaction t " +
-                    "WHERE t.live AND t.created_date >= :fromDate AND t.created_date <= :toDate " +
+                    "WHERE t.live AND (t.created_date BETWEEN :fromDate AND :toDate) " +
                     "GROUP BY date_trunc('hour', t.created_date) " +
                     "ORDER BY date_trunc('hour', t.created_date)")
                     .bind("fromDate", fromDate)

--- a/src/main/java/uk/gov/pay/ledger/report/dao/ReportDao.java
+++ b/src/main/java/uk/gov/pay/ledger/report/dao/ReportDao.java
@@ -4,7 +4,6 @@ import org.apache.commons.lang3.StringUtils;
 import org.jdbi.v3.core.Jdbi;
 import org.jdbi.v3.core.statement.Query;
 import org.jdbi.v3.sqlobject.config.RegisterRowMapper;
-import org.jdbi.v3.sqlobject.statement.SqlQuery;
 import uk.gov.pay.ledger.report.entity.PaymentCountByStateResult;
 import uk.gov.pay.ledger.report.entity.TimeseriesReportSlice;
 import uk.gov.pay.ledger.report.entity.TransactionsStatisticsResult;
@@ -72,13 +71,11 @@ public class ReportDao {
         });
     }
 
-    // @TODO(sfount) using an interface with annotations seems like a neater way of writing a DAO (see events)
-    // @TODO(sfount) selecting this report by individual gateway account would be useful in the future
     public List<TimeseriesReportSlice> getTransactionsVolumeByTimeseries(ZonedDateTime fromDate, ZonedDateTime toDate) {
         return jdbi.withHandle(handle -> handle.createQuery("SELECT " +
                     "date_trunc('hour', t.created_date) as timestamp, " +
                     "COUNT(1) as all_payments, " +
-                    "COUNT(1) filter (WHERE t.state IN ('ERROR', 'GATEWAY_ERROR')) as errored_payments, " +
+                    "COUNT(1) filter (WHERE t.state IN ('ERROR', 'ERROR_GATEWAY')) as errored_payments, " +
                     "COUNT(1) filter (WHERE t.state IN ('SUCCESS')) as completed_payments, " +
                     "SUM(t.amount) as amount, SUM(t.net_amount) as net_amount, SUM(t.total_amount) as total_amount, SUM(t.fee) as fee " +
                     "FROM transaction t " +

--- a/src/main/java/uk/gov/pay/ledger/report/entity/TimeseriesReportSlice.java
+++ b/src/main/java/uk/gov/pay/ledger/report/entity/TimeseriesReportSlice.java
@@ -1,0 +1,65 @@
+package uk.gov.pay.ledger.report.entity;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import uk.gov.pay.ledger.event.model.serializer.MicrosecondPrecisionDateTimeSerializer;
+
+import java.time.ZonedDateTime;
+
+@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+public class TimeseriesReportSlice {
+
+    @JsonSerialize(using = MicrosecondPrecisionDateTimeSerializer.class)
+    private final ZonedDateTime timestamp;
+    private final int allPayments;
+    private final int erroredPayments;
+    private final int completedPayments;
+    private final int amount;
+    private final int netAmount;
+    private final int totalAmount;
+    private final int fee;
+
+    public TimeseriesReportSlice(ZonedDateTime timestamp, int allPayments, int erroredPayments, int completedPayments, int amount, int netAmount, int totalAmount, int fee) {
+        this.timestamp = timestamp;
+        this.allPayments = allPayments;
+        this.erroredPayments = erroredPayments;
+        this.completedPayments = completedPayments;
+        this.amount = amount;
+        this.netAmount = netAmount;
+        this.totalAmount = totalAmount;
+        this.fee = fee;
+    }
+
+    public ZonedDateTime getTimestamp() {
+        return timestamp;
+    }
+
+    public int getAllPayments() {
+        return allPayments;
+    }
+
+    public int getErroredPayments() {
+        return erroredPayments;
+    }
+
+    public int getCompletedPayments() {
+        return completedPayments;
+    }
+
+    public int getAmount() {
+        return amount;
+    }
+
+    public int getNetAmount() {
+        return netAmount;
+    }
+
+    public int getTotalAmount() {
+        return totalAmount;
+    }
+
+    public int getFee() {
+        return fee;
+    }
+}

--- a/src/main/java/uk/gov/pay/ledger/report/mapper/ReportMapper.java
+++ b/src/main/java/uk/gov/pay/ledger/report/mapper/ReportMapper.java
@@ -2,10 +2,8 @@ package uk.gov.pay.ledger.report.mapper;
 
 import org.jdbi.v3.core.mapper.RowMapper;
 import org.jdbi.v3.core.statement.StatementContext;
-import uk.gov.pay.ledger.report.entity.PerformanceReportEntity;
 import uk.gov.pay.ledger.report.entity.TimeseriesReportSlice;
 
-import java.math.BigDecimal;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.time.ZoneOffset;

--- a/src/main/java/uk/gov/pay/ledger/report/mapper/ReportMapper.java
+++ b/src/main/java/uk/gov/pay/ledger/report/mapper/ReportMapper.java
@@ -1,0 +1,29 @@
+package uk.gov.pay.ledger.report.mapper;
+
+import org.jdbi.v3.core.mapper.RowMapper;
+import org.jdbi.v3.core.statement.StatementContext;
+import uk.gov.pay.ledger.report.entity.PerformanceReportEntity;
+import uk.gov.pay.ledger.report.entity.TimeseriesReportSlice;
+
+import java.math.BigDecimal;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+
+public class ReportMapper implements RowMapper<TimeseriesReportSlice>  {
+
+    @Override
+    public TimeseriesReportSlice map(ResultSet rs, StatementContext ctx) throws SQLException {
+        return new TimeseriesReportSlice(
+                ZonedDateTime.ofInstant(rs.getTimestamp("timestamp").toInstant(), ZoneOffset.UTC),
+                rs.getInt("all_payments"),
+                rs.getInt("errored_payments"),
+                rs.getInt("completed_payments"),
+                rs.getInt("amount"),
+                rs.getInt("net_amount"),
+                rs.getInt("total_amount"),
+                rs.getInt("fee")
+        );
+    }
+}

--- a/src/main/java/uk/gov/pay/ledger/report/resource/ReportResource.java
+++ b/src/main/java/uk/gov/pay/ledger/report/resource/ReportResource.java
@@ -1,6 +1,7 @@
 package uk.gov.pay.ledger.report.resource;
 
 import com.codahale.metrics.annotation.Timed;
+import uk.gov.pay.ledger.report.entity.TimeseriesReportSlice;
 import uk.gov.pay.ledger.report.entity.TransactionSummaryResult;
 import uk.gov.pay.ledger.report.params.TransactionSummaryParams;
 import uk.gov.pay.ledger.report.service.ReportService;
@@ -9,6 +10,7 @@ import uk.gov.pay.ledger.transaction.service.AccountIdSupplierManager;
 
 import javax.inject.Inject;
 import javax.validation.Valid;
+import javax.validation.ValidationException;
 import javax.ws.rs.BeanParam;
 import javax.ws.rs.DefaultValue;
 import javax.ws.rs.GET;
@@ -16,10 +18,14 @@ import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Response;
+import java.time.ZonedDateTime;
+import java.util.List;
 import java.util.Map;
 
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static javax.ws.rs.core.Response.Status.OK;
+
+import static org.apache.commons.lang3.StringUtils.isBlank;
 
 @Path("/v1/report")
 @Produces(APPLICATION_JSON)
@@ -68,5 +74,21 @@ public class ReportResource {
                 .withSupplier(accountId -> reportService.getTransactionsSummary(transactionSummaryParams))
                 .withPrivilegedSupplier(() -> reportService.getTransactionsSummary(transactionSummaryParams))
                 .validateAndGet();
+    }
+
+    @Path("/transactions-by-hour")
+    @GET
+    @Timed
+    public List<TimeseriesReportSlice> getTransactionsByHour(
+            @QueryParam("from_date") String fromDate,
+            @QueryParam("to_date") String toDate
+    ) {
+        if(isBlank(fromDate) || isBlank(toDate)) {
+            throw new ValidationException("from_date and to_date must be specified");
+        }
+        return reportService.getTransactionsByHour(
+                ZonedDateTime.parse(fromDate),
+                ZonedDateTime.parse(toDate)
+        );
     }
 }

--- a/src/main/java/uk/gov/pay/ledger/report/resource/ReportResource.java
+++ b/src/main/java/uk/gov/pay/ledger/report/resource/ReportResource.java
@@ -1,6 +1,7 @@
 package uk.gov.pay.ledger.report.resource;
 
 import com.codahale.metrics.annotation.Timed;
+import uk.gov.pay.ledger.exception.ValidationException;
 import uk.gov.pay.ledger.report.entity.TimeseriesReportSlice;
 import uk.gov.pay.ledger.report.entity.TransactionSummaryResult;
 import uk.gov.pay.ledger.report.params.TransactionSummaryParams;
@@ -10,7 +11,6 @@ import uk.gov.pay.ledger.transaction.service.AccountIdSupplierManager;
 
 import javax.inject.Inject;
 import javax.validation.Valid;
-import javax.validation.ValidationException;
 import javax.ws.rs.BeanParam;
 import javax.ws.rs.DefaultValue;
 import javax.ws.rs.GET;

--- a/src/main/java/uk/gov/pay/ledger/report/service/ReportService.java
+++ b/src/main/java/uk/gov/pay/ledger/report/service/ReportService.java
@@ -2,14 +2,17 @@ package uk.gov.pay.ledger.report.service;
 
 import com.google.inject.Inject;
 import uk.gov.pay.ledger.report.dao.ReportDao;
+import uk.gov.pay.ledger.report.entity.TimeseriesReportSlice;
 import uk.gov.pay.ledger.report.entity.TransactionsStatisticsResult;
 import uk.gov.pay.ledger.report.entity.TransactionSummaryResult;
 import uk.gov.pay.ledger.report.params.TransactionSummaryParams;
 import uk.gov.pay.ledger.transaction.model.TransactionType;
 import uk.gov.pay.ledger.transaction.state.TransactionState;
 
+import java.time.ZonedDateTime;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 public class ReportService {
@@ -36,5 +39,9 @@ public class ReportService {
         TransactionsStatisticsResult payments = reportDao.getTransactionSummaryStatistics(params, TransactionType.PAYMENT);
         TransactionsStatisticsResult refunds = reportDao.getTransactionSummaryStatistics(params, TransactionType.REFUND);
         return new TransactionSummaryResult(payments, refunds, payments.getGrossAmount() - refunds.getGrossAmount());
+    }
+
+    public List<TimeseriesReportSlice> getTransactionsByHour(ZonedDateTime fromDate, ZonedDateTime toDate) {
+        return reportDao.getTransactionsVolumeByTimeseries(fromDate, toDate);
     }
 }

--- a/src/test/java/uk/gov/pay/ledger/report/dao/ReportDaoIT.java
+++ b/src/test/java/uk/gov/pay/ledger/report/dao/ReportDaoIT.java
@@ -442,6 +442,7 @@ public class ReportDaoIT {
 
         assertThat(timeseriesReportSlices.get(0).getTimestamp().getHour(), is(0));
         assertThat(timeseriesReportSlices.get(0).getAllPayments(), is(1));
+        assertThat(timeseriesReportSlices.get(0).getCompletedPayments(), is(1));
 
         assertThat(timeseriesReportSlices.get(1).getTimestamp().getHour(), is(8));
         assertThat(timeseriesReportSlices.get(1).getAmount(), is(2000));
@@ -452,6 +453,9 @@ public class ReportDaoIT {
 
         assertThat(timeseriesReportSlices.get(2).getTimestamp().getHour(), is(9));
         assertThat(timeseriesReportSlices.get(2).getAllPayments(), is(1));
+        assertThat(timeseriesReportSlices.get(2).getCompletedPayments(), is(1));
+        assertThat(timeseriesReportSlices.get(2).getErroredPayments(), is(0));
+        assertThat(timeseriesReportSlices.get(2).getAmount(), is(1000));
 
         assertThat(timeseriesReportSlices.get(3).getTimestamp().getHour(), is(18));
         assertThat(timeseriesReportSlices.get(3).getAllPayments(), is(1));

--- a/src/test/java/uk/gov/pay/ledger/report/dao/ReportDaoIT.java
+++ b/src/test/java/uk/gov/pay/ledger/report/dao/ReportDaoIT.java
@@ -9,7 +9,6 @@ import uk.gov.pay.ledger.report.entity.TimeseriesReportSlice;
 import uk.gov.pay.ledger.report.entity.TransactionsStatisticsResult;
 import uk.gov.pay.ledger.report.params.TransactionSummaryParams;
 import uk.gov.pay.ledger.rule.AppWithPostgresAndSqsRule;
-import uk.gov.pay.ledger.transaction.entity.TransactionEntity;
 import uk.gov.pay.ledger.transaction.model.TransactionType;
 import uk.gov.pay.ledger.transaction.state.TransactionState;
 import uk.gov.pay.ledger.util.DatabaseTestHelper;

--- a/src/test/java/uk/gov/pay/ledger/report/resource/ReportResourceIT.java
+++ b/src/test/java/uk/gov/pay/ledger/report/resource/ReportResourceIT.java
@@ -214,4 +214,24 @@ public class ReportResourceIT {
                 .body("[1].all_payments", is(1))
                 .body("[1].errored_payments", is(1));
     }
+
+    @Test
+    public void shouldRejectTimeseriesReportForTransactionVolumesByHourWithInvalidParams() {
+        aTransactionFixture()
+                .withGatewayAccountId("100")
+                .withTransactionType(TransactionType.PAYMENT.name())
+                .withCreatedDate(ZonedDateTime.parse("2019-09-30T08:10:00.100Z"))
+                .withAmount(1000L)
+                .withState(TransactionState.SUCCESS)
+                .withLive(true)
+                .insert(rule.getJdbi())
+                .toEntity();
+
+        given().port(port)
+                .contentType(JSON)
+                .queryParam("to_date", "2019-09-30T23:59:59.999Z")
+                .get("/v1/report/transactions-by-hour")
+                .then()
+                .statusCode(Response.Status.BAD_REQUEST.getStatusCode());
+    }
 }


### PR DESCRIPTION
Transaction volumes grouped by hour will be used to show payment trends for a single day or comparing multiple days. Transaction volume data is grouped using the `created_date` field.

This end point requires from and to date to be specified - it should potentially limit the consumer to requesting within a one day period for performance reasons.

Future improvements: 
* optionally select data by gateway account or provide the override flag
* limit the consumer from doing huge massive queries

This will then be presented in a graph (rough draft)

<img width="887" alt="Screen Shot 2020-01-02 at 12 04 13" src="https://user-images.githubusercontent.com/2844572/71674718-e84beb80-2d73-11ea-8774-c67ab6ecad6e.png">
