### PR TITLE
PP-6085: Add default application port (8080)

### DIFF
--- a/src/main/resources/config/config.yaml
+++ b/src/main/resources/config/config.yaml
@@ -1,7 +1,7 @@
 server:
   applicationConnectors:
     - type: http
-      port: ${PORT}
+      port: ${PORT:-8080}
   requestLog:
     appenders:
       - type: console


### PR DESCRIPTION
When running on CloudFoundry via `cf run-task`, no PORT env var is supplied since no http route is served in this context. The app config throws an error without a default value.