### PR TITLE
PP-6125 Return `source` and `live` in response

### DIFF
--- a/src/main/java/uk/gov/pay/ledger/transaction/model/Payment.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/model/Payment.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
 import uk.gov.pay.commons.api.json.ApiResponseDateTimeSerializer;
+import uk.gov.pay.commons.model.Source;
 import uk.gov.pay.ledger.transaction.search.model.RefundSummary;
 import uk.gov.pay.ledger.transaction.search.model.SettlementSummary;
 import uk.gov.pay.ledger.transaction.state.TransactionState;
@@ -40,6 +41,8 @@ public class Payment extends Transaction{
     private Long totalAmount;
     private RefundSummary refundSummary;
     private SettlementSummary settlementSummary;
+    private Boolean live;
+    private Source source;
 
     public Payment() {
 
@@ -52,7 +55,7 @@ public class Payment extends Transaction{
                    CardDetails cardDetails, Boolean delayedCapture, Map<String, Object> externalMetaData,
                    Integer eventCount, String gatewayTransactionId, Long corporateCardSurcharge, Long fee,
                    Long netAmount, Long totalAmount, RefundSummary refundSummary, SettlementSummary settlementSummary,
-                   Boolean moto) {
+                   Boolean moto, Boolean live, Source source) {
         super(id, gatewayAccountId, amount, externalId);
         this.corporateCardSurcharge = corporateCardSurcharge;
         this.fee = fee;
@@ -78,6 +81,8 @@ public class Payment extends Transaction{
         this.eventCount = eventCount;
         this.gatewayTransactionId = gatewayTransactionId;
         this.moto = moto;
+        this.live = live;
+        this.source = source;
     }
 
     public Payment(String gatewayAccountId, Long amount,
@@ -87,11 +92,12 @@ public class Payment extends Transaction{
                    CardDetails cardDetails, Boolean delayedCapture, Map<String, Object> externalMetaData,
                    Integer eventCount, String gatewayTransactionId, Long corporateCardSurcharge, Long fee,
                    Long netAmount, RefundSummary refundSummary, Long totalAmount, SettlementSummary settlementSummary,
-                   Boolean moto) {
+                   Boolean moto, Boolean live, Source source) {
 
         this(null, gatewayAccountId, amount, reference, description, state, language, externalId, returnUrl, email,
                 paymentProvider, createdDate, cardDetails, delayedCapture, externalMetaData, eventCount,
-                gatewayTransactionId, corporateCardSurcharge, fee, netAmount, totalAmount, refundSummary, settlementSummary, moto);
+                gatewayTransactionId, corporateCardSurcharge, fee, netAmount, totalAmount, refundSummary,
+                settlementSummary, moto, live, source);
     }
 
     @Override
@@ -183,5 +189,13 @@ public class Payment extends Transaction{
 
     public SettlementSummary getSettlementSummary() {
         return settlementSummary;
+    }
+
+    public boolean getLive() {
+        return live;
+    }
+
+    public Source getSource() {
+        return source;
     }
 }

--- a/src/main/java/uk/gov/pay/ledger/transaction/model/TransactionFactory.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/model/TransactionFactory.java
@@ -92,7 +92,9 @@ public class TransactionFactory {
                     refundSummary,
                     entity.getTotalAmount(),
                     settlementSummary,
-                    entity.isMoto()
+                    entity.isMoto(),
+                    entity.isLive(),
+                    entity.getSource()
             );
         } catch (IOException e) {
             LOGGER.error("Error during the parsing transaction entity data [{}] [errorMessage={}]", entity.getExternalId(), e.getMessage());

--- a/src/main/java/uk/gov/pay/ledger/transaction/search/model/TransactionView.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/search/model/TransactionView.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import uk.gov.pay.commons.api.json.ApiResponseDateTimeSerializer;
+import uk.gov.pay.commons.model.Source;
 import uk.gov.pay.ledger.transaction.model.CardDetails;
 import uk.gov.pay.ledger.transaction.model.Payment;
 import uk.gov.pay.ledger.transaction.model.Refund;
@@ -51,9 +52,11 @@ public class TransactionView {
     private Map<String, Object> metadata;
     private String refundedBy;
     private String refundedByUserEmail;
+    private Boolean live;
+    private Source source;
+    private Boolean moto;
     private TransactionType transactionType;
     private TransactionView parentTransaction;
-    private Boolean moto;
 
     public TransactionView(Builder builder) {
         this.id = builder.id;
@@ -84,6 +87,8 @@ public class TransactionView {
         this.transactionType = builder.transactionType;
         this.parentTransaction = builder.parentTransaction;
         this.moto = builder.moto;
+        this.live = builder.live;
+        this.source = builder.source;
     }
 
     public TransactionView() {
@@ -118,6 +123,8 @@ public class TransactionView {
                     .withMetadata(payment.getExternalMetadata())
                     .withTransactionType(payment.getTransactionType())
                     .withGatewayTransactionId(payment.getGatewayTransactionId())
+                    .withSource(payment.getSource())
+                    .withLive(payment.getLive())
                     .withMoto(payment.getMoto())
                     .build();
         }
@@ -267,6 +274,14 @@ public class TransactionView {
         return parentTransaction;
     }
 
+    public boolean isLive() {
+        return live;
+    }
+
+    public Source getSource() {
+        return source;
+    }
+
     public static class Builder {
         private TransactionView parentTransaction;
         private Long id;
@@ -295,8 +310,10 @@ public class TransactionView {
         private String refundedBy;
         private String refundedByUserEmail;
         private TransactionType transactionType;
-        private List<Link> links = new ArrayList<>();
         private Boolean moto;
+        private Boolean live;
+        private Source source;
+        private List<Link> links = new ArrayList<>();
 
         public Builder() {
         }
@@ -437,6 +454,16 @@ public class TransactionView {
 
         public Builder withParentTransaction(TransactionView parentTransaction) {
             this.parentTransaction = parentTransaction;
+            return this;
+        }
+
+        public Builder withSource(Source source) {
+            this.source = source;
+            return this;
+        }
+
+        public Builder withLive(boolean live) {
+            this.live = live;
             return this;
         }
 

--- a/src/test/java/uk/gov/pay/ledger/transaction/resource/TransactionResourceIT.java
+++ b/src/test/java/uk/gov/pay/ledger/transaction/resource/TransactionResourceIT.java
@@ -8,6 +8,7 @@ import org.hamcrest.Matchers;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
+import uk.gov.pay.commons.model.Source;
 import uk.gov.pay.ledger.event.model.Event;
 import uk.gov.pay.ledger.metadatakey.dao.MetadataKeyDao;
 import uk.gov.pay.ledger.rule.AppWithPostgresAndSqsRule;
@@ -66,7 +67,9 @@ public class TransactionResourceIT {
 
         transactionFixture = aTransactionFixture()
                 .withDefaultCardDetails()
-                .withDefaultTransactionDetails();
+                .withDefaultTransactionDetails()
+                .withLive(true)
+                .withSource(String.valueOf(Source.CARD_PAYMENT_LINK));
         transactionFixture.insert(rule.getJdbi());
 
         given().port(port)
@@ -75,6 +78,8 @@ public class TransactionResourceIT {
                 .then()
                 .statusCode(Response.Status.OK.getStatusCode())
                 .contentType(JSON)
+                .body("live", is(true))
+                .body("source", is("CARD_PAYMENT_LINK"))
                 .body("transaction_id", is(transactionFixture.getExternalId()))
                 .body("card_details.cardholder_name", is(transactionFixture.getCardDetails().getCardHolderName()))
                 .body("card_details.expiry_date", is(transactionFixture.getCardDetails().getExpiryDate()))
@@ -230,6 +235,9 @@ public class TransactionResourceIT {
                 .body("results[0].net_amount", is(nullValue()))
                 .body("results[0].total_amount", is(nullValue()))
                 .body("results[0].fee", is(nullValue()))
+                .body("results[0].live", is(true))
+                .body("results[0].source", is("CARD_API"))
+
                 .body("results[0].refund_summary.amount_available", is(transactionToVerify.getRefundSummary().getAmountAvailable().intValue()))
                 .body("results[0].refund_summary.amount_submitted", is(transactionToVerify.getRefundSummary().getAmountSubmitted().intValue()))
                 .body("results[0].refund_summary.amount_refunded", is(transactionToVerify.getRefundSummary().getAmountRefunded().intValue()))

--- a/src/test/java/uk/gov/pay/ledger/util/fixture/TransactionFixture.java
+++ b/src/test/java/uk/gov/pay/ledger/util/fixture/TransactionFixture.java
@@ -108,6 +108,8 @@ public class TransactionFixture implements DbFixture<TransactionFixture, Transac
                     .withCardBrand(i % 2 == 0 ? "visa" : "mastercard")
                     .withTransactionType(i % 2 == 0 ? "REFUND" : "PAYMENT")
                     .withCreatedDate(ZonedDateTime.now(ZoneOffset.UTC).minusHours(1L).plusMinutes(i))
+                    .withLive(true)
+                    .withSource(String.valueOf(Source.CARD_API))
                     .insert(jdbi)
                     .toEntity();
             transactionList.add(new TransactionFactory(Jackson.newObjectMapper()).createTransactionEntity(entity));


### PR DESCRIPTION
- When a payment is sent, either in response to an ID GET request or
search, we should return the `source` and the `live` field

- Adds a test to verify that the behaviour is as expected for both a
single payment GET and a search.