### PR TITLE
PP-6139 View MOTO Transactions per gateway

### DIFF
--- a/src/main/java/uk/gov/pay/ledger/report/dao/ReportDao.java
+++ b/src/main/java/uk/gov/pay/ledger/report/dao/ReportDao.java
@@ -54,8 +54,6 @@ public class ReportDao {
         });
     }
 
-
-
     public TransactionsStatisticsResult getTransactionSummaryStatistics(TransactionSummaryParams params, TransactionType transactionType) {
         return jdbi.withHandle(handle -> {
             String template = createSearchTemplate(params.getFilterTemplates(), TRANSACTION_SUMMARY_STATISTICS);
@@ -64,6 +62,23 @@ public class ReportDao {
                     .bind("transactionType", transactionType)
                     .bind("state", TransactionState.SUCCESS);
             params.getQueryMap().forEach(query::bind);
+
+            return query.map((rs, rowNum) -> {
+                long count = rs.getLong("count");
+                long grossAmount = rs.getLong("grossAmount");
+                return new TransactionsStatisticsResult(count, grossAmount);
+            }).one();
+        });
+    }
+
+    public TransactionsStatisticsResult getMotoStatistics(TransactionSummaryParams params, TransactionType transactionType) {
+        return jdbi.withHandle(handle -> {
+            String template = createSearchTemplate(params.getFilterTemplatesWithMoto(), TRANSACTION_SUMMARY_STATISTICS);
+
+            Query query = handle.createQuery(template)
+                    .bind("transactionType", transactionType)
+                    .bind("state", TransactionState.SUCCESS);
+            params.getQueryMapWithMoto().forEach(query::bind);
 
             return query.map((rs, rowNum) -> {
                 long count = rs.getLong("count");

--- a/src/main/java/uk/gov/pay/ledger/report/entity/TransactionSummaryResult.java
+++ b/src/main/java/uk/gov/pay/ledger/report/entity/TransactionSummaryResult.java
@@ -1,14 +1,17 @@
 package uk.gov.pay.ledger.report.entity;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
 import java.util.Objects;
 
 @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class TransactionSummaryResult {
 
     private TransactionsStatisticsResult payments;
+    private TransactionsStatisticsResult motoPayments;
     private TransactionsStatisticsResult refunds;
     private Long netIncome;
 
@@ -20,8 +23,22 @@ public class TransactionSummaryResult {
         this.netIncome = netIncome;
     }
 
+    public TransactionSummaryResult(TransactionsStatisticsResult payments,
+                                    TransactionsStatisticsResult motoPayments,
+                                    TransactionsStatisticsResult refunds,
+                                    Long netIncome) {
+        this.payments = payments;
+        this.motoPayments = motoPayments;
+        this.refunds = refunds;
+        this.netIncome = netIncome;
+    }
+
     public TransactionsStatisticsResult getPayments() {
         return payments;
+    }
+
+    public TransactionsStatisticsResult getMotoPayments() {
+        return motoPayments;
     }
 
     public TransactionsStatisticsResult getRefunds() {
@@ -38,17 +55,19 @@ public class TransactionSummaryResult {
         if (o == null || getClass() != o.getClass()) { return false; }
         TransactionSummaryResult that = (TransactionSummaryResult) o;
         return that.payments.equals(this.payments) &&
+                that.motoPayments.equals(this.motoPayments) &&
                 that.refunds.equals(this.refunds);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(payments.hashCode(), refunds.hashCode(), netIncome);
+        return Objects.hash(payments.hashCode(), motoPayments.hashCode(), refunds.hashCode(), netIncome);
     }
 
     @Override
     public String toString() {
         return "TransactionsSummaryResult: { payments: " + payments.toString() +
+                " moto payments: " + motoPayments.toString() +
                 " refunds: " + refunds.toString() +
                 " total in pence: " + netIncome +
                 " }";

--- a/src/main/java/uk/gov/pay/ledger/report/params/TransactionSummaryParams.java
+++ b/src/main/java/uk/gov/pay/ledger/report/params/TransactionSummaryParams.java
@@ -15,10 +15,14 @@ import static org.apache.commons.lang3.StringUtils.isNotBlank;
 public class TransactionSummaryParams {
     private static final String TO_DATE_FIELD = "to_date";
     private static final String GATEWAY_ACCOUNT_EXTERNAL_FIELD = "account_id";
+    private static final String MOTO = "moto";
     private static final String FROM_DATE_FIELD = "from_date";
 
     @QueryParam("account_id")
     private String accountId;
+
+    @QueryParam("moto")
+    private boolean moto;
 
     @QueryParam("from_date")
     @ValidDate(message = "Invalid attribute value: from_date. Must be a valid date")
@@ -34,6 +38,14 @@ public class TransactionSummaryParams {
 
     public void setAccountId(String accountId) {
         this.accountId = accountId;
+    }
+
+    public boolean isMoto() {
+        return moto;
+    }
+
+    public void setMoto(boolean moto) {
+        this.moto = moto;
     }
 
     public String getFromDate() {
@@ -58,11 +70,22 @@ public class TransactionSummaryParams {
         if (isNotBlank(accountId)) {
             filters.add(" t.gateway_account_id = :" + GATEWAY_ACCOUNT_EXTERNAL_FIELD);
         }
+
         if (isNotBlank(fromDate)) {
             filters.add(" t.created_date > :" + FROM_DATE_FIELD);
         }
         if (isNotBlank(toDate)) {
             filters.add(" t.created_date < :" + TO_DATE_FIELD);
+        }
+
+        return filters;
+    }
+
+    public List<String> getFilterTemplatesWithMoto() {
+        List<String> filters = getFilterTemplates();
+
+        if (isMoto()) {
+            filters.add(" t.moto = :" + MOTO);
         }
 
         return filters;
@@ -74,6 +97,11 @@ public class TransactionSummaryParams {
         if (isNotBlank(accountId)) {
             queryMap.put(GATEWAY_ACCOUNT_EXTERNAL_FIELD, accountId);
         }
+
+        if (moto) {
+            queryMap.put(MOTO, true);
+        }
+
         if (isNotBlank(fromDate)) {
             queryMap.put(FROM_DATE_FIELD, ZonedDateTime.parse(fromDate));
         }
@@ -84,25 +112,34 @@ public class TransactionSummaryParams {
         return queryMap;
     }
 
+    public Map<String, Object> getQueryMapWithMoto() {
+        Map<String, Object> queryMap = getQueryMap();
+        queryMap.put(MOTO, true);
+
+        return queryMap;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         TransactionSummaryParams that = (TransactionSummaryParams) o;
         return Objects.equals(accountId, that.accountId) &&
+                Objects.equals(moto, that.moto) &&
                 Objects.equals(fromDate, that.fromDate) &&
                 Objects.equals(toDate, that.toDate);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(accountId, fromDate, toDate);
+        return Objects.hash(accountId, moto, fromDate, toDate);
     }
 
     @Override
     public String toString() {
         return "TransactionSummaryParams{" +
                 "accountId='" + accountId + '\'' +
+                "moto='" + moto + '\'' +
                 ", fromDate='" + fromDate + '\'' +
                 ", toDate='" + toDate + '\'' +
                 '}';

--- a/src/main/java/uk/gov/pay/ledger/report/service/ReportService.java
+++ b/src/main/java/uk/gov/pay/ledger/report/service/ReportService.java
@@ -38,6 +38,11 @@ public class ReportService {
     public TransactionSummaryResult getTransactionsSummary(TransactionSummaryParams params) {
         TransactionsStatisticsResult payments = reportDao.getTransactionSummaryStatistics(params, TransactionType.PAYMENT);
         TransactionsStatisticsResult refunds = reportDao.getTransactionSummaryStatistics(params, TransactionType.REFUND);
+
+        if (params.isMoto()) {
+            TransactionsStatisticsResult motoPayments = reportDao.getMotoStatistics(params, TransactionType.PAYMENT);
+            return new TransactionSummaryResult(payments, motoPayments, refunds, payments.getGrossAmount() - refunds.getGrossAmount());
+        }
         return new TransactionSummaryResult(payments, refunds, payments.getGrossAmount() - refunds.getGrossAmount());
     }
 

--- a/src/test/java/uk/gov/pay/ledger/report/resource/ReportResourceIT.java
+++ b/src/test/java/uk/gov/pay/ledger/report/resource/ReportResourceIT.java
@@ -87,9 +87,43 @@ public class ReportResourceIT {
                 )
                 .then()
                 .statusCode(Response.Status.OK.getStatusCode())
+                .contentType(JSON).log().body()
+                .body("payments.count", is(2))
+                .body("payments.gross_amount", is(3000))
+                .body("net_income", is(3000));
+    }
+
+    @Test
+    public void shouldGetTransactionSummaryStatisticsWithMotoForToolbox() {
+        aTransactionFixture()
+                .withAmount(1000L)
+                .withState(TransactionState.SUCCESS)
+                .withGatewayAccountId(gatewayAccountId)
+                .withCreatedDate(ZonedDateTime.parse("2019-10-01T10:00:00.000Z"))
+                .insert(rule.getJdbi());
+        aTransactionFixture()
+                .withAmount(2000L)
+                .withMoto(true)
+                .withState(TransactionState.SUCCESS)
+                .withGatewayAccountId(gatewayAccountId)
+                .withCreatedDate(ZonedDateTime.parse("2019-10-01T10:00:00.000Z"))
+                .insert(rule.getJdbi());
+
+        given().port(port)
+                .contentType(JSON)
+                .get("/v1/report/transactions-summary?account_id=" + gatewayAccountId +
+                        "&moto=true" +
+                        "&from_date=2019-10-01T09:00:00.000Z" +
+                        "&to_date=2019-10-01T11:00:00.000Z" +
+                        "&override_from_date_validation=true"
+                )
+                .then()
+                .statusCode(Response.Status.OK.getStatusCode())
                 .contentType(JSON)
                 .body("payments.count", is(2))
                 .body("payments.gross_amount", is(3000))
+                .body("moto_payments.count", is(1))
+                .body("moto_payments.amount", is(2000))
                 .body("net_income", is(3000));
     }
 


### PR DESCRIPTION
Description:
- Adds moto field to Ledger endpoint so that when moto flag is passed it will return the count. This is so that it can be displayed in the statistics page for the individual gateway account in Toolbox
- Since moto payments isn't a transaction type in Ledger a new method in the DAO and service layer was created to just return moto payments
- Follow up PR will address tests for DAO, service layer and validation