### PR TITLE
PP-6013 Store Source in Transaction Column

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
         <jackson.version>2.10.2</jackson.version>
         <testcontainers.version>1.12.4</testcontainers.version>
         <postgresql.version>42.2.9</postgresql.version>
-        <pay-java-commons.version>1.0.20200107160358</pay-java-commons.version>
+        <pay-java-commons.version>1.0.20200114170822</pay-java-commons.version>
         <surefire.version>3.0.0-M3</surefire.version>
         <guice.version>4.2.2</guice.version>
         <rest-assured.version>4.1.2</rest-assured.version>

--- a/src/main/java/uk/gov/pay/ledger/transaction/dao/TransactionDao.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/dao/TransactionDao.java
@@ -102,7 +102,8 @@ public class TransactionDao {
                     "refund_amount_refunded, " +
                     "refund_status, " +
                     "live, " +
-                    "gateway_transaction_id" +
+                    "gateway_transaction_id, " +
+                    "source" +
                     ") " +
                     "VALUES (" +
                     ":externalId," +
@@ -128,7 +129,8 @@ public class TransactionDao {
                     ":refundAmountRefunded," +
                     ":refundStatus," +
                     ":live, " +
-                    ":gatewayTransactionId" +
+                    ":gatewayTransactionId, " +
+                    ":source::source" +
             ") " +
             "ON CONFLICT (external_id) " +
             "DO UPDATE SET " +
@@ -155,7 +157,8 @@ public class TransactionDao {
                 "refund_amount_refunded = EXCLUDED.refund_amount_refunded, " +
                 "refund_status = EXCLUDED.refund_status, " +
                 "live = EXCLUDED.live, " +
-                "gateway_transaction_id = EXCLUDED.gateway_transaction_id " +
+                "gateway_transaction_id = EXCLUDED.gateway_transaction_id, " +
+                "source = EXCLUDED.source " +
                 "WHERE EXCLUDED.event_count >= transaction.event_count;";
 
     private final Jdbi jdbi;

--- a/src/main/java/uk/gov/pay/ledger/transaction/dao/mapper/TransactionMapper.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/dao/mapper/TransactionMapper.java
@@ -2,6 +2,7 @@ package uk.gov.pay.ledger.transaction.dao.mapper;
 
 import org.jdbi.v3.core.mapper.RowMapper;
 import org.jdbi.v3.core.statement.StatementContext;
+import uk.gov.pay.commons.model.Source;
 import uk.gov.pay.ledger.transaction.entity.TransactionEntity;
 import uk.gov.pay.ledger.transaction.state.TransactionState;
 
@@ -16,7 +17,7 @@ public class TransactionMapper implements RowMapper<TransactionEntity> {
 
     @Override
     public TransactionEntity map(ResultSet rs, StatementContext ctx) throws SQLException {
-        return new TransactionEntity.Builder()
+        var builder = new TransactionEntity.Builder()
                 .withId(rs.getLong("id"))
                 .withGatewayAccountId(rs.getString("gateway_account_id"))
                 .withExternalId(rs.getString("external_id"))
@@ -41,8 +42,9 @@ public class TransactionMapper implements RowMapper<TransactionEntity> {
                 .withFee(getLongWithNullCheck(rs, "fee"))
                 .withTransactionType(rs.getString("type"))
                 .withLive(rs.getBoolean("live"))
-                .withGatewayTransactionId(rs.getString("gateway_transaction_id"))
-                .build();
+                .withGatewayTransactionId(rs.getString("gateway_transaction_id"));
+        Source.from(rs.getString("source")).ifPresent(builder::withSource);
+        return builder.build();
     }
 
     private Long getLongWithNullCheck(ResultSet rs, String columnName) throws SQLException {

--- a/src/main/java/uk/gov/pay/ledger/transaction/entity/TransactionEntity.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/entity/TransactionEntity.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import uk.gov.pay.commons.model.Source;
 import uk.gov.pay.ledger.transaction.state.TransactionState;
 
 import java.time.ZonedDateTime;
@@ -44,6 +45,7 @@ public class TransactionEntity {
     private boolean live;
     private TransactionEntity parentTransactionEntity;
     private String gatewayTransactionId;
+    private Source source;
 
     public TransactionEntity() {
     }
@@ -75,6 +77,7 @@ public class TransactionEntity {
         this.parentTransactionEntity = builder.parentTransactionEntity;
         this.live = builder.live;
         this.gatewayTransactionId = builder.gatewayTransactionId;
+        this.source = builder.source;
     }
 
     public Long getId() {
@@ -209,6 +212,10 @@ public class TransactionEntity {
         return gatewayTransactionId;
     }
 
+    public Source getSource() {
+        return source;
+    }
+
     public static class Builder {
         private Long fee;
         private Long id;
@@ -235,7 +242,8 @@ public class TransactionEntity {
         private String transactionType;
         private boolean live;
         private TransactionEntity parentTransactionEntity;
-        public String gatewayTransactionId;
+        private Source source;
+        private String gatewayTransactionId;
 
         public Builder() {
         }
@@ -371,6 +379,11 @@ public class TransactionEntity {
 
         public Builder withGatewayTransactionId(String gatewayTransactionId) {
             this.gatewayTransactionId = gatewayTransactionId;
+            return this;
+        }
+
+        public Builder withSource(Source source) {
+            this.source = source;
             return this;
         }
     }

--- a/src/test/java/uk/gov/pay/ledger/transaction/dao/TransactionDaoIT.java
+++ b/src/test/java/uk/gov/pay/ledger/transaction/dao/TransactionDaoIT.java
@@ -3,6 +3,7 @@ package uk.gov.pay.ledger.transaction.dao;
 import com.google.common.collect.ImmutableMap;
 import org.junit.ClassRule;
 import org.junit.Test;
+import uk.gov.pay.commons.model.Source;
 import uk.gov.pay.ledger.rule.AppWithPostgresAndSqsRule;
 import uk.gov.pay.ledger.transaction.entity.TransactionEntity;
 import uk.gov.pay.ledger.transaction.model.TransactionType;
@@ -48,6 +49,25 @@ public class TransactionDaoIT {
         assertThat(retrievedTransaction.getTotalAmount(), is(transactionEntity.getTotalAmount()));
         assertThat(retrievedTransaction.getFee(), is(transactionEntity.getFee()));
         assertThat(retrievedTransaction.isLive(), is(true));
+    }
+
+    @Test
+    public void shouldInsertTransactionWithSourceCardApi() {
+        TransactionFixture fixture = aTransactionFixture()
+                .withDefaultCardDetails()
+                .withNetAmount(55)
+                .withTotalAmount(55)
+                .withTransactionType("PAYMENT")
+                .withLive(true)
+                .withSource(Source.CARD_API.toString())
+                .withDefaultTransactionDetails();
+        TransactionEntity transactionEntity = fixture.toEntity();
+
+        transactionDao.upsert(transactionEntity);
+
+        TransactionEntity retrievedTransaction = transactionDao.findTransactionByExternalId(transactionEntity.getExternalId()).get();
+
+        assertThat(retrievedTransaction.getSource(), is(Source.CARD_API));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/ledger/util/fixture/QueuePaymentEventFixture.java
+++ b/src/test/java/uk/gov/pay/ledger/util/fixture/QueuePaymentEventFixture.java
@@ -7,10 +7,13 @@ import com.google.gson.GsonBuilder;
 import com.google.gson.JsonObject;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.StringUtils;
+import uk.gov.pay.commons.model.Source;
 import uk.gov.pay.ledger.event.model.Event;
 import uk.gov.pay.ledger.event.model.ResourceType;
 
 import java.time.ZonedDateTime;
+
+import static uk.gov.pay.commons.model.Source.CARD_API;
 
 public class QueuePaymentEventFixture implements QueueFixture<QueuePaymentEventFixture, Event> {
     private String sqsMessageId;
@@ -21,6 +24,7 @@ public class QueuePaymentEventFixture implements QueueFixture<QueuePaymentEventF
     private String eventType = "PAYMENT_CREATED";
     private String eventData = "{\"event_data\": \"event data\"}";
     private String gatewayAccountId = RandomStringUtils.randomAlphanumeric(5);
+    private Source source;
 
     private QueuePaymentEventFixture() {
     }
@@ -64,6 +68,11 @@ public class QueuePaymentEventFixture implements QueueFixture<QueuePaymentEventF
         return this;
     }
 
+    public QueuePaymentEventFixture withSource(Source source) {
+        this.source = source;
+        return this;
+    }
+
     public QueuePaymentEventFixture withDefaultEventDataForEventType(String eventType) {
         switch (eventType) {
             case "PAYMENT_CREATED":
@@ -87,6 +96,7 @@ public class QueuePaymentEventFixture implements QueueFixture<QueuePaymentEventF
                                 .put("address_line1", "12 Rouge Avenue")
                                 .put("address_postcode", "N1 3QU")
                                 .put("address_city", "London")
+                                .put("source", CARD_API)
                                 .put("address_country", "GB")
                                 .build());
                 break;


### PR DESCRIPTION
- When a TransactionEntity is serialised to the database, the source
value is stored in the source column within the transaction column

- When a TransactionEntity is deserialised from the the TransactionDao
reading the database, the source column's value is correctly read

- Tests are updated, TransactionDaoIT and TransactionEntityFactoryTest
to ensure this behaviour is as expected