### PR TITLE
PP-5991 Event ticker include "to_date" for precision

### DIFF
--- a/src/main/java/uk/gov/pay/ledger/event/dao/EventDao.java
+++ b/src/main/java/uk/gov/pay/ledger/event/dao/EventDao.java
@@ -81,6 +81,6 @@ public interface EventDao {
     @SqlQuery("SELECT e.id, e.event_type, e.resource_external_id, e.event_date, t.card_brand, t.amount, " +
             "t.transaction_details->'payment_provider' as payment_provider, t.gateway_account_id, t.type " +
             "FROM event e LEFT JOIN transaction t ON e.resource_external_id = t.external_id " +
-            "WHERE e.event_date >= :fromDate AND t.live ORDER BY e.event_date DESC")
-    List<EventTicker> findEventsTickerFromDate(@Bind("fromDate") ZonedDateTime fromDate);
+            "WHERE (e.event_date between :fromDate AND :toDate) AND t.live ORDER BY e.event_date DESC")
+    List<EventTicker> findEventsTickerFromDate(@Bind("fromDate") ZonedDateTime fromDate, @Bind("toDate") ZonedDateTime toDate);
 }

--- a/src/main/java/uk/gov/pay/ledger/event/resource/EventResource.java
+++ b/src/main/java/uk/gov/pay/ledger/event/resource/EventResource.java
@@ -48,11 +48,11 @@ public class EventResource {
     @Path("/ticker")
     @GET
     @Timed
-    public List<EventTicker> eventTickerList(@QueryParam("from_date") String fromDate) {
-        if(isBlank(fromDate)) {
-            throw new ValidationException("from_date is mandatory to receive event ticker");
+    public List<EventTicker> eventTickerList(@QueryParam("from_date") String fromDate, @QueryParam("to_date") String toDate) {
+        if(isBlank(fromDate) || isBlank(toDate)) {
+            throw new ValidationException("both from_date and to_date are mandatory to receive event ticker");
         }
 
-        return eventDao.findEventsTickerFromDate(ZonedDateTime.parse(fromDate));
+        return eventDao.findEventsTickerFromDate(ZonedDateTime.parse(fromDate), ZonedDateTime.parse(toDate));
     }
 }

--- a/src/test/java/uk/gov/pay/ledger/event/dao/EventDaoIT.java
+++ b/src/test/java/uk/gov/pay/ledger/event/dao/EventDaoIT.java
@@ -246,7 +246,10 @@ public class EventDaoIT {
                 .insert(rule.getJdbi())
                 .toEntity();
 
-        List<EventTicker> eventTickers = eventDao.findEventsTickerFromDate(event1.getEventDate().minusHours(1));
+        List<EventTicker> eventTickers = eventDao.findEventsTickerFromDate(
+                event1.getEventDate().minusHours(1),
+                event1.getEventDate().plusHours(1)
+        );
         assertThat(eventTickers.size(), is(1));
         assertThat(eventTickers.get(0).getGatewayAccountId(), is("100"));
         assertThat(eventTickers.get(0).getResourceExternalId(), is("external-id-1"));

--- a/src/test/java/uk/gov/pay/ledger/event/resource/EventResourceIT.java
+++ b/src/test/java/uk/gov/pay/ledger/event/resource/EventResourceIT.java
@@ -57,9 +57,16 @@ public class EventResourceIT {
                 .insert(rule.getJdbi())
                 .toEntity();
 
+        anEventFixture()
+                .withResourceExternalId("an-external-id")
+                .withEventDate(event.getEventDate().plusHours(1))
+                .insert(rule.getJdbi())
+                .toEntity();
+
         given().port(port)
                 .contentType(JSON)
                 .queryParam("from_date", event.getEventDate().minusMinutes(1).toString())
+                .queryParam("to_date", event.getEventDate().plusMinutes(1).toString())
                 .get("/v1/event/ticker")
                 .then()
                 .statusCode(Response.Status.OK.getStatusCode())


### PR DESCRIPTION
Request for unbound data isn't reliable enough including request latency. Add upper bound `to_date` for increased precision.