### PR TITLE
PP-6059 Add index on metadata_key

### DIFF
--- a/src/main/resources/migrations/00036_index_metadata_key.sql
+++ b/src/main/resources/migrations/00036_index_metadata_key.sql
@@ -1,0 +1,5 @@
+--liquibase formatted sql
+
+--changeset uk.gov.pay:index_metadata_key runInTransaction:false
+CREATE INDEX CONCURRENTLY IF NOT EXISTS metadata_key_idx on metadata_key(key)
+--rollback drop index CONCURRENTLY metadata_key_idx;


### PR DESCRIPTION
## WHAT
- Added index on `key` column of metadata_key as the table is queried often for existence of key when processing transactions