### PR TITLE
PP-5993-Add-date-validation-to-route

### DIFF
--- a/src/main/java/uk/gov/pay/ledger/report/resource/PerformanceReportResource.java
+++ b/src/main/java/uk/gov/pay/ledger/report/resource/PerformanceReportResource.java
@@ -73,6 +73,8 @@ public class PerformanceReportResource {
                                                                                                  @QueryParam("to_date") String toDate) {
         if (isBlank(fromDate) || isBlank(toDate)) {
             throw new ValidationException("Both from_date and to_date must be provided");
+        } else if (ZonedDateTime.parse(fromDate).isAfter(ZonedDateTime.parse(toDate))) {
+            throw new ValidationException("from_date must be earlier or equal to to_date");
         }
 
         return performanceReportDao.monthlyPerformanceReportForGatewayAccounts(ZonedDateTime.parse(fromDate), ZonedDateTime.parse(toDate));

--- a/src/test/java/uk/gov/pay/ledger/report/resource/PerformanceReportResourceIT.java
+++ b/src/test/java/uk/gov/pay/ledger/report/resource/PerformanceReportResourceIT.java
@@ -206,4 +206,18 @@ public class PerformanceReportResourceIT {
                         .body("message", contains("Both from_date and to_date must be provided"))
                         .body("error_identifier", Matchers.is(ErrorIdentifier.GENERIC.toString())));
     }
+
+    @Test
+    public void should_return_400_when_from_date_is_later_than_to_date_for_gateway_performance_report() {
+
+        given().port(port)
+                .contentType(JSON)
+                .queryParam( "from_date", "2019-11-30T00:00:00Z")
+                .queryParam( "to_date", "2017-11-30T00:00:00Z")
+                .get("/v1/report/gateway-performance-report")
+                .then()
+                .statusCode(Response.Status.BAD_REQUEST.getStatusCode())
+                .body("message", contains("from_date must be earlier or equal to to_date"))
+                .body("error_identifier", Matchers.is(ErrorIdentifier.GENERIC.toString()));
+    }
 }


### PR DESCRIPTION
Description:
- This ensures that a validation error is thrown if the from_date is later than the to_date for the provided query params.