### PR TITLE
PP-6076 Return moto flag in transaction searches

### DIFF
--- a/src/main/java/uk/gov/pay/ledger/transaction/dao/TransactionDao.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/dao/TransactionDao.java
@@ -42,7 +42,8 @@ public class TransactionDao {
             " parent.refund_amount_refunded as parent_refund_amount_refunded," +
             " parent.refund_amount_available as parent_refund_amount_available, " +
             " parent.fee as parent_fee," +
-            " parent.type as parent_type " +
+            " parent.type as parent_type, " +
+            " parent.moto as parent_moto " +
             " FROM transaction t LEFT OUTER JOIN transaction parent " +
             " ON t.parent_external_id = parent.external_id ";
 

--- a/src/main/java/uk/gov/pay/ledger/transaction/dao/mapper/TransactionWithParentMapper.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/dao/mapper/TransactionWithParentMapper.java
@@ -42,6 +42,7 @@ public class TransactionWithParentMapper implements RowMapper<TransactionEntity>
                 .withFee(getLongWithNullCheck(rs, "parent_fee"))
                 .withTransactionType(rs.getString("parent_type"))
                 .withLive(rs.getBoolean("live"))
+                .withMoto(rs.getBoolean("parent_moto"))
                 .build();
 
         return new TransactionEntity.Builder()
@@ -69,6 +70,7 @@ public class TransactionWithParentMapper implements RowMapper<TransactionEntity>
                 .withFee(getLongWithNullCheck(rs, "fee"))
                 .withTransactionType(rs.getString("type"))
                 .withLive(rs.getBoolean("live"))
+                .withMoto(rs.getBoolean("moto"))
                 .withParentTransactionEntity(parentTransactionEntity)
                 .build();
     }

--- a/src/test/java/uk/gov/pay/ledger/transaction/dao/TransactionDaoSearchIT.java
+++ b/src/test/java/uk/gov/pay/ledger/transaction/dao/TransactionDaoSearchIT.java
@@ -21,7 +21,7 @@ import java.util.List;
 import static java.time.ZonedDateTime.now;
 import static org.apache.commons.lang3.RandomUtils.nextLong;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static uk.gov.pay.ledger.util.DatabaseTestHelper.aDatabaseTestHelper;
 import static uk.gov.pay.ledger.util.fixture.TransactionFixture.aTransactionFixture;
@@ -49,6 +49,7 @@ public class TransactionDaoSearchIT {
 
         transactionFixture = aTransactionFixture()
                 .withDefaultCardDetails()
+                .withMoto(true)
                 .insert(rule.getJdbi());
 
         searchParams.setAccountId(transactionFixture.getGatewayAccountId());
@@ -69,6 +70,7 @@ public class TransactionDaoSearchIT {
         assertThat(transaction.getCardholderName(), is(transactionFixture.getCardDetails().getCardHolderName()));
         assertThat(transaction.getCardBrand(), is(transactionFixture.getCardDetails().getCardBrand()));
         assertThat(transaction.getCreatedDate(), is(transactionFixture.getCreatedDate()));
+        assertThat(transaction.isMoto(), is(transactionFixture.isMoto()));
 
         Long total = transactionDao.getTotalForSearch(searchParams);
         assertThat(total, is(1L));
@@ -894,12 +896,14 @@ public class TransactionDaoSearchIT {
         assertThat(actualTransactionEntity.getCardBrand(), is(transactionFixture.getCardBrand()));
         assertThat(actualTransactionEntity.getLastDigitsCardNumber(), is(transactionFixture.getLastDigitsCardNumber()));
         assertThat(actualTransactionEntity.getFirstDigitsCardNumber(), is(transactionFixture.getFirstDigitsCardNumber()));
+        assertThat(actualTransactionEntity.isMoto(), is(transactionFixture.isMoto()));
     }
 
     private TransactionFixture insertTransaction() {
         return aTransactionFixture()
                 .withState(TransactionState.CREATED)
                 .withDefaultCardDetails()
+                .withMoto(true)
                 .insert(rule.getJdbi());
     }
 

--- a/src/test/java/uk/gov/pay/ledger/util/fixture/TransactionFixture.java
+++ b/src/test/java/uk/gov/pay/ledger/util/fixture/TransactionFixture.java
@@ -225,7 +225,7 @@ public class TransactionFixture implements DbFixture<TransactionFixture, Transac
         return this;
     }
 
-    public boolean getMoto() { return moto;}
+    public boolean isMoto() { return moto;}
 
     public TransactionFixture withMoto(boolean moto) {
         this.moto = moto;


### PR DESCRIPTION
Include the moto flag on a transaction in the results for transaction searches so that it can be included in CSVs