### PR TITLE
PP-6078: Add moto to transaction table

### DIFF
--- a/src/main/resources/migrations/00037_add_moto_to_payment_transactions.sql
+++ b/src/main/resources/migrations/00037_add_moto_to_payment_transactions.sql
@@ -1,0 +1,9 @@
+--liquibase formatted sql
+
+--changeset uk.gov.pay:add_moto_column_to_transaction_table
+
+ALTER TABLE transaction ADD COLUMN moto BOOLEAN;
+
+--changeset uk.gov.pay:default_value_moto_column
+
+ALTER TABLE transaction ALTER COLUMN moto SET DEFAULT false;


### PR DESCRIPTION
There is currently no plan to allow a service to search for MOTO payments
however it's better to technically allow this (we can envisage a service
wanting to search its MOTO payments in the future) by adding a column rather
than leaving it in the transaction_details column where it would be stored in a json
blob and then converting it to its own column later.