### PR TITLE
Merge pull request #525 from alphagov/PP-6013-add-test-for-source-enum-db-type

### DIFF
--- a/src/main/java/uk/gov/pay/ledger/transaction/dao/TransactionDao.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/dao/TransactionDao.java
@@ -131,35 +131,45 @@ public class TransactionDao {
                     ":live, " +
                     ":gatewayTransactionId, " +
                     ":source::source" +
-            ") " +
-            "ON CONFLICT (external_id) " +
-            "DO UPDATE SET " +
-                "external_id = EXCLUDED.external_id," +
-                "parent_external_id = EXCLUDED.parent_external_id," +
-                "gateway_account_id = EXCLUDED.gateway_account_id," +
-                "amount = EXCLUDED.amount," +
-                "description = EXCLUDED.description," +
-                "reference = EXCLUDED.reference," +
-                "state = EXCLUDED.state," +
-                "email = EXCLUDED.email," +
-                "cardholder_name = EXCLUDED.cardholder_name," +
-                "created_date = EXCLUDED.created_date," +
-                "transaction_details = EXCLUDED.transaction_details," +
-                "event_count = EXCLUDED.event_count," +
-                "card_brand = EXCLUDED.card_brand," +
-                "last_digits_card_number = EXCLUDED.last_digits_card_number," +
-                "first_digits_card_number = EXCLUDED.first_digits_card_number," +
-                "net_amount = EXCLUDED.net_amount," +
-                "total_amount = EXCLUDED.total_amount," +
-                "fee = EXCLUDED.fee," +
-                "type = EXCLUDED.type, " +
-                "refund_amount_available = EXCLUDED.refund_amount_available, " +
-                "refund_amount_refunded = EXCLUDED.refund_amount_refunded, " +
-                "refund_status = EXCLUDED.refund_status, " +
-                "live = EXCLUDED.live, " +
-                "gateway_transaction_id = EXCLUDED.gateway_transaction_id, " +
-                "source = EXCLUDED.source " +
-                "WHERE EXCLUDED.event_count >= transaction.event_count;";
+                    ") " +
+                    "ON CONFLICT (external_id) " +
+                    "DO UPDATE SET " +
+                    "external_id = EXCLUDED.external_id," +
+                    "parent_external_id = EXCLUDED.parent_external_id," +
+                    "gateway_account_id = EXCLUDED.gateway_account_id," +
+                    "amount = EXCLUDED.amount," +
+                    "description = EXCLUDED.description," +
+                    "reference = EXCLUDED.reference," +
+                    "state = EXCLUDED.state," +
+                    "email = EXCLUDED.email," +
+                    "cardholder_name = EXCLUDED.cardholder_name," +
+                    "created_date = EXCLUDED.created_date," +
+                    "transaction_details = EXCLUDED.transaction_details," +
+                    "event_count = EXCLUDED.event_count," +
+                    "card_brand = EXCLUDED.card_brand," +
+                    "last_digits_card_number = EXCLUDED.last_digits_card_number," +
+                    "first_digits_card_number = EXCLUDED.first_digits_card_number," +
+                    "net_amount = EXCLUDED.net_amount," +
+                    "total_amount = EXCLUDED.total_amount," +
+                    "fee = EXCLUDED.fee," +
+                    "type = EXCLUDED.type, " +
+                    "refund_amount_available = EXCLUDED.refund_amount_available, " +
+                    "refund_amount_refunded = EXCLUDED.refund_amount_refunded, " +
+                    "refund_status = EXCLUDED.refund_status, " +
+                    "live = EXCLUDED.live, " +
+                    "gateway_transaction_id = EXCLUDED.gateway_transaction_id, " +
+                    "source = EXCLUDED.source " +
+                    "WHERE EXCLUDED.event_count >= transaction.event_count;";
+
+    private static final String GET_SOURCE_TYPE_ENUM_VALUES =
+            "SELECT " +
+                    "pg_enum.enumlabel " +
+                    "FROM " +
+                    "pg_type " +
+                    "JOIN " +
+                    "pg_enum ON pg_enum.enumtypid = pg_type.oid " +
+                    "WHERE pg_type.typname = 'source';";
+
 
     private final Jdbi jdbi;
 
@@ -284,7 +294,13 @@ public class TransactionDao {
     public void upsert(TransactionEntity transaction) {
         jdbi.withHandle(handle ->
                 handle.createUpdate(UPSERT_STRING)
-                .bindBean(transaction)
-                .execute());
+                        .bindBean(transaction)
+                        .execute());
+    }
+
+    public List<String> getSourceTypeValues() {
+        return jdbi.withHandle(handle -> handle.createQuery(GET_SOURCE_TYPE_ENUM_VALUES)
+                .mapTo(String.class)
+                .collect(Collectors.toList()));
     }
 }

--- a/src/test/java/uk/gov/pay/ledger/transaction/dao/TransactionDaoIT.java
+++ b/src/test/java/uk/gov/pay/ledger/transaction/dao/TransactionDaoIT.java
@@ -10,13 +10,18 @@ import uk.gov.pay.ledger.transaction.model.TransactionType;
 import uk.gov.pay.ledger.transaction.state.TransactionState;
 import uk.gov.pay.ledger.util.fixture.TransactionFixture;
 
+import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.hasItems;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static uk.gov.pay.ledger.util.fixture.TransactionFixture.aTransactionFixture;
 
 public class TransactionDaoIT {
@@ -279,5 +284,11 @@ public class TransactionDaoIT {
 
         assertThat(transactionEntity.getId(), is(transactionWithParentExternalId.getId()));
 
+    }
+
+    @Test
+    public void sourceTypeInDatabase_shouldMatchValuesInEnum() {
+        var sourceArray = Arrays.stream(Source.values()).map(Enum::toString).collect(Collectors.toList());
+        transactionDao.getSourceTypeValues().forEach(x -> assertThat(sourceArray.contains(x), is(true)));
     }
 }


### PR DESCRIPTION
- There is a type in the database which contains all the values of the
current enum Source from pay-java-commons, if a mismatch between this
types were to occur this would be problematic

- This test will catch any mismatches between the types in the database
and the types in the Source enum

- Also includes a reformat to match code conventions regarding DB query string styling across ledger