### PR TITLE
PP-5993 - DAO Monthly live gateway performance statistics

### DIFF
--- a/src/main/java/uk/gov/pay/ledger/report/dao/ReportDao.java
+++ b/src/main/java/uk/gov/pay/ledger/report/dao/ReportDao.java
@@ -54,6 +54,8 @@ public class ReportDao {
         });
     }
 
+
+
     public TransactionsStatisticsResult getTransactionSummaryStatistics(TransactionSummaryParams params, TransactionType transactionType) {
         return jdbi.withHandle(handle -> {
             String template = createSearchTemplate(params.getFilterTemplates(), TRANSACTION_SUMMARY_STATISTICS);

--- a/src/main/java/uk/gov/pay/ledger/report/entity/GatewayAccountMonthlyPerformanceReportEntity.java
+++ b/src/main/java/uk/gov/pay/ledger/report/entity/GatewayAccountMonthlyPerformanceReportEntity.java
@@ -1,0 +1,55 @@
+package uk.gov.pay.ledger.report.entity;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+import java.math.BigDecimal;
+
+@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+public class GatewayAccountMonthlyPerformanceReportEntity {
+
+    private final long gatewayAccountId;
+    private final long totalVolume;
+    private final BigDecimal totalAmount;
+    private final BigDecimal averageAmount;
+    private final BigDecimal minimumAmount;
+    private final BigDecimal maximumAmount;
+
+    public GatewayAccountMonthlyPerformanceReportEntity(long gatewayAccountId,
+                                                        long totalVolume,
+                                                        BigDecimal totalAmount,
+                                                        BigDecimal averageAmount,
+                                                        BigDecimal minimumAmount,
+                                                        BigDecimal maximumAmount) {
+        this.gatewayAccountId = gatewayAccountId;
+        this.totalVolume = totalVolume;
+        this.totalAmount = totalAmount;
+        this.averageAmount = averageAmount;
+        this.minimumAmount = minimumAmount;
+        this.maximumAmount = maximumAmount;
+    }
+
+    public long getGatewayAccountId() {
+        return gatewayAccountId;
+    }
+
+    public long getTotalVolume() {
+        return totalVolume;
+    }
+
+    public BigDecimal getTotalAmount() {
+        return totalAmount;
+    }
+
+    public BigDecimal getAverageAmount() {
+        return averageAmount;
+    }
+
+    public BigDecimal getMinimumAmount() {
+        return minimumAmount;
+    }
+
+    public BigDecimal getMaximumAmount() {
+        return maximumAmount;
+    }
+}

--- a/src/main/java/uk/gov/pay/ledger/report/mapper/GatewayAccountMonthlyPerformanceReportEntityMapper.java
+++ b/src/main/java/uk/gov/pay/ledger/report/mapper/GatewayAccountMonthlyPerformanceReportEntityMapper.java
@@ -1,0 +1,24 @@
+package uk.gov.pay.ledger.report.mapper;
+
+import org.jdbi.v3.core.mapper.RowMapper;
+import org.jdbi.v3.core.statement.StatementContext;
+import uk.gov.pay.ledger.report.entity.GatewayAccountMonthlyPerformanceReportEntity;
+
+import java.math.BigDecimal;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+public class GatewayAccountMonthlyPerformanceReportEntityMapper implements RowMapper<GatewayAccountMonthlyPerformanceReportEntity> {
+
+    @Override
+    public GatewayAccountMonthlyPerformanceReportEntity map(ResultSet rs, StatementContext ctx) throws SQLException {
+        return new GatewayAccountMonthlyPerformanceReportEntity(
+                rs.getLong("gateway_account_id"),
+                rs.getLong("volume"),
+                new BigDecimal(rs.getString("total_amount")),
+                new BigDecimal(rs.getString("avg_amount")),
+                new BigDecimal(rs.getString("min_amount")),
+                new BigDecimal(rs.getString("max_amount"))
+        );
+    }
+}

--- a/src/main/java/uk/gov/pay/ledger/report/resource/PerformanceReportResource.java
+++ b/src/main/java/uk/gov/pay/ledger/report/resource/PerformanceReportResource.java
@@ -3,6 +3,7 @@ package uk.gov.pay.ledger.report.resource;
 import com.codahale.metrics.annotation.Timed;
 import uk.gov.pay.ledger.exception.ValidationException;
 import uk.gov.pay.ledger.report.dao.PerformanceReportDao;
+import uk.gov.pay.ledger.report.entity.GatewayAccountMonthlyPerformanceReportEntity;
 import uk.gov.pay.ledger.report.entity.PerformanceReportEntity;
 import uk.gov.pay.ledger.report.params.PerformanceReportParams.PerformanceReportParamsBuilder;
 import uk.gov.pay.ledger.transaction.state.TransactionState;
@@ -13,6 +14,7 @@ import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import java.time.ZonedDateTime;
+import java.util.List;
 import java.util.Optional;
 
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
@@ -63,5 +65,17 @@ public class PerformanceReportResource {
             }
         }
         return builder;
+    }
+
+    @Path("/gateway-performance-report")
+    @GET
+    @Timed
+    public List<GatewayAccountMonthlyPerformanceReportEntity> getGatewayMonthlyPerformanceReport(@QueryParam("from_date") String fromDate,
+                                                                                                 @QueryParam("to_date") String toDate) {
+        if (isBlank(fromDate) || isBlank(toDate)) {
+            throw new ValidationException("Both from_date and to_date must be provided");
+        }
+
+        return performanceReportDao.monthlyPerformanceReportForGatewayAccounts(ZonedDateTime.parse(fromDate), ZonedDateTime.parse(toDate));
     }
 }

--- a/src/test/java/uk/gov/pay/ledger/report/dao/PerformanceReportDaoIT.java
+++ b/src/test/java/uk/gov/pay/ledger/report/dao/PerformanceReportDaoIT.java
@@ -1,8 +1,9 @@
 package uk.gov.pay.ledger.report.dao;
 
-import org.junit.After;
+import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
+import uk.gov.pay.ledger.report.entity.GatewayAccountMonthlyPerformanceReportEntity;
 import uk.gov.pay.ledger.report.params.PerformanceReportParams.PerformanceReportParamsBuilder;
 import uk.gov.pay.ledger.rule.AppWithPostgresAndSqsRule;
 import uk.gov.pay.ledger.transaction.state.TransactionState;
@@ -25,13 +26,14 @@ public class PerformanceReportDaoIT {
     @ClassRule
     public static AppWithPostgresAndSqsRule rule = new AppWithPostgresAndSqsRule();
 
-    private PerformanceReportDao transactionDao = new PerformanceReportDao(rule.getJdbi());
-
     private DatabaseTestHelper databaseTestHelper = aDatabaseTestHelper(rule.getJdbi());
 
-    @After
-    public void tearDown() {
+    private PerformanceReportDao transactionDao;
+
+    @Before
+    public void setUp() {
         databaseTestHelper.truncateAllData();
+        transactionDao = new PerformanceReportDao(rule.getJdbi());
     }
 
     @Test
@@ -105,5 +107,70 @@ public class PerformanceReportDaoIT {
         assertThat(performanceReportEntity.getTotalVolume(), is(3L));
         assertThat(performanceReportEntity.getTotalAmount(), is(closeTo(new BigDecimal(3000L), ZERO)));
         assertThat(performanceReportEntity.getAverageAmount(), is(closeTo(new BigDecimal(1000L), ZERO)));
+    }
+
+    @Test
+    public void verifyMonthlyGatewayPerformanceReportTest() {
+        aTransactionFixture()
+                .withGatewayAccountId("1")
+                .withAmount(1000L)
+                .withState(TransactionState.STARTED)
+                .withTransactionType("PAYMENT")
+                .withLive(true)
+                .withCreatedDate(ZonedDateTime.parse("2019-01-01T02:00:00Z"))
+                .insert(rule.getJdbi());
+
+        aTransactionFixture()
+                .withGatewayAccountId("1")
+                .withAmount(1000L)
+                .withState(TransactionState.SUCCESS)
+                .withTransactionType("REFUND")
+                .withLive(true)
+                .withCreatedDate(ZonedDateTime.parse("2019-01-01T02:00:00Z"))
+                .insert(rule.getJdbi());
+
+        aTransactionFixture()
+                .withGatewayAccountId("1")
+                .withAmount(1000L)
+                .withState(TransactionState.SUCCESS)
+                .withTransactionType("PAYMENT")
+                .withLive(true)
+                .withCreatedDate(ZonedDateTime.parse("2018-01-01T02:00:00Z"))
+                .insert(rule.getJdbi());
+
+        List<String> relevantGatewayAccounts = List.of("1", "2");
+        relevantGatewayAccounts.stream().forEach(account -> aTransactionFixture()
+                .withGatewayAccountId(account)
+                .withAmount(1000L)
+                .withState(TransactionState.SUCCESS)
+                .withTransactionType("PAYMENT")
+                .withLive(true)
+                .withCreatedDate(ZonedDateTime.parse("2019-01-01T02:00:00Z"))
+                .insert(rule.getJdbi()));
+
+        BigDecimal expectedValue = BigDecimal.valueOf(1000);
+        ZonedDateTime startDate = ZonedDateTime.parse("2019-01-01T00:00:00Z");
+        ZonedDateTime endDate = ZonedDateTime.parse("2019-02-01T00:00:00Z");
+
+        List<GatewayAccountMonthlyPerformanceReportEntity> performanceReport = transactionDao.monthlyPerformanceReportForGatewayAccounts(startDate, endDate);
+
+        GatewayAccountMonthlyPerformanceReportEntity gatewayAccountOnePerformanceReport = performanceReport.get(0);
+        GatewayAccountMonthlyPerformanceReportEntity gatewayAccountTwoPerformanceReport = performanceReport.get(1);
+
+        assertThat(performanceReport.size(), is(2));
+
+        assertThat(gatewayAccountOnePerformanceReport.getGatewayAccountId(), is(1L));
+        assertThat(gatewayAccountOnePerformanceReport.getTotalVolume(), is(1L));
+        assertThat(gatewayAccountOnePerformanceReport.getTotalAmount(), is(closeTo(expectedValue, ZERO)));
+        assertThat(gatewayAccountOnePerformanceReport.getAverageAmount(), is(closeTo(expectedValue, ZERO)));
+        assertThat(gatewayAccountOnePerformanceReport.getMinimumAmount(), is(closeTo(expectedValue, ZERO)));
+        assertThat(gatewayAccountOnePerformanceReport.getMaximumAmount(), is(closeTo(expectedValue, ZERO)));
+
+        assertThat(gatewayAccountTwoPerformanceReport.getGatewayAccountId(), is(2L));
+        assertThat(gatewayAccountOnePerformanceReport.getTotalVolume(), is(1L));
+        assertThat(gatewayAccountOnePerformanceReport.getTotalAmount(), is(closeTo(expectedValue, ZERO)));
+        assertThat(gatewayAccountOnePerformanceReport.getAverageAmount(), is(closeTo(expectedValue, ZERO)));
+        assertThat(gatewayAccountOnePerformanceReport.getMinimumAmount(), is(closeTo(expectedValue, ZERO)));
+        assertThat(gatewayAccountOnePerformanceReport.getMaximumAmount(), is(closeTo(expectedValue, ZERO)));
     }
 }


### PR DESCRIPTION
Description:
- Queries the Transaction database instead of Connector returns gateway_account_id,  average amount, total amount and total volume per gateway account given a start and end date
- PerformanceReportDAO is  called directly in the controller.

This is similar to [https://github.com/alphagov/pay-ledger/pull/493/files](#493 ) and could possibly be included in this endpoint but for the time being I have made it separate.