### PR TITLE
PP-6125 Return `source` and `live` in Response

### DIFF
--- a/src/main/java/uk/gov/pay/ledger/transaction/model/Payment.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/model/Payment.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
 import uk.gov.pay.commons.api.json.ApiResponseDateTimeSerializer;
+import uk.gov.pay.commons.model.Source;
 import uk.gov.pay.ledger.transaction.search.model.RefundSummary;
 import uk.gov.pay.ledger.transaction.search.model.SettlementSummary;
 import uk.gov.pay.ledger.transaction.state.TransactionState;
@@ -40,6 +41,8 @@ public class Payment extends Transaction{
     private Long totalAmount;
     private RefundSummary refundSummary;
     private SettlementSummary settlementSummary;
+    private Boolean live;
+    private Source source;
 
     public Payment() {
 
@@ -52,7 +55,7 @@ public class Payment extends Transaction{
                    CardDetails cardDetails, Boolean delayedCapture, Map<String, Object> externalMetaData,
                    Integer eventCount, String gatewayTransactionId, Long corporateCardSurcharge, Long fee,
                    Long netAmount, Long totalAmount, RefundSummary refundSummary, SettlementSummary settlementSummary,
-                   Boolean moto) {
+                   Boolean moto, Boolean live, Source source) {
         super(id, gatewayAccountId, amount, externalId);
         this.corporateCardSurcharge = corporateCardSurcharge;
         this.fee = fee;
@@ -78,6 +81,8 @@ public class Payment extends Transaction{
         this.eventCount = eventCount;
         this.gatewayTransactionId = gatewayTransactionId;
         this.moto = moto;
+        this.live = live;
+        this.source = source;
     }
 
     public Payment(String gatewayAccountId, Long amount,
@@ -87,11 +92,12 @@ public class Payment extends Transaction{
                    CardDetails cardDetails, Boolean delayedCapture, Map<String, Object> externalMetaData,
                    Integer eventCount, String gatewayTransactionId, Long corporateCardSurcharge, Long fee,
                    Long netAmount, RefundSummary refundSummary, Long totalAmount, SettlementSummary settlementSummary,
-                   Boolean moto) {
+                   Boolean moto, Boolean live, Source source) {
 
         this(null, gatewayAccountId, amount, reference, description, state, language, externalId, returnUrl, email,
                 paymentProvider, createdDate, cardDetails, delayedCapture, externalMetaData, eventCount,
-                gatewayTransactionId, corporateCardSurcharge, fee, netAmount, totalAmount, refundSummary, settlementSummary, moto);
+                gatewayTransactionId, corporateCardSurcharge, fee, netAmount, totalAmount, refundSummary,
+                settlementSummary, moto, live, source);
     }
 
     @Override
@@ -183,5 +189,13 @@ public class Payment extends Transaction{
 
     public SettlementSummary getSettlementSummary() {
         return settlementSummary;
+    }
+
+    public Boolean isLive() {
+        return live;
+    }
+
+    public Source getSource() {
+        return source;
     }
 }

--- a/src/main/java/uk/gov/pay/ledger/transaction/model/TransactionFactory.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/model/TransactionFactory.java
@@ -92,7 +92,9 @@ public class TransactionFactory {
                     refundSummary,
                     entity.getTotalAmount(),
                     settlementSummary,
-                    entity.isMoto()
+                    entity.isMoto(),
+                    entity.isLive(),
+                    entity.getSource()
             );
         } catch (IOException e) {
             LOGGER.error("Error during the parsing transaction entity data [{}] [errorMessage={}]", entity.getExternalId(), e.getMessage());

--- a/src/main/java/uk/gov/pay/ledger/transaction/search/model/TransactionView.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/search/model/TransactionView.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import uk.gov.pay.commons.api.json.ApiResponseDateTimeSerializer;
+import uk.gov.pay.commons.model.Source;
 import uk.gov.pay.ledger.transaction.model.CardDetails;
 import uk.gov.pay.ledger.transaction.model.Payment;
 import uk.gov.pay.ledger.transaction.model.Refund;
@@ -54,6 +55,8 @@ public class TransactionView {
     private TransactionType transactionType;
     private TransactionView parentTransaction;
     private Boolean moto;
+    private Boolean live;
+    private Source source;
 
     public TransactionView(Builder builder) {
         this.id = builder.id;
@@ -84,6 +87,8 @@ public class TransactionView {
         this.transactionType = builder.transactionType;
         this.parentTransaction = builder.parentTransaction;
         this.moto = builder.moto;
+        this.live = builder.live;
+        this.source = builder.source;
     }
 
     public TransactionView() {
@@ -119,6 +124,8 @@ public class TransactionView {
                     .withTransactionType(payment.getTransactionType())
                     .withGatewayTransactionId(payment.getGatewayTransactionId())
                     .withMoto(payment.getMoto())
+                    .withLive(payment.isLive())
+                    .withSource(payment.getSource())
                     .build();
         }
 
@@ -267,6 +274,14 @@ public class TransactionView {
         return parentTransaction;
     }
 
+    public Boolean getLive() {
+        return live;
+    }
+
+    public Source getSource() {
+        return source;
+    }
+
     public static class Builder {
         private TransactionView parentTransaction;
         private Long id;
@@ -297,6 +312,8 @@ public class TransactionView {
         private TransactionType transactionType;
         private List<Link> links = new ArrayList<>();
         private Boolean moto;
+        private Boolean live;
+        private Source source;
 
         public Builder() {
         }
@@ -442,6 +459,16 @@ public class TransactionView {
 
         public Builder withMoto(Boolean moto) {
             this.moto = moto;
+            return this;
+        }
+
+        public Builder withLive(Boolean live) {
+            this.live = live;
+            return this;
+        }
+
+        public Builder withSource(Source source) {
+            this.source = source;
             return this;
         }
     }


### PR DESCRIPTION
- When we respond with a `TransactionView`, in response to both GET
single payment requests and GET search requests, in which case a
`List<TransactionView>` is returned, we want to include the `source` and
`live` parameters.

- Add tests to ensure that this is the case for payments.