### PR TITLE
PP-6061 Add index for transaction_metadata foreign keys

### DIFF
--- a/src/main/resources/migrations/00038_index_transaction_metadata_foreign_keys.sql
+++ b/src/main/resources/migrations/00038_index_transaction_metadata_foreign_keys.sql
@@ -1,0 +1,6 @@
+--liquibase formatted sql
+
+--changeset uk.gov.pay:add_index_transaction_metadata_foreign_keys runInTransaction:false
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS transaction_metadata_transaction_id_metadatakey_id_idx
+ON transaction_metadata USING btree(transaction_id, metadata_key_id);


### PR DESCRIPTION
## WHAT 
- Added index on transaction_id and metadata_key_id columns to avoid sequential scan on entire table when joined with transaction and metadata_key tables