### PR TITLE
PP-6184 Add new endpoint for get transaction by gateway_transaction_id

### DIFF
--- a/src/main/java/uk/gov/pay/ledger/transaction/resource/TransactionResource.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/resource/TransactionResource.java
@@ -179,4 +179,14 @@ public class TransactionResource {
 
         return transactionService.getTransactions(parentTransactionExternalId, gatewayAccountId);
     }
+
+    @Path("/gateway-transaction/{gatewayTransactionId}")
+    @GET
+    @Timed
+    public TransactionView findByGatewayTransactionId(@PathParam("gatewayTransactionId") String gatewayTransactionId,
+                                                      @QueryParam("payment_provider") @NotEmpty String paymentProvider
+                                                      ) {
+        return transactionService.findByGatewayTransactionId(gatewayTransactionId, paymentProvider)
+                .orElseThrow(() -> new WebApplicationException(Response.Status.NOT_FOUND));
+    }
 }

--- a/src/main/java/uk/gov/pay/ledger/transaction/search/common/TransactionSearchParams.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/search/common/TransactionSearchParams.java
@@ -31,6 +31,7 @@ public class TransactionSearchParams {
     private static final String CARD_BRAND_FIELD = "card_brand";
     private static final String STATE_FIELD = "state";
     private static final String TRANSACTION_TYPE_FIELD = "transaction_type";
+    private static final String GATEWAY_TRANSACTION_ID_FIELD = "gateway_transaction_id";
     private static final long DEFAULT_PAGE_NUMBER = 1L;
     private static final long DEFAULT_MAX_DISPLAY_SIZE = 500L;
 
@@ -77,6 +78,7 @@ public class TransactionSearchParams {
     @QueryParam("display_size")
     private Long displaySize = DEFAULT_MAX_DISPLAY_SIZE;
     private Map<String, Object> queryMap;
+    private String gatewayTransactionId;
 
     public void setAccountId(String accountId) {
         this.accountId = accountId;
@@ -174,6 +176,9 @@ public class TransactionSearchParams {
         }
         if (isNotBlank(lastDigitsCardNumber)) {
             filters.add(" t.last_digits_card_number = :" + LAST_DIGITS_CARD_NUMBER_FIELD);
+        }
+        if (isNotBlank(gatewayTransactionId)) {
+            filters.add(" t.gateway_transaction_id = :" + GATEWAY_TRANSACTION_ID_FIELD);
         }
 
         return List.copyOf(filters);
@@ -290,6 +295,9 @@ public class TransactionSearchParams {
             }
             if (transactionType != null) {
                 queryMap.put(TRANSACTION_TYPE_FIELD, transactionType);
+            }
+            if (gatewayTransactionId != null) {
+                queryMap.put(GATEWAY_TRANSACTION_ID_FIELD, gatewayTransactionId);
             }
         }
         return queryMap;
@@ -434,5 +442,9 @@ public class TransactionSearchParams {
 
     public void setExactReferenceMatch(boolean exactReferenceMatch) {
         this.exactReferenceMatch = exactReferenceMatch;
+    }
+
+    public void setGatewayTransactionId(String gatewayTransactionId) {
+        this.gatewayTransactionId = gatewayTransactionId;
     }
 }

--- a/src/main/java/uk/gov/pay/ledger/transaction/service/TransactionService.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/service/TransactionService.java
@@ -36,6 +36,7 @@ import java.util.stream.Collectors;
 
 import static java.lang.String.format;
 import static java.util.stream.Collectors.groupingBy;
+import static uk.gov.pay.ledger.transaction.model.TransactionType.PAYMENT;
 
 public class TransactionService {
 
@@ -177,6 +178,20 @@ public class TransactionService {
         } else {
             return TransactionEventResponse.of(externalId, removeDuplicates(transactionEvents));
         }
+    }
+
+    public Optional<TransactionView> findByGatewayTransactionId(String gatewayTransactionId, String paymentProvider
+                                                                ) {
+        TransactionSearchParams searchParams = new TransactionSearchParams();
+        searchParams.setGatewayTransactionId(gatewayTransactionId);
+        searchParams.setTransactionType(PAYMENT);
+
+        return transactionDao.searchTransactions(searchParams)
+                .stream()
+                .map(transactionEntity ->
+                        TransactionView.from(transactionFactory.createTransactionEntity(transactionEntity), DEFAULT_STATUS_VERSION))
+                .filter(transaction -> paymentProvider.equalsIgnoreCase(transaction.getPaymentProvider()))
+                .findFirst();
     }
 
     private Map<String, TransactionEntity> getTransactionsAsMap(String externalId, String gatewayAccountId) {

--- a/src/test/java/uk/gov/pay/ledger/transaction/dao/TransactionDaoSearchIT.java
+++ b/src/test/java/uk/gov/pay/ledger/transaction/dao/TransactionDaoSearchIT.java
@@ -489,6 +489,32 @@ public class TransactionDaoSearchIT {
     }
 
     @Test
+    public void shouldFilterByGatewayTransactionIdWhenSpecified() {
+        String gatewayAccountId = "account-id-" + nextLong();
+        String gatewayTransactionId = "transaction-id-" + nextLong();
+
+        TransactionFixture transaction = aTransactionFixture()
+                .withGatewayAccountId(gatewayAccountId)
+                .withGatewayTransactionId(gatewayTransactionId)
+                .withTransactionType("PAYMENT")
+                .insert(rule.getJdbi());
+
+        aTransactionFixture()
+                .withGatewayAccountId(gatewayAccountId)
+                .withGatewayTransactionId(gatewayTransactionId + "different-id")
+                .withTransactionType("PAYMENT")
+                .insert(rule.getJdbi());
+        TransactionSearchParams searchParams = new TransactionSearchParams();
+        searchParams.setGatewayTransactionId(gatewayTransactionId);
+
+        List<TransactionEntity> transactionList = transactionDao.searchTransactions(searchParams);
+
+        assertThat(transactionList.size(), Matchers.is(1));
+        assertThat(transactionList.get(0).getExternalId(), is(transaction.getExternalId()));
+        assertThat(transactionList.get(0).getGatewayTransactionId(), is(transaction.getGatewayTransactionId()));
+    }
+
+    @Test
     public void shouldNotFilterByGatewayAccountIdWhenNotSpecified() {
         String gatewayAccountId = "account-id-" + nextLong();
 


### PR DESCRIPTION
## WHAT 
- Added new endpoint (`v1/transaction/gateway-transaction/{gatewayTransactionId}`) to find
  a transaction by gateway_transaction_id (payment provider reference) and payment provider.
  This is needed to handle refund notifications (which need charge details to send confirmation
  email and also gateway_account info) in connector for expunged charges
- Relevant tests