### PR TITLE
PP-6029 Add java buildpack manifest

### DIFF
--- a/dev.yml
+++ b/dev.yml
@@ -1,0 +1,12 @@
+memory: 500M
+db_password: mysecretpassword
+db_user: ledger
+db_name: ledger
+db_ssl_option: ssl=none
+disk_quota: 500M
+disable_internal_https: 'true'
+run_migration: 'true'
+aws_access_key: x
+aws_secret_key: x
+
+

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,0 +1,47 @@
+---
+applications:
+  - name: ledger
+    buildpacks:
+      - java_buildpack
+    path: target/pay-ledger-0.1-SNAPSHOT-allinone.jar
+    health-check-type: http
+    health-check-http-endpoint: '/healthcheck'
+    health-check-invocation-timeout: 5
+    memory: ((memory))
+    disk_quota: ((disk_quota))
+    env:
+      ADMIN_PORT: '10701'
+      DISABLE_INTERNAL_HTTPS: ((disable_internal_https))
+      ENVIRONMENT: ((space))
+      JAVA_OPTS: -Xms512m -Xmx1G
+      JBP_CONFIG_JAVA_MAIN: '{ arguments: "server /home/vcap/app/config/config.yaml" }'
+      JBP_CONFIG_OPEN_JDK_JRE: '{ jre: { version: 11.+ } }'
+      JPA_LOG_LEVEL: 'INFO'
+      JPA_SQL_LOG_LEVEL: 'INFO'
+
+      # Provide via ledger-db service
+      DB_HOST: postgres-((space)).apps.internal
+      DB_NAME: ((db_name))
+      DB_PASSWORD: ((db_password))
+      DB_USER: ((db_user))
+      DB_SSL_OPTION: ((db_ssl_option))
+
+      AWS_XRAY_CONTEXT_MISSING: LOG_ERROR
+
+      # Provide via aws-sqs service
+      AWS_ACCESS_KEY: ((aws_access_key))
+      AWS_SECRET_KEY: ((aws_secret_key))
+      AWS_SQS_ENDPOINT: http://sqs-((space)).apps.internal:9324
+      AWS_SQS_MESSAGE_MAXIMUM_WAIT_TIME_IN_SECONDS: '20'
+      QUEUE_MESSAGE_RECEIVER_THREAD_DELAY_IN_MILLISECONDS: '1000'
+      AWS_SQS_NON_STANDARD_SERVICE_ENDPOINT: 'true'
+      AWS_SQS_PAYMENT_EVENT_QUEUE_URL: http://sqs-((space)).apps.internal:9324/queue/pay_event_queue
+      AWS_SQS_REGION: region-1
+
+      # Provide via Sentry service
+      SENTRY_DSN: noop://localhost
+
+      RUN_APP: 'true'
+      RUN_MIGRATION: ((run_migration))
+    routes:
+      - route: ((ledger_route))


### PR DESCRIPTION
Adds a java buildpack manifest and dev.yml with common development
environment variables. To deploy into a PaaS space log into the space
and run the following from this project's root::

```
cf push --vars-file dev.yml \
  --var space=<space> \
  --var ledger_route=ledger-<space>.apps.internal

```

**How to test**
Push to your dev space. If its the first time you may need to delete the existing docker image based app with `cf delete ledger` and then recreate the postgres network policy with
`cf add-network-policy ledger --destination-app postgres --protocol tcp --port 5432` (and the same for sqs) once the new buildpack based version of ledger exists (likely it'll fail to start first time because it won't be able to connect to postgres).