### PR TITLE
PP-6061 Add findMetadataKeysForTransactions DAO method

### DIFF
--- a/src/main/java/uk/gov/pay/ledger/app/LedgerModule.java
+++ b/src/main/java/uk/gov/pay/ledger/app/LedgerModule.java
@@ -88,7 +88,7 @@ public class LedgerModule extends AbstractModule {
     @Provides
     @Singleton
     public TransactionMetadataDao provideTransactionMetadataDao() {
-        return jdbi.onDemand(TransactionMetadataDao.class);
+        return new TransactionMetadataDao(jdbi);
     }
 
     @Provides

--- a/src/main/java/uk/gov/pay/ledger/transactionmetadata/dao/TransactionMetadataDao.java
+++ b/src/main/java/uk/gov/pay/ledger/transactionmetadata/dao/TransactionMetadataDao.java
@@ -1,21 +1,74 @@
 package uk.gov.pay.ledger.transactionmetadata.dao;
 
+import com.google.inject.Inject;
+import org.apache.commons.lang3.StringUtils;
+import org.jdbi.v3.core.Jdbi;
+import org.jdbi.v3.core.statement.Query;
 import org.jdbi.v3.sqlobject.customizer.Bind;
-import org.jdbi.v3.sqlobject.statement.GetGeneratedKeys;
-import org.jdbi.v3.sqlobject.statement.SqlUpdate;
+import uk.gov.pay.ledger.transaction.search.common.TransactionSearchParams;
 
-import java.util.Optional;
+import java.util.List;
+import java.util.function.BiConsumer;
 
-public interface TransactionMetadataDao {
+public class TransactionMetadataDao {
 
-    @SqlUpdate("INSERT INTO transaction_metadata(transaction_id, metadata_key_id) " +
+    private static final String FIND_METADATA_KEYS = "SELECT distinct mk.key FROM transaction t, transaction_metadata tm, metadata_key mk " +
+            " WHERE tm.transaction_id = t.id" +
+            "  AND tm.metadata_key_id = mk.id" +
+            "  AND transaction_details??'external_metadata'" +
+            " :searchExtraFields ";
+
+    private static final String INSERT_STRING = "INSERT INTO transaction_metadata(transaction_id, metadata_key_id) " +
             "SELECT :transactionId, (select id from metadata_key where key = :key) " +
             "WHERE NOT EXISTS ( " +
             "    SELECT 1 " +
             "    FROM transaction_metadata " +
             "    WHERE metadata_key_id in (select id from metadata_key where key = :key ) " +
-            "      and transaction_id = :transactionId)")
-    @GetGeneratedKeys
-    Optional<Long> insertIfNotExist(@Bind("transactionId") Long transactionId,
-                                    @Bind("key") String key);
+            "      and transaction_id = :transactionId)";
+
+    private final Jdbi jdbi;
+
+    @Inject
+    public TransactionMetadataDao(Jdbi jdbi) {
+        this.jdbi = jdbi;
+    }
+
+    public void insertIfNotExist(Long transactionId,
+                                 String key) {
+        jdbi.withHandle(handle ->
+                handle.createUpdate(INSERT_STRING)
+                        .bind("transactionId", transactionId)
+                        .bind("key", key)
+                        .execute()
+        );
+    }
+
+    public List<String> findMetadataKeysForTransactions(TransactionSearchParams searchParams) {
+        return jdbi.withHandle(handle -> {
+
+            String searchClauseTemplate = String.join(" AND ", searchParams.getFilterTemplates());
+
+            if (StringUtils.isNotBlank(searchClauseTemplate)) {
+                searchClauseTemplate = "AND " + searchClauseTemplate;
+            }
+
+            String queryString = FIND_METADATA_KEYS.replace(":searchExtraFields", searchClauseTemplate);
+            Query query = handle.createQuery(queryString);
+            searchParams.getQueryMap().forEach(bindSearchParameter(query));
+
+            return query
+                    .mapTo(String.class)
+                    .list();
+        });
+    }
+
+    private BiConsumer<String, Object> bindSearchParameter(Query query) {
+        return (searchKey, searchValue) -> {
+            if (searchValue instanceof List<?>) {
+                query.bindList(searchKey, ((List<?>) searchValue));
+            } else {
+                query.bind(searchKey, searchValue);
+            }
+        };
+    }
 }

--- a/src/test/java/uk/gov/pay/ledger/transactionmetadata/dao/TransactionMetadataDaoIT.java
+++ b/src/test/java/uk/gov/pay/ledger/transactionmetadata/dao/TransactionMetadataDaoIT.java
@@ -1,16 +1,24 @@
 package uk.gov.pay.ledger.transactionmetadata.dao;
 
+import com.google.common.collect.ImmutableMap;
+import org.hamcrest.MatcherAssert;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
 import uk.gov.pay.ledger.metadatakey.dao.MetadataKeyDao;
 import uk.gov.pay.ledger.rule.AppWithPostgresAndSqsRule;
+import uk.gov.pay.ledger.transaction.entity.TransactionEntity;
+import uk.gov.pay.ledger.transaction.search.common.TransactionSearchParams;
+import uk.gov.pay.ledger.transaction.state.TransactionState;
 import uk.gov.pay.ledger.util.DatabaseTestHelper;
 import uk.gov.pay.ledger.util.fixture.TransactionFixture;
 
+import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Map;
 
+import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -26,13 +34,15 @@ public class TransactionMetadataDaoIT {
     private DatabaseTestHelper dbHelper;
     private MetadataKeyDao metadataKeyDao;
     private TransactionFixture transactionFixture;
+    private TransactionSearchParams searchParams;
 
     @Before
     public void setUp() {
-        transactionMetadataDao = rule.getJdbi().onDemand(TransactionMetadataDao.class);
+        transactionMetadataDao = new TransactionMetadataDao(rule.getJdbi());
         metadataKeyDao = rule.getJdbi().onDemand(MetadataKeyDao.class);
         dbHelper = aDatabaseTestHelper(rule.getJdbi());
 
+        searchParams = new TransactionSearchParams();
         metadataKeyDao.insertIfNotExist(key);
         transactionFixture = aTransactionFixture()
                 .insert(rule.getJdbi());
@@ -61,5 +71,63 @@ public class TransactionMetadataDaoIT {
         assertThat(transactionMetadata.size(), is(1));
         assertThat(transactionMetadata.get(0).get("transaction_id"), is(transactionFixture.getId()));
         assertThat(transactionMetadata.get(0).get("metadata_key_id"), is(notNullValue()));
+    }
+
+    @Test
+    public void shouldReturnCorrectMetadataKeysForTransactionSearch() {
+        TransactionEntity transaction1 = aTransactionFixture()
+                .withState(TransactionState.CREATED)
+                .withTransactionType("PAYMENT")
+                .withExternalMetadata(ImmutableMap.of("test-key-1", "value1"))
+                .withDefaultCardDetails()
+                .withFirstDigitsCardNumber("123456")
+                .withLastDigitsCardNumber("1234")
+                .withDefaultTransactionDetails()
+                .insert(rule.getJdbi())
+                .toEntity();
+
+        TransactionEntity transaction2 = aTransactionFixture()
+                .withState(TransactionState.SUBMITTED)
+                .withReference(transaction1.getReference())
+                .withGatewayAccountId(transaction1.getGatewayAccountId())
+                .withExternalMetadata(ImmutableMap.of("test-key-2", "value1"))
+                .withDefaultCardDetails()
+                .withFirstDigitsCardNumber("123456")
+                .withLastDigitsCardNumber("1234")
+                .withDefaultTransactionDetails()
+                .insert(rule.getJdbi())
+                .toEntity();
+
+        TransactionEntity transactionToBeExcluded = aTransactionFixture()
+                .withState(TransactionState.SUBMITTED)
+                .withCreatedDate(ZonedDateTime.now().plusDays(3))
+                .withGatewayAccountId(transaction1.getGatewayAccountId())
+                .withExternalMetadata(ImmutableMap.of("test-key-3", "value1"))
+                .withDefaultTransactionDetails()
+                .insert(rule.getJdbi())
+                .toEntity();
+
+        metadataKeyDao.insertIfNotExist("test-key-1");
+        metadataKeyDao.insertIfNotExist("test-key-2");
+        metadataKeyDao.insertIfNotExist("test-key-3");
+
+        transactionMetadataDao.insertIfNotExist(transaction1.getId(), "test-key-1");
+        transactionMetadataDao.insertIfNotExist(transaction2.getId(), "test-key-2");
+
+        searchParams.setAccountId(transaction1.getGatewayAccountId());
+        searchParams.setFromDate(ZonedDateTime.now().minusDays(10).toString());
+        searchParams.setToDate(ZonedDateTime.now().plusDays(1).toString());
+        searchParams.setFirstDigitsCardNumber(transaction1.getFirstDigitsCardNumber());
+        searchParams.setLastDigitsCardNumber(transaction1.getLastDigitsCardNumber());
+        searchParams.setCardHolderName(transaction1.getCardholderName());
+        searchParams.setReference(transaction1.getReference());
+        searchParams.setEmail(transaction1.getEmail());
+        List<String> transactionEntityList =
+                transactionMetadataDao.findMetadataKeysForTransactions(searchParams);
+
+        MatcherAssert.assertThat(transactionEntityList.size(), is(2));
+
+        Assert.assertThat(transactionEntityList, hasItem("test-key-1"));
+        Assert.assertThat(transactionEntityList, hasItem("test-key-2"));
     }
 }


### PR DESCRIPTION
## WHAT 
- Added new method `findMetadataKeysForTransactions` to derive metadata keys from new tables (transaction_metadata and metadata_key) for given search parameters
- Changed `TransactionMetadataDao` to a class to add concrete method
- Relevant test