### PR TITLE
[BAU] Fix some style issues

### DIFF
--- a/src/main/java/uk/gov/pay/ledger/event/model/ResourceType.java
+++ b/src/main/java/uk/gov/pay/ledger/event/model/ResourceType.java
@@ -12,5 +12,5 @@ public enum ResourceType {
     @JsonProperty(value = "service")
     SERVICE,
     @JsonProperty(value = "card_payment")
-    CARD_PAYMENT;
+    CARD_PAYMENT
 }

--- a/src/main/java/uk/gov/pay/ledger/exception/JerseyViolationExceptionMapper.java
+++ b/src/main/java/uk/gov/pay/ledger/exception/JerseyViolationExceptionMapper.java
@@ -5,6 +5,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.pay.commons.model.ErrorIdentifier;
 
+import javax.validation.ConstraintViolation;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.ext.ExceptionMapper;
 import java.util.stream.Collectors;
@@ -15,12 +16,12 @@ import static org.eclipse.jetty.http.HttpStatus.UNPROCESSABLE_ENTITY_422;
 public class JerseyViolationExceptionMapper implements ExceptionMapper<JerseyViolationException> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(JerseyViolationExceptionMapper.class);
-    
+
     @Override
     public Response toResponse(JerseyViolationException exception) {
         LOGGER.error(exception.getConstraintViolations().iterator().next().getMessage());
         ErrorResponse errorResponse = new ErrorResponse(ErrorIdentifier.GENERIC,
-                exception.getConstraintViolations().stream().map(x -> x.getMessage()).collect(Collectors.toList()));
+                exception.getConstraintViolations().stream().map(ConstraintViolation::getMessage).collect(Collectors.toList()));
         return Response.status(UNPROCESSABLE_ENTITY_422).entity(errorResponse).type(APPLICATION_JSON).build();
     }
 }

--- a/src/main/java/uk/gov/pay/ledger/filters/LoggingMDCRequestFilter.java
+++ b/src/main/java/uk/gov/pay/ledger/filters/LoggingMDCRequestFilter.java
@@ -15,7 +15,7 @@ public class LoggingMDCRequestFilter implements ContainerRequestFilter {
     public static final String TRANSACTION_EXTERNAL_ID = "transaction_external_id";
 
     @Override
-    public void filter(ContainerRequestContext requestContext) throws IOException {
+    public void filter(ContainerRequestContext requestContext) {
         getPathParameterFromRequest("eventId", requestContext)
                 .ifPresent(eventId -> MDC.put(LEDGER_EVENT_ID, eventId));
 

--- a/src/main/java/uk/gov/pay/ledger/filters/LoggingMDCResponseFilter.java
+++ b/src/main/java/uk/gov/pay/ledger/filters/LoggingMDCResponseFilter.java
@@ -5,7 +5,6 @@ import org.slf4j.MDC;
 import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.container.ContainerResponseContext;
 import javax.ws.rs.container.ContainerResponseFilter;
-import java.io.IOException;
 import java.util.List;
 
 import static uk.gov.pay.ledger.filters.LoggingMDCRequestFilter.PARENT_TRANSACTION_EXTERNAL_ID;
@@ -15,7 +14,7 @@ import static uk.gov.pay.logging.LoggingKeys.LEDGER_EVENT_ID;
 public class LoggingMDCResponseFilter implements ContainerResponseFilter {
 
     @Override
-    public void filter(ContainerRequestContext containerRequestContext, ContainerResponseContext containerResponseContext) throws IOException {
+    public void filter(ContainerRequestContext containerRequestContext, ContainerResponseContext containerResponseContext) {
         List.of(LEDGER_EVENT_ID, TRANSACTION_EXTERNAL_ID, PARENT_TRANSACTION_EXTERNAL_ID).forEach(MDC::remove);
     }
 }

--- a/src/main/java/uk/gov/pay/ledger/healthcheck/SQSHealthCheck.java
+++ b/src/main/java/uk/gov/pay/ledger/healthcheck/SQSHealthCheck.java
@@ -33,14 +33,12 @@ public class SQSHealthCheck extends HealthCheck {
     }
 
     @Override
-    protected Result check() throws Exception {
+    protected Result check() {
         Optional<String> result = checkQueue(sqsHealthCheckHolder);
 
-        if (result.isPresent()) {
-            return Result.unhealthy(format("Failed %s queue attribute check: %s", sqsHealthCheckHolder.getName(), result.get()));
-        }
-
-        return Result.healthy();
+        return result
+                .map(s -> Result.unhealthy(format("Failed %s queue attribute check: %s", sqsHealthCheckHolder.getName(), s)))
+                .orElseGet(Result::healthy);
     }
 
     private Optional<String> checkQueue(NameValuePair nameValuePair) {

--- a/src/main/java/uk/gov/pay/ledger/report/dao/PerformanceReportDao.java
+++ b/src/main/java/uk/gov/pay/ledger/report/dao/PerformanceReportDao.java
@@ -59,7 +59,7 @@ public class PerformanceReportDao {
                 query.bind("startDate", dateRange.getFromDate());
                 query.bind("toDate", dateRange.getToDate());
             });
-            return query.map(new PerformanceReportEntityMapper()).findOnly();
+            return query.map(new PerformanceReportEntityMapper()).one();
         });
     }
 

--- a/src/main/java/uk/gov/pay/ledger/report/dao/ReportDao.java
+++ b/src/main/java/uk/gov/pay/ledger/report/dao/ReportDao.java
@@ -69,7 +69,7 @@ public class ReportDao {
                 long count = rs.getLong("count");
                 long grossAmount = rs.getLong("grossAmount");
                 return new TransactionsStatisticsResult(count, grossAmount);
-            }).findOnly();
+            }).one();
         });
     }
 

--- a/src/main/java/uk/gov/pay/ledger/transaction/dao/TransactionDao.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/dao/TransactionDao.java
@@ -227,7 +227,7 @@ public class TransactionDao {
             searchParams.getQueryMap().forEach(bindSearchParameter(query));
             return query
                     .mapTo(Long.class)
-                    .findOnly();
+                    .one();
         });
     }
 
@@ -250,7 +250,7 @@ public class TransactionDao {
             searchParams.getQueryMap().forEach(bindSearchParameter(query));
             return query
                     .mapTo(Long.class)
-                    .findOnly();
+                    .one();
         });
     }
 

--- a/src/main/java/uk/gov/pay/ledger/transaction/search/common/CommaDelimitedSetParameter.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/search/common/CommaDelimitedSetParameter.java
@@ -16,8 +16,8 @@ public class CommaDelimitedSetParameter {
                 : List.of(queryString.split(","));
     }
 
-    public boolean isEmpty() {
-        return elements.isEmpty();
+    public boolean isNotEmpty() {
+        return !elements.isEmpty();
     }
 
     public String getRawString() {

--- a/src/main/java/uk/gov/pay/ledger/transaction/search/common/TransactionSearchParams.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/search/common/TransactionSearchParams.java
@@ -172,7 +172,7 @@ public class TransactionSearchParams {
         if (isNotBlank(cardHolderName)) {
             filters.add(" lower(t.cardholder_name) LIKE lower(:" + CARDHOLDER_NAME_FIELD + ")");
         }
-        if (cardBrands != null && !cardBrands.isEmpty()) {
+        if (cardBrands != null && cardBrands.isNotEmpty()) {
             filters.add(" t.card_brand IN (<" + CARD_BRAND_FIELD + ">)");
         }
         if (isNotBlank(lastDigitsCardNumber)) {
@@ -199,7 +199,7 @@ public class TransactionSearchParams {
             filters.add(" (t.last_digits_card_number = :" + LAST_DIGITS_CARD_NUMBER_FIELD +
                     " or parent.last_digits_card_number = :" + LAST_DIGITS_CARD_NUMBER_FIELD + ")");
         }
-        if (cardBrands != null && !cardBrands.isEmpty()) {
+        if (cardBrands != null && cardBrands.isNotEmpty()) {
             filters.add(" (lower(t.card_brand) IN (<" + CARD_BRAND_FIELD + ">)" +
                     " or lower(parent.card_brand) IN (<" + CARD_BRAND_FIELD + ">))");
         }
@@ -277,7 +277,7 @@ public class TransactionSearchParams {
                                 .map(TransactionState::name)
                                 .collect(Collectors.toList()));
             }
-            if (cardBrands != null && !cardBrands.isEmpty()) {
+            if (cardBrands != null && cardBrands.isNotEmpty()) {
                 queryMap.put(CARD_BRAND_FIELD, cardBrands.getParameters());
             }
             if (isSet(paymentStates)) {
@@ -372,10 +372,10 @@ public class TransactionSearchParams {
         if (isSet(paymentStates)) {
             queries.add(PAYMENT_STATES_FIELD + "=" + paymentStates.getRawString());
         }
-        if (refundStates != null && !refundStates.isEmpty()) {
+        if (refundStates != null && refundStates.isNotEmpty()) {
             queries.add(REFUND_STATES_FIELD + "=" + refundStates.getRawString());
         }
-        if (cardBrands != null && !cardBrands.isEmpty()) {
+        if (cardBrands != null && cardBrands.isNotEmpty()) {
             queries.add(CARD_BRAND_FIELD + "=" + cardBrands.getRawString());
         }
         if (isNotBlank(state)) {
@@ -433,7 +433,7 @@ public class TransactionSearchParams {
     }
 
     private boolean isSet(CommaDelimitedSetParameter commaDelimitedSetParameter) {
-        return commaDelimitedSetParameter != null && !commaDelimitedSetParameter.isEmpty();
+        return commaDelimitedSetParameter != null && commaDelimitedSetParameter.isNotEmpty();
     }
 
     public TransactionSearchParams setExactReferenceMatch(boolean exactReferenceMatch) {

--- a/src/main/java/uk/gov/pay/ledger/transaction/search/model/SettlementSummary.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/search/model/SettlementSummary.java
@@ -21,7 +21,7 @@ public class SettlementSummary {
     @JsonProperty("capture_submit_time")
     public Optional<String> getSettlementSubmittedTime() {
         return Optional.ofNullable(settlementSubmittedTime)
-                .map(t -> ISO_INSTANT_MILLISECOND_PRECISION.format(t));
+                .map(ISO_INSTANT_MILLISECOND_PRECISION::format);
     }
 
     @JsonProperty("captured_date")

--- a/src/main/java/uk/gov/pay/ledger/util/JsonParser.java
+++ b/src/main/java/uk/gov/pay/ledger/util/JsonParser.java
@@ -3,6 +3,7 @@ package uk.gov.pay.ledger.util;
 import com.fasterxml.jackson.databind.JsonNode;
 
 import java.time.ZonedDateTime;
+import java.util.Objects;
 import java.util.Optional;
 
 public class JsonParser {
@@ -37,6 +38,6 @@ public class JsonParser {
 
     private static Optional<JsonNode> safeGetJsonElement(JsonNode object, String fieldName) {
         return Optional.ofNullable(object.get(fieldName))
-                .filter(p -> p != null);
+                .filter(Objects::nonNull);
     }
 }

--- a/src/main/java/uk/gov/pay/ledger/util/csv/CSVMessageBodyWriter.java
+++ b/src/main/java/uk/gov/pay/ledger/util/csv/CSVMessageBodyWriter.java
@@ -7,7 +7,6 @@ import com.fasterxml.jackson.dataformat.csv.CsvMapper;
 import com.fasterxml.jackson.dataformat.csv.CsvSchema;
 
 import javax.ws.rs.Produces;
-import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.ext.MessageBodyWriter;
@@ -47,7 +46,7 @@ public class CSVMessageBodyWriter implements MessageBodyWriter<List> {
 
                 CsvSchema.Builder builder = CsvSchema.builder();
                 Map<String, Object> headerRow = (Map<String, Object>) data.get(data.size() - 1); // get last record which is header
-                headerRow.keySet().forEach(columnName -> builder.addColumn(columnName));
+                headerRow.keySet().forEach(builder::addColumn);
 
                 CsvSchema schema = builder.build().withoutHeader(); // without header to avoid writing header for each line
                 data.remove(data.size() - 1);

--- a/src/test/java/uk/gov/pay/ledger/event/dao/EventDaoIT.java
+++ b/src/test/java/uk/gov/pay/ledger/event/dao/EventDaoIT.java
@@ -62,7 +62,7 @@ public class EventDaoIT {
         assertThat(result.get("resource_external_id"), is(event.getResourceExternalId()));
         assertThat(result.get("parent_resource_external_id"), is(event.getParentResourceExternalId()));
         assertThat((Timestamp) result.get("event_date"), isDate(CREATED_AT));
-        assertThat(result.get("event_type").toString(), is(event.getEventType().toString()));
+        assertThat(result.get("event_type").toString(), is(event.getEventType()));
         assertThat(objectMapper.readTree(result.get("event_data").toString()), is(objectMapper.readTree(event.getEventData())));
     }
 
@@ -82,7 +82,7 @@ public class EventDaoIT {
         assertThat(result.get("resource_type_id"), is(resourceTypeId));
         assertThat(result.get("resource_external_id"), is(event.getResourceExternalId()));
         assertThat((Timestamp) result.get("event_date"), isDate(CREATED_AT));
-        assertThat(result.get("event_type").toString(), is(event.getEventType().toString()));
+        assertThat(result.get("event_type").toString(), is(event.getEventType()));
         assertThat(objectMapper.readTree(result.get("event_data").toString()), is(objectMapper.readTree(event.getEventData())));
     }
 
@@ -131,7 +131,7 @@ public class EventDaoIT {
         assertThat(result.get("resource_type_id"), is(resourceTypeId));
         assertThat(result.get("resource_external_id"), is(event.getResourceExternalId()));
         assertThat((Timestamp) result.get("event_date"), isDate(event.getEventDate()));
-        assertThat(result.get("event_type").toString(), is(event.getEventType().toString()));
+        assertThat(result.get("event_type").toString(), is(event.getEventType()));
         assertThat(objectMapper.readTree(result.get("event_data").toString()), is(objectMapper.readTree(event.getEventData())));
     }
 
@@ -148,7 +148,7 @@ public class EventDaoIT {
         assertThat(retrievedEvent.getResourceExternalId(), is(event.getResourceExternalId()));
         assertThat(retrievedEvent.getResourceType().name(), is(event.getResourceType().name()));
         assertThat(retrievedEvent.getSqsMessageId(), is(event.getSqsMessageId()));
-        assertThat(retrievedEvent.getEventType().toString(), is(event.getEventType().toString()));
+        assertThat(retrievedEvent.getEventType(), is(event.getEventType()));
         assertThat(retrievedEvent.getEventDate(), is(event.getEventDate()));
         assertThat(retrievedEvent.getEventData(), is(event.getEventData()));
     }

--- a/src/test/java/uk/gov/pay/ledger/event/model/TransactionEntityFactoryTest.java
+++ b/src/test/java/uk/gov/pay/ledger/event/model/TransactionEntityFactoryTest.java
@@ -72,7 +72,7 @@ public class TransactionEntityFactoryTest {
         assertThat(transactionEntity.isLive(), is(true));
 
 
-        JsonObject transactionDetails = new JsonParser().parse(transactionEntity.getTransactionDetails()).getAsJsonObject();
+        JsonObject transactionDetails = JsonParser.parseString(transactionEntity.getTransactionDetails()).getAsJsonObject();
         assertThat(transactionDetails.get("language").getAsString(), is("en"));
         assertThat(transactionDetails.get("payment_provider").getAsString(), is("sandbox"));
         assertThat(transactionDetails.get("expiry_date").getAsString(), is("11/21"));

--- a/src/test/java/uk/gov/pay/ledger/event/resource/EventResourceIT.java
+++ b/src/test/java/uk/gov/pay/ledger/event/resource/EventResourceIT.java
@@ -34,7 +34,7 @@ public class EventResourceIT {
                 .body("resource_external_id", is(event.getResourceExternalId()))
                 .body("resource_type", is(event.getResourceType().name().toLowerCase()))
                 .body("sqs_message_id", is(event.getSqsMessageId()))
-                .body("event_type", is(event.getEventType().toString()))
+                .body("event_type", is(event.getEventType()))
                 .body("event_data", is(event.getEventData()));
     }
 

--- a/src/test/java/uk/gov/pay/ledger/pact/CaptureConfirmedEventQueueContractTest.java
+++ b/src/test/java/uk/gov/pay/ledger/pact/CaptureConfirmedEventQueueContractTest.java
@@ -67,7 +67,7 @@ public class CaptureConfirmedEventQueueContractTest {
 
     @Test
     @PactVerification({"connector"})
-    public void test() throws Exception {
+    public void test() {
         appRule.getSqsClient().sendMessage(SqsTestDocker.getQueueUrl("event-queue"), new String(currentMessage));
 
         TransactionDao transactionDao = new TransactionDao(appRule.getJdbi());

--- a/src/test/java/uk/gov/pay/ledger/pact/CaptureSubmittedEventQueueContractTest.java
+++ b/src/test/java/uk/gov/pay/ledger/pact/CaptureSubmittedEventQueueContractTest.java
@@ -62,7 +62,7 @@ public class CaptureSubmittedEventQueueContractTest {
 
     @Test
     @PactVerification({"connector"})
-    public void test() throws Exception {
+    public void test() {
         appRule.getSqsClient().sendMessage(SqsTestDocker.getQueueUrl("event-queue"), new String(currentMessage));
 
         TransactionDao transactionDao = new TransactionDao(appRule.getJdbi());

--- a/src/test/java/uk/gov/pay/ledger/pact/PaymentCreatedEventQueueContractTest.java
+++ b/src/test/java/uk/gov/pay/ledger/pact/PaymentCreatedEventQueueContractTest.java
@@ -59,7 +59,7 @@ public class PaymentCreatedEventQueueContractTest {
 
     @Test
     @PactVerification({"connector"})
-    public void test() throws Exception {
+    public void test() {
         appRule.getSqsClient().sendMessage(SqsTestDocker.getQueueUrl("event-queue"), new String(currentMessage));
 
         TransactionDao transactionDao = new TransactionDao(appRule.getJdbi());

--- a/src/test/java/uk/gov/pay/ledger/pact/PaymentDetailsEnteredEventQueueContractTest.java
+++ b/src/test/java/uk/gov/pay/ledger/pact/PaymentDetailsEnteredEventQueueContractTest.java
@@ -61,7 +61,7 @@ public class PaymentDetailsEnteredEventQueueContractTest {
 
     @Test
     @PactVerification({"connector"})
-    public void test() throws Exception {
+    public void test() {
         TransactionDao transactionDao = new TransactionDao(appRule.getJdbi());
         setupTransaction(transactionDao);
 

--- a/src/test/java/uk/gov/pay/ledger/pact/PaymentNotificationCreatedEventQueueContractTest.java
+++ b/src/test/java/uk/gov/pay/ledger/pact/PaymentNotificationCreatedEventQueueContractTest.java
@@ -62,7 +62,7 @@ public class PaymentNotificationCreatedEventQueueContractTest {
 
     @Test
     @PactVerification({"connector"})
-    public void test() throws Exception {
+    public void test() {
         appRule.getSqsClient().sendMessage(SqsTestDocker.getQueueUrl("event-queue"), new String(currentMessage));
 
         TransactionDao transactionDao = new TransactionDao(appRule.getJdbi());

--- a/src/test/java/uk/gov/pay/ledger/pact/RefundCreatedByUserEventQueueContractTest.java
+++ b/src/test/java/uk/gov/pay/ledger/pact/RefundCreatedByUserEventQueueContractTest.java
@@ -68,7 +68,7 @@ public class RefundCreatedByUserEventQueueContractTest {
 
     @Test
     @PactVerification({"connector"})
-    public void test() throws Exception {
+    public void test() {
         aTransactionFixture()  // adds parent payment transaction for refund to be inserted
                 .withExternalId(refundFixture.getParentResourceExternalId())
                 .withTransactionType("PAYMENT")

--- a/src/test/java/uk/gov/pay/ledger/report/dao/PerformanceReportDaoIT.java
+++ b/src/test/java/uk/gov/pay/ledger/report/dao/PerformanceReportDaoIT.java
@@ -76,7 +76,7 @@ public class PerformanceReportDaoIT {
                 .withLive(false).insert(rule.getJdbi());
 
         List<Long> relevantAmounts = List.of(1200L, 1020L, 750L);
-        relevantAmounts.stream().forEach(amount -> aTransactionFixture()
+        relevantAmounts.forEach(amount -> aTransactionFixture()
                 .withAmount(amount)
                 .withState(TransactionState.SUCCESS)
                 .withTransactionType("PAYMENT")
@@ -139,7 +139,7 @@ public class PerformanceReportDaoIT {
                 .insert(rule.getJdbi());
 
         List<String> relevantGatewayAccounts = List.of("1", "2");
-        relevantGatewayAccounts.stream().forEach(account -> aTransactionFixture()
+        relevantGatewayAccounts.forEach(account -> aTransactionFixture()
                 .withGatewayAccountId(account)
                 .withAmount(1000L)
                 .withState(TransactionState.SUCCESS)

--- a/src/test/java/uk/gov/pay/ledger/util/DatabaseTestHelper.java
+++ b/src/test/java/uk/gov/pay/ledger/util/DatabaseTestHelper.java
@@ -44,7 +44,7 @@ public class DatabaseTestHelper {
                         .createQuery("SELECT COUNT(*) FROM event WHERE resource_external_id = :external_id")
                         .bind("external_id", externalId)
                         .mapTo(Integer.class)
-                        .findOnly()
+                        .one()
         );
     }
 

--- a/src/test/java/uk/gov/pay/ledger/util/fixture/EventFixture.java
+++ b/src/test/java/uk/gov/pay/ledger/util/fixture/EventFixture.java
@@ -136,7 +136,7 @@ public class EventFixture implements DbFixture<EventFixture, Event> {
         resourceExternalId = event.getResourceExternalId();
         parentResourceExternalId = event.getParentResourceExternalId();
         eventDate = event.getEventDate();
-        eventType = event.getEventType().toString();
+        eventType = event.getEventType();
         eventData = event.getEventData();
         return this;
     }

--- a/src/test/java/uk/gov/pay/ledger/util/fixture/QueueEventFixtureUtil.java
+++ b/src/test/java/uk/gov/pay/ledger/util/fixture/QueueEventFixtureUtil.java
@@ -47,7 +47,7 @@ public class QueueEventFixtureUtil {
             eventDetails.stringType("parent_resource_external_id", parentResourceExternalId);
         }
 
-        PactDslJsonBody eventDetailsPact = getNestedPact(new JsonParser().parse(eventData).getAsJsonObject());
+        PactDslJsonBody eventDetailsPact = getNestedPact(JsonParser.parseString(eventData).getAsJsonObject());
 
         eventDetails.object("event_details", eventDetailsPact);
 

--- a/src/test/java/uk/gov/pay/ledger/util/fixture/TransactionFixture.java
+++ b/src/test/java/uk/gov/pay/ledger/util/fixture/TransactionFixture.java
@@ -181,7 +181,7 @@ public class TransactionFixture implements DbFixture<TransactionFixture, Transac
     }
 
     public TransactionFixture withExternalMetadata(String externalMetadata) {
-        this.externalMetadata = new JsonParser().parse(externalMetadata);
+        this.externalMetadata = JsonParser.parseString(externalMetadata);
         return this;
     }
 


### PR DESCRIPTION
Changes:
* replace deprecated ResultIterable.findOnly with ResultIterable.one
* replace deprecated instantiating of JsonParser and parse method with static
  JsonParser.parseString
* remove unnecessary semicolon
* updated healthcheck code in functional style
* inverse the isEmpty method (it's always being used with negation - should
improve readability)
* remove redundant 'throws' clause
* simplify stream API call chain (PerformanceReportDaoIT)
* replace lambda with method reference
* remove redundant 'toString' call