### PR TITLE
PP-6076 Use "moto" value of payment for refunds in CSV

### DIFF
--- a/src/main/java/uk/gov/pay/ledger/transaction/model/CsvTransactionFactory.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/model/CsvTransactionFactory.java
@@ -109,7 +109,6 @@ public class CsvTransactionFactory {
             result.put(FIELD_CORPORATE_CARD_SURCHARGE, penceToCurrency(
                     Optional.ofNullable(safeGetAsLong(transactionDetails, "corporate_surcharge")).orElse(0L)
             ));
-            result.put(FIELD_MOTO, transactionEntity.isMoto());
 
             if (transactionEntity.getState() != null) {
                 ExternalTransactionState state = ExternalTransactionState.from(transactionEntity.getState(), 2);
@@ -148,6 +147,7 @@ public class CsvTransactionFactory {
         result.put(FIELD_CARD_EXPIRY_DATE, safeGetAsString(transactionDetails, "expiry_date"));
         result.put(FIELD_PROVIDER_ID, safeGetAsString(transactionDetails, "gateway_transaction_id"));
         result.put(FIELD_CARD_TYPE, StringUtils.lowerCase(safeGetAsString(transactionDetails, "card_type")));
+        result.put(FIELD_MOTO, transactionEntity.isMoto());
 
         result.put(FIELD_WALLET_TYPE, capitalizeFully(
                 replaceChars(safeGetAsString(transactionDetails, "wallet"), '_', ' '))

--- a/src/test/java/uk/gov/pay/ledger/transaction/model/CsvTransactionFactoryTest.java
+++ b/src/test/java/uk/gov/pay/ledger/transaction/model/CsvTransactionFactoryTest.java
@@ -72,7 +72,9 @@ public class CsvTransactionFactoryTest {
     @Test
     public void toMapShouldReturnMapWithCorrectCsvDataForRefundTransaction() {
 
-        TransactionEntity transactionEntity = transactionFixture.toEntity();
+        TransactionEntity transactionEntity = transactionFixture
+                .withMoto(true)
+                .toEntity();
         TransactionEntity refundTransactionEntity = transactionFixture.withTransactionType("REFUND")
                 .withAmount(99L)
                 .withTotalAmount(99L)
@@ -95,6 +97,7 @@ public class CsvTransactionFactoryTest {
         assertThat(csvDataMap.get("Corporate Card Surcharge"), is("0.00"));
         assertThat(csvDataMap.get("Total Amount"), is("-0.99"));
         assertThat(csvDataMap.get("Net"), is("-0.99"));
+        assertThat(csvDataMap.get("MOTO"), is(true));
     }
 
     @Test


### PR DESCRIPTION
For refund line items in the CSV, use whether the parent payment is moto
or not to populate the "MOTO" column for refunds.