### PR TITLE
[BAU] update getTransactions method to use gatewayAccountId

### DIFF
--- a/src/main/java/uk/gov/pay/ledger/transaction/dao/TransactionDao.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/dao/TransactionDao.java
@@ -18,7 +18,8 @@ import java.util.stream.Collectors;
 public class TransactionDao {
 
     private static final String FIND_TRANSACTION_BY_EXTERNAL_ID = "SELECT * FROM transaction " +
-            "WHERE external_id = :externalId";
+            "WHERE external_id = :externalId " +
+            "AND (:gatewayAccountId is NULL OR gateway_account_id = :gatewayAccountId)";
 
     private static final String FIND_TRANSACTION_BY_EXTERNAL_ID_AND_GATEWAY_ACCOUNT_ID = "SELECT * FROM transaction " +
             "WHERE external_id = :externalId " +
@@ -176,9 +177,14 @@ public class TransactionDao {
     }
 
     public Optional<TransactionEntity> findTransactionByExternalId(String externalId) {
+        return findTransactionByExternalIdAndGatewayAccountId(externalId, null);
+    }
+
+    public Optional<TransactionEntity> findTransactionByExternalIdAndGatewayAccountId(String externalId, String gatewayAccountId) {
         return jdbi.withHandle(handle ->
                 handle.createQuery(FIND_TRANSACTION_BY_EXTERNAL_ID)
                         .bind("externalId", externalId)
+                        .bind("gatewayAccountId", gatewayAccountId)
                         .map(new TransactionMapper())
                         .findFirst());
     }

--- a/src/main/java/uk/gov/pay/ledger/transaction/service/TransactionService.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/service/TransactionService.java
@@ -72,7 +72,7 @@ public class TransactionService {
     }
 
     public TransactionsForTransactionResponse getTransactions(String parentTransactionExternalId, String gatewayAccountId) {
-        return transactionDao.findTransactionByExternalId(parentTransactionExternalId)
+        return transactionDao.findTransactionByExternalIdAndGatewayAccountId(parentTransactionExternalId, gatewayAccountId)
                 .map(transactionEntity ->
                         findTransactionsForParentExternalId(
                                 transactionEntity.getExternalId(),

--- a/src/test/java/uk/gov/pay/ledger/pact/CaptureSubmittedEventQueueContractTest.java
+++ b/src/test/java/uk/gov/pay/ledger/pact/CaptureSubmittedEventQueueContractTest.java
@@ -8,6 +8,7 @@ import au.com.dius.pact.model.v3.messaging.MessagePact;
 import com.google.gson.Gson;
 import org.junit.Rule;
 import org.junit.Test;
+import uk.gov.pay.ledger.event.model.SalientEventType;
 import uk.gov.pay.ledger.rule.AppWithPostgresAndSqsRule;
 import uk.gov.pay.ledger.rule.SqsTestDocker;
 import uk.gov.pay.ledger.transaction.dao.TransactionDao;
@@ -47,7 +48,8 @@ public class CaptureSubmittedEventQueueContractTest {
                 .withResourceExternalId(externalId)
                 .withEventDate(eventDate)
                 .withGatewayAccountId(gatewayAccountId)
-                .withDefaultEventDataForEventType("CAPTURE_SUBMITTED");
+                .withEventType(SalientEventType.CAPTURE_SUBMITTED.toString())
+                .withDefaultEventDataForEventType(SalientEventType.CAPTURE_SUBMITTED.toString());
 
         Map<String, String> metadata = new HashMap<String, String>();
         metadata.put("contentType", "application/json");

--- a/src/test/java/uk/gov/pay/ledger/pact/PaymentCreatedEventQueueContractTest.java
+++ b/src/test/java/uk/gov/pay/ledger/pact/PaymentCreatedEventQueueContractTest.java
@@ -66,10 +66,10 @@ public class PaymentCreatedEventQueueContractTest {
         EventDao eventDao = appRule.getJdbi().onDemand(EventDao.class);
 
         await().atMost(1, TimeUnit.SECONDS).until(
-                () -> transactionDao.findTransactionByExternalId(externalId).isPresent()
+                () -> transactionDao.findTransactionByExternalIdAndGatewayAccountId(externalId, gatewayAccountId).isPresent()
         );
 
-        Optional<TransactionEntity> transaction = transactionDao.findTransactionByExternalId(externalId);
+        Optional<TransactionEntity> transaction = transactionDao.findTransactionByExternalIdAndGatewayAccountId(externalId, gatewayAccountId);
         assertThat(transaction.isPresent(), is(true));
         assertThat(transaction.get().getExternalId(), is(externalId));
         assertThat(transaction.get().getAmount(), is(1000L));

--- a/src/test/java/uk/gov/pay/ledger/transaction/dao/TransactionDaoIT.java
+++ b/src/test/java/uk/gov/pay/ledger/transaction/dao/TransactionDaoIT.java
@@ -43,34 +43,55 @@ public class TransactionDaoIT {
 
         TransactionEntity retrievedTransaction = transactionDao.findTransactionByExternalId(transactionEntity.getExternalId()).get();
 
-        assertThat(retrievedTransaction.getId(), notNullValue());
-        assertThat(retrievedTransaction.getGatewayAccountId(), is(transactionEntity.getGatewayAccountId()));
-        assertThat(retrievedTransaction.getExternalId(), is(transactionEntity.getExternalId()));
-        assertThat(retrievedTransaction.getAmount(), is(transactionEntity.getAmount()));
-        assertThat(retrievedTransaction.getReference(), is(transactionEntity.getReference()));
-        assertThat(retrievedTransaction.getDescription(), is(transactionEntity.getDescription()));
-        assertThat(retrievedTransaction.getState(), is(transactionEntity.getState()));
-        assertThat(retrievedTransaction.getEmail(), is(transactionEntity.getEmail()));
-        assertThat(retrievedTransaction.getCardholderName(), is(transactionEntity.getCardholderName()));
-        assertThat(retrievedTransaction.getTransactionDetails(), containsString("\"external_metadata\": {\"key1\": \"value1\", \"anotherKey\": {\"nestedKey\": \"value\"}}"));
-        assertThat(retrievedTransaction.getCreatedDate(), is(transactionEntity.getCreatedDate()));
-        assertThat(retrievedTransaction.getTransactionDetails().contains(fixture.getLanguage()), is(true));
-        assertThat(retrievedTransaction.getTransactionDetails().contains(fixture.getReturnUrl()), is(true));
-        assertThat(retrievedTransaction.getTransactionDetails().contains(fixture.getPaymentProvider()), is(true));
-        assertThat(retrievedTransaction.getTransactionDetails().contains(fixture.getCardDetails().getBillingAddress().getAddressLine1()), is(true));
-        assertThat(retrievedTransaction.getEventCount(), is(transactionEntity.getEventCount()));
-        assertThat(retrievedTransaction.getCardBrand(), is(transactionEntity.getCardBrand()));
-        assertThat(retrievedTransaction.getLastDigitsCardNumber(), is(transactionEntity.getLastDigitsCardNumber()));
-        assertThat(retrievedTransaction.getFirstDigitsCardNumber(), is(transactionEntity.getFirstDigitsCardNumber()));
+        assertTransactionEntity(retrievedTransaction, fixture);
         assertThat(retrievedTransaction.getNetAmount(), is(transactionEntity.getNetAmount()));
         assertThat(retrievedTransaction.getTotalAmount(), is(transactionEntity.getTotalAmount()));
         assertThat(retrievedTransaction.getFee(), is(transactionEntity.getFee()));
-        assertThat(retrievedTransaction.getTransactionType(), is(transactionEntity.getTransactionType()));
-        assertThat(retrievedTransaction.getRefundAmountAvailable(), is(transactionEntity.getRefundAmountAvailable()));
-        assertThat(retrievedTransaction.getRefundAmountRefunded(), is(transactionEntity.getRefundAmountRefunded()));
-        assertThat(retrievedTransaction.getRefundStatus(), is(transactionEntity.getRefundStatus()));
-        assertThat(retrievedTransaction.getGatewayTransactionId(), is(transactionEntity.getGatewayTransactionId()));
         assertThat(retrievedTransaction.isLive(), is(true));
+    }
+
+    @Test
+    public void shouldRetrieveTransactionByExternalIdAndGatewayAccount() {
+        TransactionFixture fixture = aTransactionFixture()
+                .withDefaultCardDetails()
+                .withExternalMetadata(ImmutableMap.of("key1", "value1", "anotherKey", ImmutableMap.of("nestedKey", "value")))
+                .withDefaultTransactionDetails()
+                .insert(rule.getJdbi());
+
+        TransactionEntity retrievedTransaction = transactionDao.findTransactionByExternalIdAndGatewayAccountId(
+                fixture.getExternalId(), fixture.getGatewayAccountId()).get();
+
+        assertTransactionEntity(retrievedTransaction, fixture);
+        assertThat(retrievedTransaction.getFee(), is(nullValue()));
+        assertThat(retrievedTransaction.getTotalAmount(), is(nullValue()));
+        assertThat(retrievedTransaction.getNetAmount(), is(nullValue()));
+    }
+
+    private void assertTransactionEntity(TransactionEntity transaction, TransactionFixture fixture) {
+        assertThat(transaction.getId(), notNullValue());
+        assertThat(transaction.getGatewayAccountId(), is(fixture.getGatewayAccountId()));
+        assertThat(transaction.getExternalId(), is(fixture.getExternalId()));
+        assertThat(transaction.getAmount(), is(fixture.getAmount()));
+        assertThat(transaction.getReference(), is(fixture.getReference()));
+        assertThat(transaction.getDescription(), is(fixture.getDescription()));
+        assertThat(transaction.getState(), is(fixture.getState()));
+        assertThat(transaction.getEmail(), is(fixture.getEmail()));
+        assertThat(transaction.getCardholderName(), is(fixture.getCardholderName()));
+        assertThat(transaction.getTransactionDetails(), containsString("\"external_metadata\": {\"key1\": \"value1\", \"anotherKey\": {\"nestedKey\": \"value\"}}"));
+        assertThat(transaction.getCreatedDate(), is(fixture.getCreatedDate()));
+        assertThat(transaction.getTransactionDetails().contains(fixture.getLanguage()), is(true));
+        assertThat(transaction.getTransactionDetails().contains(fixture.getReturnUrl()), is(true));
+        assertThat(transaction.getTransactionDetails().contains(fixture.getPaymentProvider()), is(true));
+        assertThat(transaction.getTransactionDetails().contains(fixture.getCardDetails().getBillingAddress().getAddressLine1()), is(true));
+        assertThat(transaction.getEventCount(), is(fixture.getEventCount()));
+        assertThat(transaction.getCardBrand(), is(fixture.getCardBrand()));
+        assertThat(transaction.getLastDigitsCardNumber(), is(fixture.getLastDigitsCardNumber()));
+        assertThat(transaction.getFirstDigitsCardNumber(), is(fixture.getFirstDigitsCardNumber()));
+        assertThat(transaction.getTransactionType(), is(fixture.getTransactionType()));
+        assertThat(transaction.getRefundAmountAvailable(), is(fixture.getRefundAmountAvailable()));
+        assertThat(transaction.getRefundAmountRefunded(), is(fixture.getRefundAmountRefunded()));
+        assertThat(transaction.getRefundStatus(), is(fixture.getRefundStatus()));
+        assertThat(transaction.getGatewayTransactionId(), is(fixture.getGatewayTransactionId()));
     }
 
     @Test
@@ -81,38 +102,16 @@ public class TransactionDaoIT {
                 .withExternalMetadata(ImmutableMap.of("key1", "value1", "anotherKey", ImmutableMap.of("nestedKey", "value")))
                 .withDefaultTransactionDetails()
                 .insert(rule.getJdbi());
-        TransactionEntity transactionEntity = fixture.toEntity();
 
         TransactionEntity transaction = transactionDao
                 .findTransaction(
-                        transactionEntity.getExternalId(),
-                        transactionEntity.getGatewayAccountId(),
+                        fixture.getExternalId(),
+                        fixture.getGatewayAccountId(),
                         TransactionType.PAYMENT, null).get();
 
-        assertThat(transaction.getId(), notNullValue());
-        assertThat(transaction.getGatewayAccountId(), is(transactionEntity.getGatewayAccountId()));
-        assertThat(transaction.getExternalId(), is(transactionEntity.getExternalId()));
-        assertThat(transaction.getAmount(), is(transactionEntity.getAmount()));
-        assertThat(transaction.getReference(), is(transactionEntity.getReference()));
-        assertThat(transaction.getDescription(), is(transactionEntity.getDescription()));
-        assertThat(transaction.getState(), is(transactionEntity.getState()));
-        assertThat(transaction.getEmail(), is(transactionEntity.getEmail()));
-        assertThat(transaction.getCardholderName(), is(transactionEntity.getCardholderName()));
-        assertThat(transaction.getTransactionDetails(), containsString("\"external_metadata\": {\"key1\": \"value1\", \"anotherKey\": {\"nestedKey\": \"value\"}}"));
-        assertThat(transaction.getCreatedDate(), is(transactionEntity.getCreatedDate()));
-        assertThat(transaction.getTransactionDetails().contains(fixture.getLanguage()), is(true));
-        assertThat(transaction.getTransactionDetails().contains(fixture.getReturnUrl()), is(true));
-        assertThat(transaction.getTransactionDetails().contains(fixture.getPaymentProvider()), is(true));
-        assertThat(transaction.getTransactionDetails().contains(fixture.getCardDetails().getBillingAddress().getAddressLine1()), is(true));
-        assertThat(transaction.getEventCount(), is(transactionEntity.getEventCount()));
-        assertThat(transaction.getCardBrand(), is(transactionEntity.getCardBrand()));
-        assertThat(transaction.getLastDigitsCardNumber(), is(transactionEntity.getLastDigitsCardNumber()));
-        assertThat(transaction.getFirstDigitsCardNumber(), is(transactionEntity.getFirstDigitsCardNumber()));
-        assertThat(transaction.getTransactionType(), is(transactionEntity.getTransactionType()));
+        assertTransactionEntity(transaction, fixture);
         assertThat(transaction.getFee(), is(nullValue()));
         assertThat(transaction.getTotalAmount(), is(nullValue()));
-        assertThat(transaction.getRefundAmountAvailable(), is(transactionEntity.getRefundAmountAvailable()));
-        assertThat(transaction.getRefundAmountRefunded(), is(transactionEntity.getRefundAmountRefunded()));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/ledger/transaction/resource/TransactionResourceIT.java
+++ b/src/test/java/uk/gov/pay/ledger/transaction/resource/TransactionResourceIT.java
@@ -590,6 +590,7 @@ public class TransactionResourceIT {
     public void getTransactionsForTransactionShouldReturnEmptyListIfParentTransactionHasNoTransactions() {
         transactionFixture = aTransactionFixture()
                 .withTransactionType("PAYMENT")
+                .withGatewayAccountId("1")
                 .withDefaultCardDetails()
                 .withDefaultTransactionDetails();
         transactionFixture.insert(rule.getJdbi());

--- a/src/test/java/uk/gov/pay/ledger/util/fixture/TransactionFixture.java
+++ b/src/test/java/uk/gov/pay/ledger/util/fixture/TransactionFixture.java
@@ -538,4 +538,24 @@ public class TransactionFixture implements DbFixture<TransactionFixture, Transac
         this.refundedByUserEmail = refundedByUserEmail;
         return this;
     }
+
+    public String getTransactionType() {
+        return transactionType;
+    }
+
+    public Long getRefundAmountAvailable() {
+        return refundAmountAvailable;
+    }
+
+    public Long getRefundAmountRefunded() {
+        return refundAmountRefunded;
+    }
+
+    public String getRefundStatus() {
+        return refundStatus;
+    }
+
+    public String getGatewayTransactionId() {
+        return gatewayTransactionId;
+    }
 }


### PR DESCRIPTION
Why?
We're passing the gatewayAccountId from resource to the method, but we're actually not using
it at all.

Changes:
* update DAO method to use gatewayAccountId when retrieving transactions
* update getTransactions method in TransactionService to pass gatewayAccount id to DAO method
* new unit test
* update to relevant tests