### PR TITLE
PP-6085 Add accept header to test

### DIFF
--- a/src/test/java/uk/gov/pay/ledger/transaction/resource/TransactionResourceTest.java
+++ b/src/test/java/uk/gov/pay/ledger/transaction/resource/TransactionResourceTest.java
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 import static org.mockito.ArgumentMatchers.anyBoolean;
@@ -92,7 +93,11 @@ public class TransactionResourceTest {
 
     @Test
     public void shouldReturn400IfTransactionGatewayAccountIdIsNotProvidedForSearch() {
-        Response response = resources.target("/v1/transaction/").request().get();
+        Response response = resources.target("/v1/transaction/")
+                .request()
+                .header("Accept", APPLICATION_JSON)
+                .get();
+
         assertThat(response.getStatus(), is(400));
     }
 


### PR DESCRIPTION
There are two methods within `TransactionResource` named `search` and
`streamCsv`. Both use the path `/` and http method `GET` but provide
either "application/json" or "text/csv" respectively.

According to the jax-rs specification when the client does not specify
the "accept" header then it is not garanteed as to which method will be
invoked, since both methods have the same level of specificity in what
they provide.

When
`shouldReturn400IfTransactionGatewayAccountIdIsNotProvidedForSearch`
runs locally and on Jenkins the `search` method is invoked as expected,
however on Travis `streamCsv` is called and an NPE is thrown as the test
provides a mock config with null parameters.

This shouldn't be a concern in production since the client of this
service is publicApi which provides an accept header. Therefore we feel it is
exceptable to add the header to the test and not disambiguate the
two methods any further.