### PR TITLE
PP-6058 Index id, created_date on transaction table

### DIFF
--- a/src/main/resources/migrations/00033_compound_index_transaction_id_created_date.sql
+++ b/src/main/resources/migrations/00033_compound_index_transaction_id_created_date.sql
@@ -1,0 +1,5 @@
+--liquibase formatted sql
+
+--changeset uk.gov.pay:compound_index_transaction_created_date_id runInTransaction:false
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS transaction_created_date_id_idx ON transaction USING btree(created_date, id);


### PR DESCRIPTION
In order to use keyset pagination through transactions on asynchronous
(CSV) downloads, add compound index across both id and transaction
created_date.

This allows ordering by created_date and then id, providing a guaranteed
unique and consistent page without overlapping entities. Created date on
its own could is likely to contain duplicates and we cannot gaurantee
the order of transaction ids as events are eventually consistent.