### PR TITLE
PP-5991 Reflect all event ticker query attributes in entity

### DIFF
--- a/src/main/java/uk/gov/pay/ledger/event/dao/EventDao.java
+++ b/src/main/java/uk/gov/pay/ledger/event/dao/EventDao.java
@@ -78,8 +78,8 @@ public interface EventDao {
             " ORDER BY e.event_date ASC")
     List<Event> findEventsForExternalIds(@BindList("externalIds") Set<String> externalIds);
 
-    @SqlQuery("SELECT e.id, e.event_type, t.type, e.resource_external_id, e.event_date, t.card_brand, " +
-            "t.transaction_details->'payment_provider', t.gateway_account_id, t.type " +
+    @SqlQuery("SELECT e.id, e.event_type, e.resource_external_id, e.event_date, t.card_brand, " +
+            "t.transaction_details->'payment_provider' as payment_provider, t.gateway_account_id, t.type " +
             "FROM event e LEFT JOIN transaction t ON e.resource_external_id = t.external_id " +
             "WHERE e.event_date >= :fromDate AND t.live ORDER BY e.event_date DESC")
     List<EventTicker> findEventsTickerFromDate(@Bind("fromDate") ZonedDateTime fromDate);

--- a/src/main/java/uk/gov/pay/ledger/event/dao/mapper/EventTickerMapper.java
+++ b/src/main/java/uk/gov/pay/ledger/event/dao/mapper/EventTickerMapper.java
@@ -19,7 +19,11 @@ public class EventTickerMapper implements RowMapper<EventTicker> {
                 ResourceType.valueOf(resultSet.getString("type").toUpperCase(Locale.UK)),
                 resultSet.getString("resource_external_id"),
                 ZonedDateTime.ofInstant(resultSet.getTimestamp("event_date").toInstant(), ZoneOffset.UTC),
-                resultSet.getString("event_type")
+                resultSet.getString("event_type"),
+                resultSet.getString("card_brand"),
+                resultSet.getString("type"),
+                resultSet.getString("payment_provider"),
+                resultSet.getString("gateway_account_id")
         );
     }
 }

--- a/src/main/java/uk/gov/pay/ledger/event/model/EventTicker.java
+++ b/src/main/java/uk/gov/pay/ledger/event/model/EventTicker.java
@@ -19,21 +19,25 @@ public class EventTicker {
     @JsonSerialize(using = MicrosecondPrecisionDateTimeSerializer.class)
     private ZonedDateTime eventDate;
     private String eventType;
+    private String cardBrand;
+    private String transactionType;
+    private String paymentProvider;
+    private String gatewayAccountId;
+
 
     public EventTicker() { }
 
     public EventTicker(Long id, ResourceType resourceType, String resourceExternalId,
-                       ZonedDateTime eventDate, String eventType) {
+                       ZonedDateTime eventDate, String eventType, String cardBrand, String transactionType, String paymentProvider, String gatewayAccountId) {
         this.id = id;
         this.resourceType = resourceType;
         this.resourceExternalId = resourceExternalId;
         this.eventDate = eventDate;
         this.eventType = eventType;
-    }
-
-    public EventTicker(ResourceType resourceType, String resourceExternalId, ZonedDateTime eventDate,
-                       String eventType) {
-        this(null, resourceType, resourceExternalId, eventDate, eventType);
+        this.cardBrand = cardBrand;
+        this.transactionType = transactionType;
+        this.paymentProvider = paymentProvider;
+        this.gatewayAccountId = gatewayAccountId;
     }
 
     public Long getId() {
@@ -86,5 +90,21 @@ public class EventTicker {
     @Override
     public int hashCode() {
         return Objects.hash(id, resourceType, resourceExternalId, eventDate, eventType);
+    }
+
+    public String getCardBrand() {
+        return cardBrand;
+    }
+
+    public String getTransactionType() {
+        return transactionType;
+    }
+
+    public String getGatewayAccountId() {
+        return gatewayAccountId;
+    }
+
+    public String getPaymentProvider() {
+        return paymentProvider;
     }
 }

--- a/src/test/java/uk/gov/pay/ledger/event/dao/EventDaoIT.java
+++ b/src/test/java/uk/gov/pay/ledger/event/dao/EventDaoIT.java
@@ -224,12 +224,14 @@ public class EventDaoIT {
     public void findEventsTickerFromDate_ShouldGetAllEventsFromDateSpecified() {
         aTransactionFixture()
                 .withExternalId("external-id-1")
+                .withGatewayAccountId("100")
                 .withLive(true)
                 .insert(rule.getJdbi())
                 .toEntity();
 
         Event event1 = anEventFixture()
                 .withResourceExternalId("external-id-1")
+                .withEventType("PAYMENT_CREATED")
                 .insert(rule.getJdbi())
                 .toEntity();
         Event event2 = anEventFixture()
@@ -245,6 +247,9 @@ public class EventDaoIT {
 
         List<EventTicker> eventTickers = eventDao.findEventsTickerFromDate(event1.getEventDate().minusHours(1));
         assertThat(eventTickers.size(), is(1));
+        assertThat(eventTickers.get(0).getGatewayAccountId(), is("100"));
+        assertThat(eventTickers.get(0).getResourceExternalId(), is("external-id-1"));
+        assertThat(eventTickers.get(0).getEventType(), is("PAYMENT_CREATED"));
     }
 
 }


### PR DESCRIPTION
The event ticker query returns a superset of what is actually sent through the entity, add remaining attributes.