### PR TITLE
PP-5970 CSV data - displayName for TransactionState

### DIFF
--- a/src/main/java/uk/gov/pay/ledger/transaction/model/CsvTransactionFactory.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/model/CsvTransactionFactory.java
@@ -9,6 +9,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.pay.ledger.transaction.entity.TransactionEntity;
 import uk.gov.pay.ledger.transaction.state.ExternalTransactionState;
+import uk.gov.pay.ledger.transaction.state.PaymentState;
+import uk.gov.pay.ledger.transaction.state.RefundState;
 
 import java.io.IOException;
 import java.text.DecimalFormat;
@@ -88,6 +90,7 @@ public class CsvTransactionFactory {
                 result.put(FIELD_TOTAL_AMOUNT, penceToCurrency(totalAmount));
                 result.put(FIELD_NET, penceToCurrency(netAmount));
                 result.put(FIELD_FEE, penceToCurrency(transactionEntity.getFee()));
+                result.put(FIELD_STATE, PaymentState.getDisplayName(transactionEntity.getState()));
             }
             if (TransactionType.REFUND.toString().equals(transactionEntity.getTransactionType())) {
                 if (transactionEntity.getParentTransactionEntity() != null) {
@@ -100,6 +103,7 @@ public class CsvTransactionFactory {
                 result.put(FIELD_NET, penceToCurrency(netAmount * -1));
                 result.put(FIELD_TOTAL_AMOUNT, penceToCurrency(totalAmount * -1));
                 result.put(FIELD_ISSUED_BY, safeGetAsString(transactionDetails, "user_email"));
+                result.put(FIELD_STATE, RefundState.getDisplayName(transactionEntity.getState()));
             }
 
             result.put(FIELD_DATE_CREATED, dateCreated);
@@ -110,7 +114,6 @@ public class CsvTransactionFactory {
 
             if (transactionEntity.getState() != null) {
                 ExternalTransactionState state = ExternalTransactionState.from(transactionEntity.getState(), 2);
-                result.put(FIELD_STATE, state.getStatus());
                 result.put(FIELD_FINISHED, state.isFinished());
                 result.put(FIELD_ERROR_CODE, state.getCode());
                 result.put(FIELD_ERROR_MESSAGE, state.getMessage());

--- a/src/main/java/uk/gov/pay/ledger/transaction/state/PaymentState.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/state/PaymentState.java
@@ -1,0 +1,57 @@
+package uk.gov.pay.ledger.transaction.state;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+import java.util.Optional;
+
+import static java.util.Arrays.stream;
+import static java.util.List.of;
+import static uk.gov.pay.ledger.transaction.state.TransactionState.CAPTURABLE;
+import static uk.gov.pay.ledger.transaction.state.TransactionState.CREATED;
+import static uk.gov.pay.ledger.transaction.state.TransactionState.ERROR_GATEWAY;
+import static uk.gov.pay.ledger.transaction.state.TransactionState.FAILED_CANCELLED;
+import static uk.gov.pay.ledger.transaction.state.TransactionState.FAILED_EXPIRED;
+import static uk.gov.pay.ledger.transaction.state.TransactionState.FAILED_REJECTED;
+import static uk.gov.pay.ledger.transaction.state.TransactionState.STARTED;
+import static uk.gov.pay.ledger.transaction.state.TransactionState.SUBMITTED;
+
+public enum PaymentState {
+
+    IN_PROGRESS(of(CREATED, STARTED, SUBMITTED, CAPTURABLE), "In progress"),
+    SUCCESS(of(TransactionState.SUCCESS), "Success"),
+    DECLINED(of(FAILED_REJECTED), "Declined"),
+    TIMED_OUT(of(FAILED_EXPIRED), "Timed out"),
+    CANCELLED(of(FAILED_CANCELLED, TransactionState.CANCELLED), "Cancelled"),
+    ERROR(of(TransactionState.ERROR, ERROR_GATEWAY), "Error");
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(PaymentState.class);
+    private final String displayName;
+    private List<TransactionState> states;
+
+    PaymentState(List<TransactionState> states, String displayName) {
+        this.states = states;
+        this.displayName = displayName;
+    }
+
+    public static PaymentState from(TransactionState transactionState) {
+        return stream(values())
+                .filter(states -> states.getStates().contains(transactionState))
+                .findFirst()
+                .orElseGet(() -> {
+                    LOGGER.warn("Unknown transaction state {}", transactionState);
+                    return null;
+                });
+    }
+
+    public static String getDisplayName(TransactionState transactionState) {
+        return Optional.ofNullable(from(transactionState))
+                .map(paymentState -> paymentState.displayName)
+                .orElse(null);
+    }
+
+    public List<TransactionState> getStates() {
+        return states;
+    }
+}

--- a/src/main/java/uk/gov/pay/ledger/transaction/state/RefundState.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/state/RefundState.java
@@ -1,0 +1,48 @@
+package uk.gov.pay.ledger.transaction.state;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+import java.util.Optional;
+
+import static java.util.Arrays.stream;
+import static java.util.List.of;
+import static uk.gov.pay.ledger.transaction.state.TransactionState.CREATED;
+import static uk.gov.pay.ledger.transaction.state.TransactionState.ERROR_GATEWAY;
+
+public enum RefundState {
+
+    SUBMITTED(of(TransactionState.SUBMITTED, CREATED), "Refund submitted"),
+    SUCCESS(of(TransactionState.SUCCESS), "Refund success"),
+    ERROR(of(TransactionState.ERROR, ERROR_GATEWAY), "Refund error");
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(RefundState.class);
+    private final String displayName;
+    private List<TransactionState> states;
+
+    RefundState(List<TransactionState> states, String displayName) {
+        this.states = states;
+        this.displayName = displayName;
+    }
+
+    public static RefundState from(TransactionState transactionState) {
+        return stream(values())
+                .filter(states -> states.getStates().contains(transactionState))
+                .findFirst()
+                .orElseGet(() -> {
+                    LOGGER.warn("Unknown transaction state {}", transactionState);
+                    return null;
+                });
+    }
+
+    public static String getDisplayName(TransactionState transactionState) {
+        return Optional.ofNullable(from(transactionState))
+                .map(refundState -> refundState.displayName)
+                .orElse(null);
+    }
+
+    public List<TransactionState> getStates() {
+        return states;
+    }
+}

--- a/src/test/java/uk/gov/pay/ledger/transaction/model/CsvTransactionFactoryTest.java
+++ b/src/test/java/uk/gov/pay/ledger/transaction/model/CsvTransactionFactoryTest.java
@@ -59,7 +59,7 @@ public class CsvTransactionFactoryTest {
         assertPaymentDetails(csvDataMap, transactionEntity);
 
         assertThat(csvDataMap.get("Amount"), is("1.00"));
-        assertThat(csvDataMap.get("State"), is("declined"));
+        assertThat(csvDataMap.get("State"), is("Declined"));
         assertThat(csvDataMap.get("Finished"), is(true));
         assertThat(csvDataMap.get("Error Code"), is("P0010"));
         assertThat(csvDataMap.get("Error Message"), is("Payment method rejected"));
@@ -76,6 +76,7 @@ public class CsvTransactionFactoryTest {
         TransactionEntity refundTransactionEntity = transactionFixture.withTransactionType("REFUND")
                 .withAmount(99L)
                 .withTotalAmount(99L)
+                .withState(TransactionState.ERROR)
                 .withParentTransactionEntity(transactionEntity)
                 .withTransactionDetails(new GsonBuilder().create()
                         .toJson(ImmutableMap.builder().put("user_email", "refundedbyuser@example.org").build()))
@@ -85,10 +86,10 @@ public class CsvTransactionFactoryTest {
 
         assertPaymentDetails(csvDataMap, refundTransactionEntity.getParentTransactionEntity());
         assertThat(csvDataMap.get("Amount"), is("-0.99"));
-        assertThat(csvDataMap.get("State"), is("declined"));
+        assertThat(csvDataMap.get("State"), is("Refund error"));
         assertThat(csvDataMap.get("Finished"), is(true));
-        assertThat(csvDataMap.get("Error Code"), is("P0010"));
-        assertThat(csvDataMap.get("Error Message"), is("Payment method rejected"));
+        assertThat(csvDataMap.get("Error Code"), is("P0050"));
+        assertThat(csvDataMap.get("Error Message"), is("Payment provider returned an error"));
         assertThat(csvDataMap.get("Date Created"), is("12 Mar 2018"));
         assertThat(csvDataMap.get("Time Created"), is("16:25:01"));
         assertThat(csvDataMap.get("Corporate Card Surcharge"), is("0.00"));

--- a/src/test/java/uk/gov/pay/ledger/transaction/resource/TransactionResourceIT.java
+++ b/src/test/java/uk/gov/pay/ledger/transaction/resource/TransactionResourceIT.java
@@ -666,7 +666,7 @@ public class TransactionResourceIT {
         CSVRecord paymentRecord = csvRecords.get(0);
         assertPaymentTransactionDetails(paymentRecord, transactionFixture);
         assertThat(paymentRecord.get("Amount"), is("1.23"));
-        assertThat(paymentRecord.get("State"), is("error")); //todo: Map state to displayName as per selfservice and update test
+        assertThat(paymentRecord.get("State"), is("Error"));
         assertThat(paymentRecord.get("Finished"), is("true"));
         assertThat(paymentRecord.get("Error Code"), is("P0050"));
         assertThat(paymentRecord.get("Error Message"), is("Payment provider returned an error"));
@@ -679,7 +679,7 @@ public class TransactionResourceIT {
         CSVRecord refundRecord = csvRecords.get(1);
         assertPaymentTransactionDetails(refundRecord, transactionFixture);
         assertThat(refundRecord.get("Amount"), is("-1.00"));
-        assertThat(refundRecord.get("State"), is("error")); //todo: Map state to displayName as per selfservice and update test
+        assertThat(refundRecord.get("State"), is("Refund error"));
         assertThat(refundRecord.get("Finished"), is("true"));
         assertThat(refundRecord.get("Error Code"), is("P0050"));
         assertThat(refundRecord.get("Error Message"), is("Payment provider returned an error"));
@@ -689,7 +689,6 @@ public class TransactionResourceIT {
         assertThat(refundRecord.get("Total Amount"), is("-1.00"));
         assertThat(refundRecord.get("Wallet Type"), is(""));
         assertThat(refundRecord.get("Issued By"), is("refund-by-user-email@example.org"));
-
     }
 
     @Test


### PR DESCRIPTION
## WHAT
- Currently selfservice derives user friendly name for payment & refunds states for CSV. Introduced the same for ledger CSV data