### PR TITLE
PP-6076 Drop default for moto column

### DIFF
--- a/src/main/resources/migrations/00039_drop_default_for_transaction_moto_column.sql
+++ b/src/main/resources/migrations/00039_drop_default_for_transaction_moto_column.sql
@@ -1,0 +1,3 @@
+--changeset uk.gov.pay:drop_default_value_moto_column
+
+ALTER TABLE transaction ALTER COLUMN moto DROP DEFAULT;


### PR DESCRIPTION
Drop the default value, as the ledger convention is that columns do not have a value until connector sends an event containing the data to populate it.