### PR TITLE
PP-6013 Ensure Enum Modifications Exist In DB

### DIFF
--- a/src/test/java/uk/gov/pay/ledger/transaction/dao/TransactionDaoIT.java
+++ b/src/test/java/uk/gov/pay/ledger/transaction/dao/TransactionDaoIT.java
@@ -290,5 +290,6 @@ public class TransactionDaoIT {
     public void sourceTypeInDatabase_shouldMatchValuesInEnum() {
         var sourceArray = Arrays.stream(Source.values()).map(Enum::toString).collect(Collectors.toList());
         transactionDao.getSourceTypeValues().forEach(x -> assertThat(sourceArray.contains(x), is(true)));
+        sourceArray.forEach(x -> assertThat(transactionDao.getSourceTypeValues().contains(x), is(true)));
     }
 }


### PR DESCRIPTION
- When the Source enum is modified, the test will ensure that there is
parity between the different values and those that exist for the DB
type.