### PR TITLE
PP-6059 Create metadata tables

### DIFF
--- a/src/main/resources/migrations/00033_create_table_metadata_key.sql
+++ b/src/main/resources/migrations/00033_create_table_metadata_key.sql
@@ -1,0 +1,8 @@
+--liquibase formatted sql
+
+--changeset uk.gov.pay:create_table_metadata_key
+CREATE TABLE metadata_key (
+    id BIGSERIAL PRIMARY KEY,
+    key VARCHAR(50) NOT NULL
+);
+--rollback drop table metadata_key;

--- a/src/main/resources/migrations/00034_create_table_transaction_metadata.sql
+++ b/src/main/resources/migrations/00034_create_table_transaction_metadata.sql
@@ -1,0 +1,20 @@
+--liquibase formatted sql
+
+--changeset uk.gov.pay:create_table_transaction_metadata
+CREATE TABLE transaction_metadata (
+    id BIGSERIAL PRIMARY KEY,
+    transaction_id bigserial NOT NULL,
+    metadata_key_id bigserial NOT NULL
+);
+--rollback drop table transaction_metadata;
+
+--changeset uk.gov.pay:add_transaction_metadata_transaction_id_fk
+ALTER TABLE transaction_metadata ADD CONSTRAINT transaction_metadata_transaction_id_fk
+FOREIGN KEY (transaction_id) REFERENCES transaction (id);
+--rollback drop constraint add_transaction_metadata_transaction_id_fk;
+
+
+--changeset uk.gov.pay:add_transaction_metadata_metadata_key_id_fk
+ALTER TABLE transaction_metadata ADD CONSTRAINT transaction_metadata_metadata_key_id_fk
+FOREIGN KEY (metadata_key_id) REFERENCES metadata_key (id);
+--rollback drop constraint add_transaction_metadata_metadata_key_id_fk;


### PR DESCRIPTION
## WHAT

- Creates new tables `metadata_key`, `transaction_metadata` to store to external metadata keys for transactions.
- metadata `key` is set to `50` characters long, which is over the limit `30` we allow services