### PR TITLE
PP-6059 Partial index on transaction_details (external_metadata)

### DIFF
--- a/src/main/resources/migrations/00035_table_transaction_external_metadata.sql
+++ b/src/main/resources/migrations/00035_table_transaction_external_metadata.sql
@@ -1,0 +1,6 @@
+--liquibase formatted sql
+
+--changeset uk.gov.pay:partial_index_transaction_external_metadata runInTransaction:false
+CREATE INDEX CONCURRENTLY IF NOT EXISTS transaction_external_metadata_idx on transaction(transaction_details)
+where transaction_details ?? 'external_metadata';
+--rollback drop index CONCURRENTLY transaction_external_metadata_idx;


### PR DESCRIPTION
## WHAT 
- Creates partial index on transaction_details for existence of external_metadata so this can be used to filter our transactions metadata and to derive metadata keys