### PR TITLE
PP-6013 Add Source Column To Transaction Table

### DIFF
--- a/src/main/resources/migrations/00032_add_source_to_transaction_table.sql
+++ b/src/main/resources/migrations/00032_add_source_to_transaction_table.sql
@@ -1,0 +1,7 @@
+--liquibase formatted sql
+
+--changeset uk.gov.pay:add_source_to_transaction_table
+CREATE type source as enum ('CARD_API', 'CARD_PAYMENT_LINK', 'CARD_EXTERNAL_TELEPHONE');
+
+ALTER TABLE transaction
+    ADD COLUMN source source;


### PR DESCRIPTION
- Adds the source column, which is an enum of all possible supported
values, to the transaction table

Co-authored-by: Alex Bishop <alexbishop1@users.noreply.github.com>