### PR TITLE
PP-6070 Reporting config for max csv size

### DIFF
--- a/src/main/java/uk/gov/pay/ledger/app/LedgerConfig.java
+++ b/src/main/java/uk/gov/pay/ledger/app/LedgerConfig.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import io.dropwizard.Configuration;
 import io.dropwizard.db.DataSourceFactory;
 import uk.gov.pay.ledger.app.config.QueueMessageReceiverConfig;
+import uk.gov.pay.ledger.app.config.ReportingConfig;
 import uk.gov.pay.ledger.app.config.SqsConfig;
 
 import javax.validation.Valid;
@@ -32,11 +33,19 @@ public class LedgerConfig extends Configuration {
     @JsonProperty("queueMessageReceiverConfig")
     private QueueMessageReceiverConfig queueMessageReceiverConfig;
 
+    @NotNull
+    @JsonProperty("reportingConfig")
+    private ReportingConfig reportingConfig;
+
     public SqsConfig getSqsConfig() {
         return sqsConfig;
     }
 
     public QueueMessageReceiverConfig getQueueMessageReceiverConfig() {
         return queueMessageReceiverConfig;
+    }
+
+    public ReportingConfig getReportingConfig() {
+        return reportingConfig;
     }
 }

--- a/src/main/java/uk/gov/pay/ledger/app/config/ReportingConfig.java
+++ b/src/main/java/uk/gov/pay/ledger/app/config/ReportingConfig.java
@@ -1,0 +1,16 @@
+package uk.gov.pay.ledger.app.config;
+
+import io.dropwizard.Configuration;
+
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+
+public class ReportingConfig extends Configuration {
+
+    @Valid
+    private int maximumCsvRowsSize;
+
+    public int getMaximumCsvRowsSize() {
+        return maximumCsvRowsSize;
+    }
+}

--- a/src/main/java/uk/gov/pay/ledger/app/config/ReportingConfig.java
+++ b/src/main/java/uk/gov/pay/ledger/app/config/ReportingConfig.java
@@ -10,7 +10,14 @@ public class ReportingConfig extends Configuration {
     @Valid
     private int maximumCsvRowsSize;
 
+    @Valid
+    private int streamingCsvPageSize;
+
     public int getMaximumCsvRowsSize() {
         return maximumCsvRowsSize;
+    }
+
+    public int getStreamingCsvPageSize() {
+        return streamingCsvPageSize;
     }
 }

--- a/src/main/java/uk/gov/pay/ledger/transaction/resource/TransactionResource.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/resource/TransactionResource.java
@@ -122,7 +122,7 @@ public class TransactionResource {
                               @Context UriInfo uriInfo) {
         StreamingOutput stream = outputStream -> {
             TransactionSearchParams csvSearchParams = Optional.ofNullable(searchParams).orElse(new TransactionSearchParams());
-            csvSearchParams.overrideMaxDisplaySize(1000L);
+            csvSearchParams.overrideMaxDisplaySize((long) configuration.getReportingConfig().getStreamingCsvPageSize());
             csvSearchParams.setAccountId(gatewayAccountId);
             List<TransactionEntity> page;
             ZonedDateTime startingAfterCreatedDate = null;

--- a/src/main/java/uk/gov/pay/ledger/transaction/resource/TransactionResource.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/resource/TransactionResource.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.ObjectWriter;
 import com.google.inject.Inject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import uk.gov.pay.ledger.app.LedgerConfig;
 import uk.gov.pay.ledger.transaction.entity.TransactionEntity;
 import uk.gov.pay.ledger.transaction.model.TransactionEventResponse;
 import uk.gov.pay.ledger.transaction.model.TransactionSearchResponse;
@@ -46,11 +47,13 @@ public class TransactionResource {
     private static final Logger LOGGER = LoggerFactory.getLogger(TransactionResource.class);
     private final TransactionService transactionService;
     private final CsvService csvService;
+    private final LedgerConfig configuration;
 
     @Inject
-    public TransactionResource(TransactionService transactionService, CsvService csvService) {
+    public TransactionResource(TransactionService transactionService, CsvService csvService, LedgerConfig configuration) {
         this.transactionService = transactionService;
         this.csvService = csvService;
+        this.configuration = configuration;
     }
 
     @Path("/{transactionExternalId}")
@@ -144,7 +147,7 @@ public class TransactionResource {
                     );
                     outputStream.flush();
                 }
-            } while (!page.isEmpty() && count < 200000);
+            } while (!page.isEmpty() && count < configuration.getReportingConfig().getMaximumCsvRowsSize());
             outputStream.close();
         };
         return Response.ok(stream).build();

--- a/src/main/resources/config/config.yaml
+++ b/src/main/resources/config/config.yaml
@@ -77,3 +77,4 @@ queueMessageReceiverConfig:
 
 reportingConfig:
   maximumCsvRowsSize: ${REPORTING_MAX_CSV_ROWS_SIZE:-100000}
+  streamingCsvPageSize: ${STREAMING_CSV_PAGE_SIZE:-5000}

--- a/src/main/resources/config/config.yaml
+++ b/src/main/resources/config/config.yaml
@@ -74,3 +74,6 @@ queueMessageReceiverConfig:
   threadDelayInMilliseconds: ${QUEUE_MESSAGE_RECEIVER_THREAD_DELAY_IN_MILLISECONDS:-1}
   numberOfThreads: ${QUEUE_MESSAGE_RECEIVER_NUMBER_OF_THREADS:-1}
   messageRetryDelayInSeconds: ${QUEUE_MESSAGE_RETRY_DELAY_IN_SECONDS:-900}
+
+reportingConfig:
+  maximumCsvRowsSize: ${REPORTING_MAX_CSV_ROWS_SIZE:-100000}

--- a/src/test/java/uk/gov/pay/ledger/transaction/resource/TransactionResourceTest.java
+++ b/src/test/java/uk/gov/pay/ledger/transaction/resource/TransactionResourceTest.java
@@ -1,10 +1,13 @@
 package uk.gov.pay.ledger.transaction.resource;
 
 import io.dropwizard.testing.junit.ResourceTestRule;
+import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.pay.ledger.app.LedgerConfig;
+import uk.gov.pay.ledger.app.config.ReportingConfig;
 import uk.gov.pay.ledger.exception.BadRequestExceptionMapper;
 import uk.gov.pay.ledger.transaction.search.model.TransactionView;
 import uk.gov.pay.ledger.transaction.service.CsvService;
@@ -31,10 +34,11 @@ import static org.mockito.Mockito.when;
 public class TransactionResourceTest {
     private static final TransactionService mockTransactionService = mock(TransactionService.class);
     private static final CsvService mockCsvService = mock(CsvService.class);
+    private static final LedgerConfig mockConfig = mock(LedgerConfig.class);
 
     @ClassRule
     public static final ResourceTestRule resources = ResourceTestRule.builder()
-            .addResource(new TransactionResource(mockTransactionService, mockCsvService))
+            .addResource(new TransactionResource(mockTransactionService, mockCsvService, mockConfig))
             .addProvider(BadRequestExceptionMapper.class)
             .build();
 

--- a/src/test/resources/config/test-config.yaml
+++ b/src/test/resources/config/test-config.yaml
@@ -60,3 +60,6 @@ queueMessageReceiverConfig:
   threadDelayInMilliseconds: ${QUEUE_MESSAGE_RECEIVER_THREAD_DELAY_IN_MILLISECONDS:-1}
   numberOfThreads: ${QUEUE_MESSAGE_RECEIVER_NUMBER_OF_THREADS:-1}
   messageRetryDelayInSeconds: ${QUEUE_MESSAGE_RETRY_DELAY_IN_SECONDS:-900}
+
+reportingConfig:
+  maximumCsvRowsSize: ${REPORTING_MAX_CSV_ROWS_SIZE:-100000}

--- a/src/test/resources/config/test-config.yaml
+++ b/src/test/resources/config/test-config.yaml
@@ -63,3 +63,4 @@ queueMessageReceiverConfig:
 
 reportingConfig:
   maximumCsvRowsSize: ${REPORTING_MAX_CSV_ROWS_SIZE:-100000}
+  streamingCsvPageSize: ${STREAMING_CSV_PAGE_SIZE:-5000}


### PR DESCRIPTION
Accept `REPORTING_MAX_CSV_ROWS_SIZE` for streaming configuration; defaults to 100,000.