### PR TITLE
PP-5920 update RDS CA Cert to 2019

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ ENV LANG C.UTF-8
 RUN echo networkaddress.cache.ttl=$DNS_TTL >> "$JAVA_HOME/conf/security/java.security"
 
 # Add RDS CA certificates to the default truststore
-RUN wget -qO - https://s3.amazonaws.com/rds-downloads/rds-ca-2015-root.pem       | keytool -importcert -noprompt -cacerts -storepass changeit -alias rds-ca-2015-root \
+RUN wget -qO - https://s3.amazonaws.com/rds-downloads/rds-ca-2019-root.pem       | keytool -importcert -noprompt -cacerts -storepass changeit -alias rds-ca-2019-root \
  && wget -qO - https://s3.amazonaws.com/rds-downloads/rds-combined-ca-bundle.pem | keytool -importcert -noprompt -cacerts -storepass changeit -alias rds-combined-ca-bundle
 
 RUN ["apk", "add", "--no-cache", "bash"]


### PR DESCRIPTION
WHAT YOU DID
Updated the the root CA certificate in the container build in preparation for updating the certs installed on the RDS instances.

The combined cert bundle URL does not need to be updated as the URL has not changed, but the updated bundle will be downloaded at build time.

https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.SSL.html

How to test
Rebuild containers and deploy to test environment
Ensure app works with NEW CA root cert but OLD RDS certs. The new ca certs must be backward compatible.
Schedule the cert update on the RDS instance.

See similar PR for connector
https://github.com/alphagov/pay-connector/pull/2026