### PR TITLE
PP-5970 CSV endpoint - Refund data mapping

### DIFF
--- a/src/test/java/uk/gov/pay/ledger/util/fixture/TransactionFixture.java
+++ b/src/test/java/uk/gov/pay/ledger/util/fixture/TransactionFixture.java
@@ -67,6 +67,7 @@ public class TransactionFixture implements DbFixture<TransactionFixture, Transac
     private String cardBrandLabel;
     private boolean live;
     private String refundedByUserEmail;
+    private TransactionEntity parentTransactionEntity;
 
     private TransactionFixture() {
     }
@@ -274,6 +275,11 @@ public class TransactionFixture implements DbFixture<TransactionFixture, Transac
         return this;
     }
 
+    public TransactionFixture withParentTransactionEntity(TransactionEntity parentTransactionEntity) {
+        this.parentTransactionEntity = parentTransactionEntity;
+        return this;
+    }
+
     public TransactionFixture withLive(boolean live) {
         this.live = live;
         return this;
@@ -410,6 +416,7 @@ public class TransactionFixture implements DbFixture<TransactionFixture, Transac
                 .withTransactionType(transactionType)
                 .withLive(live)
                 .withGatewayTransactionId(gatewayTransactionId)
+                .withParentTransactionEntity(parentTransactionEntity)
                 .build();
     }
 


### PR DESCRIPTION
## WHAT
- For CSV data and especially for refunds, we need to get payment specific details (payment details, card details and so on) from Payment transaction. This change maps payment attributes to refund record.
- Also for refunds amount is represented in negatives
- Additional tests for refund mapping and CSV data
- Refactored resource test to get CSV fields by header name to make it more readable.

Fixes
- Fixed wallet mapped which is stored as JSON field `wallet` and is returned as titleCase in CSV
- Fixed card_type value - update to return lowercase value
- Fixed total_amount & net_amount as calculated in selfservice