### PR TITLE
PP-6163 Search For Multiple Gateway Accounts

### DIFF
--- a/src/main/java/uk/gov/pay/ledger/transaction/search/common/TransactionSearchParams.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/search/common/TransactionSearchParams.java
@@ -46,7 +46,7 @@ public class TransactionSearchParams {
     @DefaultValue("false")
     @QueryParam("with_parent_transaction")
     private boolean withParentTransaction;
-    private String accountId;
+    private List<String> accountIds;
     @QueryParam("email")
     private String email;
     @QueryParam("reference")
@@ -80,8 +80,8 @@ public class TransactionSearchParams {
     private Map<String, Object> queryMap;
     private String gatewayTransactionId;
 
-    public void setAccountId(String accountId) {
-        this.accountId = accountId;
+    public void setAccountIds(List<String> accountIds) {
+        this.accountIds = List.copyOf(accountIds);
     }
 
     public void setEmail(String email) {
@@ -221,8 +221,8 @@ public class TransactionSearchParams {
 
     private void addCommonFilterTemplates(List<String> filters) {
 
-        if (isNotBlank(accountId)) {
-            filters.add(" t.gateway_account_id = :" + GATEWAY_ACCOUNT_EXTERNAL_FIELD);
+        if (accountIds != null && !accountIds.isEmpty()) {
+            filters.add(" t.gateway_account_id IN (<" + GATEWAY_ACCOUNT_EXTERNAL_FIELD + ">)");
         }
         if (transactionType != null) {
             filters.add(" t.type = :" + TRANSACTION_TYPE_FIELD + "::transaction_type");
@@ -249,8 +249,8 @@ public class TransactionSearchParams {
         if (queryMap == null) {
             queryMap = new HashMap<>();
 
-            if (isNotBlank(accountId)) {
-                queryMap.put(GATEWAY_ACCOUNT_EXTERNAL_FIELD, accountId);
+            if (accountIds != null && !accountIds.isEmpty()) {
+                queryMap.put(GATEWAY_ACCOUNT_EXTERNAL_FIELD, accountIds);
             }
 
             if (isNotBlank(email)) {
@@ -309,8 +309,8 @@ public class TransactionSearchParams {
                 TransactionState.getStatesForOldStatus(status);
     }
 
-    public String getAccountId() {
-        return accountId;
+    public List<String> getAccountIds() {
+        return accountIds;
     }
 
     public Long getPageNumber() {
@@ -348,8 +348,8 @@ public class TransactionSearchParams {
     public String buildQueryParamString(Long forPage) {
         List<String> queries = new ArrayList<>();
 
-        if (isNotBlank(accountId)) {
-            queries.add(GATEWAY_ACCOUNT_EXTERNAL_FIELD + "=" + accountId);
+        if (accountIds != null && !accountIds.isEmpty()) {
+            queries.add(GATEWAY_ACCOUNT_EXTERNAL_FIELD + "=" + String.join(",", accountIds));
         }
         if (isNotBlank(fromDate)) {
             queries.add(FROM_DATE_FIELD + "=" + fromDate);

--- a/src/main/java/uk/gov/pay/ledger/transaction/search/common/TransactionSearchParamsValidator.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/search/common/TransactionSearchParamsValidator.java
@@ -6,22 +6,20 @@ import uk.gov.pay.ledger.exception.ValidationException;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeParseException;
 
-import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
 public class TransactionSearchParamsValidator {
     private static final String FROM_DATE_FIELD = "from_date";
     private static final String TO_DATE_FIELD = "to_date";
 
-    public static void validateSearchParams(TransactionSearchParams searchParams, String gatewayAccountId) {
+    public static void validateSearchParams(TransactionSearchParams searchParams, CommaDelimitedSetParameter gatewayAccountIds) {
         if (isNotBlank(searchParams.getFromDate())) {
             validateDate(FROM_DATE_FIELD, searchParams.getFromDate());
         }
         if (isNotBlank(searchParams.getToDate())) {
             validateDate(TO_DATE_FIELD, searchParams.getToDate());
         }
-
-        if(searchParams.getWithParentTransaction() && isBlank(gatewayAccountId)){
+        if(searchParams.getWithParentTransaction() && gatewayAccountIds.getParameters().isEmpty()){
             throw new ValidationException("gateway_account_id is mandatory to search with parent transaction");
         }
     }

--- a/src/main/java/uk/gov/pay/ledger/transaction/service/AccountIdListSupplierManager.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/service/AccountIdListSupplierManager.java
@@ -1,0 +1,52 @@
+package uk.gov.pay.ledger.transaction.service;
+
+import uk.gov.pay.ledger.exception.ValidationException;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+import static java.lang.String.format;
+
+public class AccountIdListSupplierManager<T> {
+
+    private static final String ACCOUNT_ID = "account_id";
+
+    private final boolean overrideAccountRestriction;
+    private final List<String> gatewayAccountIds;
+
+    private Supplier<T> privilegedSupplier;
+    private Function<List<String>, T> supplier;
+
+    public AccountIdListSupplierManager(Boolean overrideAccountRestriction, List<String> gatewayAccountIds) {
+        this.overrideAccountRestriction = Optional.ofNullable(overrideAccountRestriction).orElse(false);
+        this.gatewayAccountIds = gatewayAccountIds != null ? gatewayAccountIds : List.of();
+    }
+
+    public static <U> AccountIdListSupplierManager<U> of(Boolean overrideAccountRestriction, List<String> gatewayAccountIds) {
+        return new AccountIdListSupplierManager<>(overrideAccountRestriction, gatewayAccountIds);
+    }
+
+    public AccountIdListSupplierManager<T> withPrivilegedSupplier(Supplier<T> supplier) {
+        this.privilegedSupplier = supplier;
+        return this;
+    }
+
+    public AccountIdListSupplierManager<T> withSupplier(Function<List<String>, T> supplier) {
+        this.supplier = supplier;
+        return this;
+    }
+
+    public T validateAndGet() {
+        if (!overrideAccountRestriction && gatewayAccountIds.isEmpty()) {
+            throw new ValidationException(format("Field [%s] cannot be empty", ACCOUNT_ID));
+        }
+
+        if (gatewayAccountIds.isEmpty()) {
+            return privilegedSupplier.get();
+        }
+
+        return supplier.apply(gatewayAccountIds);
+    }
+}

--- a/src/main/java/uk/gov/pay/ledger/transaction/service/TransactionService.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/service/TransactionService.java
@@ -2,7 +2,6 @@ package uk.gov.pay.ledger.transaction.service;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.inject.Inject;
-import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.pay.ledger.event.dao.EventDao;
@@ -85,12 +84,13 @@ public class TransactionService {
     }
 
     public TransactionSearchResponse searchTransactions(TransactionSearchParams searchParams, UriInfo uriInfo) {
-        return searchTransactions(null, searchParams, uriInfo);
+        return searchTransactions(List.of(), searchParams, uriInfo);
     }
 
-    public TransactionSearchResponse searchTransactions(String gatewayAccountId, TransactionSearchParams searchParams, UriInfo uriInfo) {
-        if (StringUtils.isNotBlank(gatewayAccountId)) {
-            searchParams.setAccountId(gatewayAccountId);
+    public TransactionSearchResponse searchTransactions(List<String> gatewayAccountIds,
+                                                        TransactionSearchParams searchParams, UriInfo uriInfo) {
+        if (!gatewayAccountIds.isEmpty()) {
+            searchParams.setAccountIds(gatewayAccountIds);
         }
 
         if (searchParams.getWithParentTransaction()) {

--- a/src/test/java/uk/gov/pay/ledger/transaction/dao/TransactionDaoSearchIT.java
+++ b/src/test/java/uk/gov/pay/ledger/transaction/dao/TransactionDaoSearchIT.java
@@ -52,7 +52,7 @@ public class TransactionDaoSearchIT {
                 .withMoto(true)
                 .insert(rule.getJdbi());
 
-        searchParams.setAccountId(transactionFixture.getGatewayAccountId());
+        searchParams.setAccountIds(List.of(transactionFixture.getGatewayAccountId()));
 
         List<TransactionEntity> transactionList = transactionDao.searchTransactions(searchParams);
 
@@ -89,7 +89,7 @@ public class TransactionDaoSearchIT {
                 .insert(rule.getJdbi());
 
         TransactionSearchParams searchParams = new TransactionSearchParams();
-        searchParams.setAccountId(gatewayAccountId);
+        searchParams.setAccountIds(List.of(gatewayAccountId));
 
         List<TransactionEntity> transactionList = transactionDao.searchTransactions(searchParams);
 
@@ -113,7 +113,7 @@ public class TransactionDaoSearchIT {
         }
 
         TransactionSearchParams searchParams = new TransactionSearchParams();
-        searchParams.setAccountId(gatewayAccountId);
+        searchParams.setAccountIds(List.of(gatewayAccountId));
         searchParams.setEmail("testemail1");
 
         List<TransactionEntity> transactionList = transactionDao.searchTransactions(searchParams);
@@ -140,7 +140,7 @@ public class TransactionDaoSearchIT {
         }
 
         TransactionSearchParams searchParams = new TransactionSearchParams();
-        searchParams.setAccountId(gatewayAccountId);
+        searchParams.setAccountIds(List.of(gatewayAccountId));
         searchParams.setExactReferenceMatch(true);
         searchParams.setReference("reference 1");
 
@@ -168,7 +168,7 @@ public class TransactionDaoSearchIT {
         }
 
         TransactionSearchParams searchParams = new TransactionSearchParams();
-        searchParams.setAccountId(gatewayAccountId);
+        searchParams.setAccountIds(List.of(gatewayAccountId));
         searchParams.setExactReferenceMatch(false);
         searchParams.setReference("1");
 
@@ -197,7 +197,7 @@ public class TransactionDaoSearchIT {
         }
 
         TransactionSearchParams searchParams = new TransactionSearchParams();
-        searchParams.setAccountId(gatewayAccountId);
+        searchParams.setAccountIds(List.of(gatewayAccountId));
         searchParams.setCardHolderName("name1");
 
         List<TransactionEntity> transactionList = transactionDao.searchTransactions(searchParams);
@@ -222,7 +222,7 @@ public class TransactionDaoSearchIT {
         }
 
         TransactionSearchParams searchParams = new TransactionSearchParams();
-        searchParams.setAccountId(gatewayAccountId);
+        searchParams.setAccountIds(List.of(gatewayAccountId));
         searchParams.setFromDate(now().minusDays(1).minusMinutes(10).toString());
 
         List<TransactionEntity> transactionList = transactionDao.searchTransactions(searchParams);
@@ -245,7 +245,7 @@ public class TransactionDaoSearchIT {
         }
 
         TransactionSearchParams searchParams = new TransactionSearchParams();
-        searchParams.setAccountId(gatewayAccountId);
+        searchParams.setAccountIds(List.of(gatewayAccountId));
         searchParams.setToDate(now().minusDays(2).plusMinutes(10).toString());
 
         List<TransactionEntity> transactionList = transactionDao.searchTransactions(searchParams);
@@ -267,7 +267,7 @@ public class TransactionDaoSearchIT {
         }
 
         TransactionSearchParams searchParams = new TransactionSearchParams();
-        searchParams.setAccountId(gatewayAccountId);
+        searchParams.setAccountIds(List.of(gatewayAccountId));
         searchParams.setDisplaySize(10L);
 
         List<TransactionEntity> transactionList = transactionDao.searchTransactions(searchParams);
@@ -292,7 +292,7 @@ public class TransactionDaoSearchIT {
         }
 
         TransactionSearchParams searchParams = new TransactionSearchParams();
-        searchParams.setAccountId(gatewayAccountId);
+        searchParams.setAccountIds(List.of(gatewayAccountId));
         searchParams.setDisplaySize(2L);
         searchParams.setPageNumber(3L);
 
@@ -324,7 +324,7 @@ public class TransactionDaoSearchIT {
 
 
         TransactionSearchParams searchParams = new TransactionSearchParams();
-        searchParams.setAccountId(gatewayAccountId);
+        searchParams.setAccountIds(List.of(gatewayAccountId));
         searchParams.setState("created");
 
         List<TransactionEntity> transactionList = transactionDao.searchTransactions(searchParams);
@@ -346,7 +346,7 @@ public class TransactionDaoSearchIT {
                     .insert(rule.getJdbi());
         }
         TransactionSearchParams searchParams = new TransactionSearchParams();
-        searchParams.setAccountId(gatewayAccountId);
+        searchParams.setAccountIds(List.of(gatewayAccountId));
         searchParams.setLastDigitsCardNumber("1234");
 
         List<TransactionEntity> transactionList = transactionDao.searchTransactions(searchParams);
@@ -365,7 +365,7 @@ public class TransactionDaoSearchIT {
                     .insert(rule.getJdbi());
         }
         TransactionSearchParams searchParams = new TransactionSearchParams();
-        searchParams.setAccountId(gatewayAccountId);
+        searchParams.setAccountIds(List.of(gatewayAccountId));
         searchParams.setFirstDigitsCardNumber("123456");
 
         List<TransactionEntity> transactionList = transactionDao.searchTransactions(searchParams);
@@ -384,7 +384,7 @@ public class TransactionDaoSearchIT {
                     .insert(rule.getJdbi());
         }
         TransactionSearchParams searchParams = new TransactionSearchParams();
-        searchParams.setAccountId(gatewayAccountId);
+        searchParams.setAccountIds(List.of(gatewayAccountId));
         searchParams.setCardBrands(new CommaDelimitedSetParameter("visa,mastercard"));
         List<TransactionEntity> transactionList = transactionDao.searchTransactions(searchParams);
 
@@ -402,7 +402,7 @@ public class TransactionDaoSearchIT {
                     .insert(rule.getJdbi());
         }
         TransactionSearchParams searchParams = new TransactionSearchParams();
-        searchParams.setAccountId(gatewayAccountId);
+        searchParams.setAccountIds(List.of(gatewayAccountId));
         searchParams.setCardBrands(new CommaDelimitedSetParameter("visa"));
         List<TransactionEntity> transactionList = transactionDao.searchTransactions(searchParams);
 
@@ -420,7 +420,7 @@ public class TransactionDaoSearchIT {
                     .insert(rule.getJdbi());
         }
         TransactionSearchParams searchParams = new TransactionSearchParams();
-        searchParams.setAccountId(gatewayAccountId);
+        searchParams.setAccountIds(List.of(gatewayAccountId));
         searchParams.setCardHolderName("smith");
 
         List<TransactionEntity> transactionList = transactionDao.searchTransactions(searchParams);
@@ -439,7 +439,7 @@ public class TransactionDaoSearchIT {
                     .insert(rule.getJdbi());
         }
         TransactionSearchParams searchParams = new TransactionSearchParams();
-        searchParams.setAccountId(gatewayAccountId);
+        searchParams.setAccountIds(List.of(gatewayAccountId));
         searchParams.setTransactionType(TransactionType.REFUND);
 
         List<TransactionEntity> transactionList = transactionDao.searchTransactions(searchParams);
@@ -459,7 +459,7 @@ public class TransactionDaoSearchIT {
                     .insert(rule.getJdbi());
         }
         TransactionSearchParams searchParams = new TransactionSearchParams();
-        searchParams.setAccountId(gatewayAccountId);
+        searchParams.setAccountIds(List.of(gatewayAccountId));
 
         List<TransactionEntity> transactionList = transactionDao.searchTransactions(searchParams);
 
@@ -480,7 +480,7 @@ public class TransactionDaoSearchIT {
                 .withTransactionType("PAYMENT")
                 .insert(rule.getJdbi());
         TransactionSearchParams searchParams = new TransactionSearchParams();
-        searchParams.setAccountId(gatewayAccountId);
+        searchParams.setAccountIds(List.of(gatewayAccountId));
 
         List<TransactionEntity> transactionList = transactionDao.searchTransactions(searchParams);
 
@@ -545,7 +545,7 @@ public class TransactionDaoSearchIT {
                 now(ZoneOffset.UTC).plusDays(1));
         TransactionFixture transactionThatShouldBeExcluded = insertTransaction();
 
-        searchParams.setAccountId(transactionFixture.getGatewayAccountId());
+        searchParams.setAccountIds(List.of(transactionFixture.getGatewayAccountId()));
         List<TransactionEntity> transactionList = transactionDao.searchTransactionsAndParent(searchParams);
         assertThat(transactionList.size(), is(2));
 
@@ -566,7 +566,7 @@ public class TransactionDaoSearchIT {
                 now(ZoneOffset.UTC).plusDays(1));
 
         TransactionSearchParams searchParams = new TransactionSearchParams();
-        searchParams.setAccountId(transactionFixture.getGatewayAccountId());
+        searchParams.setAccountIds(List.of(transactionFixture.getGatewayAccountId()));
         searchParams.setEmail("test");
 
         List<TransactionEntity> transactionList = transactionDao.searchTransactionsAndParent(searchParams);
@@ -588,7 +588,7 @@ public class TransactionDaoSearchIT {
         TransactionFixture transactionFixtureChild = insertRefundChildTransaction(transactionFixture,
                 now(ZoneOffset.UTC).plusDays(1));
 
-        searchParams.setAccountId(transactionFixture.getGatewayAccountId());
+        searchParams.setAccountIds(List.of(transactionFixture.getGatewayAccountId()));
         searchParams.setReference("ref");
         List<TransactionEntity> transactionList = transactionDao.searchTransactionsAndParent(searchParams);
         assertThat(transactionList.size(), is(2));
@@ -613,7 +613,7 @@ public class TransactionDaoSearchIT {
                 .withGatewayAccountId(transactionFixture.getGatewayAccountId())
                 .insert(rule.getJdbi());
 
-        searchParams.setAccountId(transactionFixture.getGatewayAccountId());
+        searchParams.setAccountIds(List.of(transactionFixture.getGatewayAccountId()));
         searchParams.setExactReferenceMatch(true);
         searchParams.setReference("reference");
         List<TransactionEntity> transactionList = transactionDao.searchTransactionsAndParent(searchParams);
@@ -635,7 +635,7 @@ public class TransactionDaoSearchIT {
         TransactionFixture transactionFixtureChild = insertRefundChildTransaction(transactionFixture,
                 now(ZoneOffset.UTC).plusDays(1));
 
-        searchParams.setAccountId(transactionFixture.getGatewayAccountId());
+        searchParams.setAccountIds(List.of(transactionFixture.getGatewayAccountId()));
         searchParams.setCardHolderName("mr");
         List<TransactionEntity> transactionList = transactionDao.searchTransactionsAndParent(searchParams);
         assertThat(transactionList.size(), is(2));
@@ -656,7 +656,7 @@ public class TransactionDaoSearchIT {
         TransactionFixture transactionFixtureChild = insertRefundChildTransaction(transactionFixture,
                 now(ZoneOffset.UTC).plusDays(1));
 
-        searchParams.setAccountId(transactionFixture.getGatewayAccountId());
+        searchParams.setAccountIds(List.of(transactionFixture.getGatewayAccountId()));
         searchParams.setLastDigitsCardNumber("4242");
         List<TransactionEntity> transactionList = transactionDao.searchTransactionsAndParent(searchParams);
         assertThat(transactionList.size(), is(2));
@@ -677,7 +677,7 @@ public class TransactionDaoSearchIT {
         TransactionFixture transactionFixtureChild = insertRefundChildTransaction(transactionFixture,
                 now(ZoneOffset.UTC).plusDays(2));
 
-        searchParams.setAccountId(transactionFixture.getGatewayAccountId());
+        searchParams.setAccountIds(List.of(transactionFixture.getGatewayAccountId()));
         searchParams.setCardBrands(new CommaDelimitedSetParameter("visa"));
 
         List<TransactionEntity> transactionList = transactionDao.searchTransactionsAndParent(searchParams);
@@ -698,7 +698,7 @@ public class TransactionDaoSearchIT {
         TransactionFixture transactionFixtureChild = insertRefundChildTransaction(transactionFixture,
                 now(ZoneOffset.UTC).plusDays(1));
 
-        searchParams.setAccountId(transactionFixture.getGatewayAccountId());
+        searchParams.setAccountIds(List.of(transactionFixture.getGatewayAccountId()));
         searchParams.setFromDate(now(ZoneOffset.UTC).toString());
         List<TransactionEntity> transactionList = transactionDao.searchTransactionsAndParent(searchParams);
         assertThat(transactionList.size(), is(1));
@@ -717,7 +717,7 @@ public class TransactionDaoSearchIT {
                 .insert(rule.getJdbi());
         insertRefundChildTransaction(transactionFixture, now(ZoneOffset.UTC).plusDays(1));
 
-        searchParams.setAccountId(transactionFixture.getGatewayAccountId());
+        searchParams.setAccountIds(List.of(transactionFixture.getGatewayAccountId()));
         searchParams.setToDate(now(ZoneOffset.UTC).toString());
         List<TransactionEntity> transactionList = transactionDao.searchTransactionsAndParent(searchParams);
         assertThat(transactionList.size(), is(1));
@@ -738,7 +738,7 @@ public class TransactionDaoSearchIT {
                     .insert(rule.getJdbi());
         }
 
-        searchParams.setAccountId(gatewayAccountId);
+        searchParams.setAccountIds(List.of(gatewayAccountId));
         searchParams.setDisplaySize(10L);
 
         List<TransactionEntity> transactionList = transactionDao.searchTransactionsAndParent(searchParams);
@@ -759,7 +759,7 @@ public class TransactionDaoSearchIT {
                 .insert(rule.getJdbi());
 
         TransactionSearchParams searchParams = new TransactionSearchParams();
-        searchParams.setAccountId(transactionFixture.getGatewayAccountId());
+        searchParams.setAccountIds(List.of(transactionFixture.getGatewayAccountId()));
         searchParams.setDisplaySize(1L);
         searchParams.setPageNumber(2L);
 
@@ -781,7 +781,7 @@ public class TransactionDaoSearchIT {
         insertRefundChildTransaction(transactionFixture, now(ZoneOffset.UTC).plusDays(2));
 
         TransactionSearchParams searchParams = new TransactionSearchParams();
-        searchParams.setAccountId(transactionFixture.getGatewayAccountId());
+        searchParams.setAccountIds(List.of(transactionFixture.getGatewayAccountId()));
         searchParams.setPaymentStates(new CommaDelimitedSetParameter("created"));
 
         List<TransactionEntity> transactionList = transactionDao.searchTransactionsAndParent(searchParams);
@@ -801,7 +801,7 @@ public class TransactionDaoSearchIT {
         TransactionFixture transactionFixtureChild = insertRefundChildTransaction(transactionFixture,
                 now(ZoneOffset.UTC).plusDays(2));
 
-        searchParams.setAccountId(transactionFixture.getGatewayAccountId());
+        searchParams.setAccountIds(List.of(transactionFixture.getGatewayAccountId()));
         searchParams.setRefundStates(new CommaDelimitedSetParameter("created"));
 
         List<TransactionEntity> transactionList = transactionDao.searchTransactionsAndParent(searchParams);
@@ -819,7 +819,7 @@ public class TransactionDaoSearchIT {
                 .insert(rule.getJdbi());
         insertRefundChildTransaction(transactionFixture, now(ZoneOffset.UTC).plusDays(2));
 
-        searchParams.setAccountId(transactionFixture.getGatewayAccountId());
+        searchParams.setAccountIds(List.of(transactionFixture.getGatewayAccountId()));
         searchParams.setFirstDigitsCardNumber("424242");
 
         List<TransactionEntity> transactionList = transactionDao.searchTransactionsAndParent(searchParams);
@@ -843,13 +843,56 @@ public class TransactionDaoSearchIT {
                 .withCreatedDate(now(ZoneOffset.UTC).minusDays(1))
                 .insert(rule.getJdbi());
 
-        searchParams.setAccountId("1");
+        searchParams.setAccountIds(List.of("1"));
 
         List<TransactionEntity> transactionList = transactionDao.cursorTransactionSearch(searchParams, null, null);
 
         assertThat(transactionList.size(), is(2));
     }
 
+    @Test
+    public void searchTransactionsByMultipleGatewayAccounts() {
+        aTransactionFixture()
+                .withGatewayAccountId("1")
+                .withExternalId("ex-1")
+                .withCreatedDate(now(ZoneOffset.UTC).minusDays(1))
+                .insert(rule.getJdbi());
+
+        aTransactionFixture()
+                .withGatewayAccountId("1")
+                .withExternalId("ex-2")
+                .withCreatedDate(now(ZoneOffset.UTC).minusDays(1))
+                .insert(rule.getJdbi());
+
+        aTransactionFixture()
+                .withGatewayAccountId("2")
+                .withExternalId("ex-3")
+                .withCreatedDate(now(ZoneOffset.UTC).minusDays(1))
+                .insert(rule.getJdbi());
+
+        aTransactionFixture()
+                .withGatewayAccountId("1")
+                .withExternalId("ex-4")
+                .withCreatedDate(now(ZoneOffset.UTC).minusDays(1))
+                .insert(rule.getJdbi());
+
+        aTransactionFixture()
+                .withGatewayAccountId("1337")
+                .withExternalId("ex-5")
+                .withCreatedDate(now(ZoneOffset.UTC).minusDays(1))
+                .insert(rule.getJdbi());
+
+        searchParams.setAccountIds(List.of("1","2"));
+
+        var searchParamsList = List.of("ex-1", "ex-2", "ex-3", "ex-4");
+        var doNotIncludeList = List.of("ex-5");
+
+        List<TransactionEntity> transactionList = transactionDao.searchTransactions(searchParams);
+
+        assertThat(transactionList.size(), is(4));
+        assertThat(transactionList.stream().filter(x -> searchParamsList.contains(x.getExternalId())).count(), is(4L));
+        assertThat(transactionList.stream().filter(x -> doNotIncludeList.contains(x.getExternalId())).count(), is(0L));
+    }
     @Test
     public void searchTransactionsByCursor_shouldSplitCursorPages() {
         transactionFixture = aTransactionFixture()
@@ -882,7 +925,7 @@ public class TransactionDaoSearchIT {
                 .withCreatedDate(now(ZoneOffset.UTC).minusDays(6))
                 .insert(rule.getJdbi());
 
-        searchParams.setAccountId("1");
+        searchParams.setAccountIds(List.of("1"));
         searchParams.setDisplaySize(2L);
 
         List<TransactionEntity> firstPage = transactionDao.cursorTransactionSearch(searchParams, null, null);

--- a/src/test/java/uk/gov/pay/ledger/transaction/resource/TransactionResourceSearchIT.java
+++ b/src/test/java/uk/gov/pay/ledger/transaction/resource/TransactionResourceSearchIT.java
@@ -408,4 +408,42 @@ public class TransactionResourceSearchIT {
                 .body("results[1].transaction_id", is(payment.getExternalId()))
                 .body("results[1].parent_transaction", is(nullValue()));
     }
+
+    @Test
+    public void shouldSearchUsingMultipleGatewayAccountIds() {
+        String targetGatewayAccountId = "123";
+        String targetGatewayAccountId2 = "456";
+        String targetGatewayAccountId3 = "1337";
+
+        TransactionFixture targetPayment = aTransactionFixture()
+                .withTransactionType("PAYMENT")
+                .withState(TransactionState.SUBMITTED)
+                .withGatewayAccountId(targetGatewayAccountId)
+                .insert(rule.getJdbi());
+
+        aTransactionFixture()
+                .withTransactionType("PAYMENT")
+                .withState(TransactionState.SUBMITTED)
+                .withGatewayAccountId(targetGatewayAccountId2)
+                .insert(rule.getJdbi());
+
+        aTransactionFixture()
+                .withTransactionType("PAYMENT")
+                .withState(TransactionState.SUBMITTED)
+                .withGatewayAccountId(targetGatewayAccountId3)
+                .insert(rule.getJdbi());
+
+        given().port(port)
+                .contentType(JSON)
+                .accept(JSON)
+                .get("/v1/transaction?" +
+                        "account_id=" + targetGatewayAccountId+ "," + targetGatewayAccountId2+
+                        "&page=1" +
+                        "&display_size=5"
+                )
+                .then()
+                .statusCode(Response.Status.OK.getStatusCode())
+                .contentType(JSON)
+                .body("count", is(2));
+    }
 }

--- a/src/test/java/uk/gov/pay/ledger/transaction/search/common/TransactionSearchParamsTest.java
+++ b/src/test/java/uk/gov/pay/ledger/transaction/search/common/TransactionSearchParamsTest.java
@@ -133,9 +133,9 @@ public class TransactionSearchParamsTest {
 
     @Test
     public void getFilterTemplateWithParentTxnSearch_shouldReturnFilterWithGatewayAccountId() {
-        transactionSearchParams.setAccountId("1");
-        assertThat(transactionSearchParams.getFilterTemplatesWithParentTransactionSearch().get(0), is(" t.gateway_account_id = :account_id"));
-        assertThat(transactionSearchParams.getQueryMap().get("account_id"), is("1"));
+        transactionSearchParams.setAccountIds(List.of("1"));
+        assertThat(transactionSearchParams.getFilterTemplatesWithParentTransactionSearch().get(0), is(" t.gateway_account_id IN (<account_id>)"));
+        assertThat(transactionSearchParams.getQueryMap().get("account_id"), is(List.of("1")));
     }
 
     @Test
@@ -214,13 +214,13 @@ public class TransactionSearchParamsTest {
 
     @Test
     public void getsEmptyQueryParamStringWhenEmptyAccountId() {
-        transactionSearchParams.setAccountId("");
+        transactionSearchParams.setAccountIds(List.of());
         assertThat(transactionSearchParams.buildQueryParamString(1L), not(containsString("account_id")));
     }
 
     @Test
     public void getsQueryParamStringWhenNotEmptyAccountId() {
-        transactionSearchParams.setAccountId("xyz");
+        transactionSearchParams.setAccountIds(List.of("xyz"));
         assertThat(transactionSearchParams.buildQueryParamString(1L), containsString("account_id=xyz"));
     }
 

--- a/src/test/java/uk/gov/pay/ledger/transaction/search/common/TransactionSearchParamsValidatorTest.java
+++ b/src/test/java/uk/gov/pay/ledger/transaction/search/common/TransactionSearchParamsValidatorTest.java
@@ -45,14 +45,20 @@ public class TransactionSearchParamsValidatorTest {
     @Test
     public void shouldNotThrowException_whenGatewayAccountIdAvailableAndWithParentTransactionIsTrue() {
         searchParams.setWithParentTransaction(true);
-        TransactionSearchParamsValidator.validateSearchParams(searchParams,"account-id");
+        TransactionSearchParamsValidator.validateSearchParams(searchParams, new CommaDelimitedSetParameter("account-id"));
     }
 
     @Test
-    public void shouldThrowException_whenGatewayAccountIdIsNotAvailableAndWithParentTransactionIsTrue() {
+    public void shouldNotThrowException_whenGatewayAccountIdsAvailableAndWithParentTransactionIsTrue() {
         searchParams.setWithParentTransaction(true);
         thrown.expect(ValidationException.class);
         thrown.expectMessage("gateway_account_id is mandatory to search with parent transaction");
-        TransactionSearchParamsValidator.validateSearchParams(searchParams,"");
+        TransactionSearchParamsValidator.validateSearchParams(searchParams,new CommaDelimitedSetParameter(""));
+    }
+
+    @Test
+    public void shouldNotThrowException_whenGatewayAccountIdIsNotAvailableAndWithParentTransactionIsTrue() {
+        searchParams.setWithParentTransaction(true);
+        TransactionSearchParamsValidator.validateSearchParams(searchParams,new CommaDelimitedSetParameter("1,2"));
     }
 }

--- a/src/test/java/uk/gov/pay/ledger/transaction/service/AccountIdSupplierManagerTest.java
+++ b/src/test/java/uk/gov/pay/ledger/transaction/service/AccountIdSupplierManagerTest.java
@@ -9,6 +9,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.pay.ledger.exception.ValidationException;
 import uk.gov.pay.ledger.transaction.search.model.TransactionView;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -24,7 +25,7 @@ public class AccountIdSupplierManagerTest {
     public ExpectedException thrown = ExpectedException.none();
 
     @Mock
-    private Function<String, Optional<TransactionView>> supplier;
+    private Function<List<String>, Optional<TransactionView>> supplier;
 
     @Mock
     private Supplier<Optional<TransactionView>> privilegedSupplier;
@@ -42,17 +43,17 @@ public class AccountIdSupplierManagerTest {
 
     @Test
     public void givenAccountIdProvidedWhenRequiredUsesSupplier() {
-        setUpAndGet(null, "some-id");
+        setUpAndGet(null, List.of("some-id"));
 
-        verify(supplier).apply("some-id");
+        verify(supplier).apply(List.of("some-id"));
         verify(privilegedSupplier, never()).get();
     }
 
     @Test
     public void givenAccountIdProvidedWhenNotRequiredUsesSupplier() {
-        setUpAndGet(true, "some-id");
+        setUpAndGet(true, List.of("some-id"));
 
-        verify(supplier).apply("some-id");
+        verify(supplier).apply(List.of("some-id"));
         verify(privilegedSupplier, never()).get();
     }
 
@@ -64,8 +65,8 @@ public class AccountIdSupplierManagerTest {
         verify(privilegedSupplier).get();
     }
 
-    private void setUpAndGet(Boolean overrideAccountRestriction, String gatewayAccountId) {
-        new AccountIdSupplierManager(overrideAccountRestriction, gatewayAccountId)
+    private void setUpAndGet(Boolean overrideAccountRestriction, List<String> gatewayAccountId) {
+        new AccountIdListSupplierManager(overrideAccountRestriction, gatewayAccountId)
                 .withPrivilegedSupplier(privilegedSupplier)
                 .withSupplier(supplier)
                 .validateAndGet();

--- a/src/test/java/uk/gov/pay/ledger/transaction/service/TransactionServiceTest.java
+++ b/src/test/java/uk/gov/pay/ledger/transaction/service/TransactionServiceTest.java
@@ -73,7 +73,7 @@ public class TransactionServiceTest {
         transactionService = new TransactionService(mockTransactionDao, mockEventDao, transactionEntityFactory,
                 transactionFactory, csvTransactionFactory, objectMapper);
         searchParams = new TransactionSearchParams();
-        searchParams.setAccountId(gatewayAccountId);
+        searchParams.setAccountIds(List.of(gatewayAccountId));
 
         when(mockUriInfo.getBaseUriBuilder()).thenReturn(UriBuilder.fromUri("http://app.com"));
         when(mockUriInfo.getPath()).thenReturn("/v1/transaction");
@@ -136,7 +136,7 @@ public class TransactionServiceTest {
         when(mockTransactionDao.searchTransactions(any(TransactionSearchParams.class))).thenReturn(transactionViewList);
         when(mockTransactionDao.getTotalForSearch(any(TransactionSearchParams.class))).thenReturn(100L);
 
-        TransactionSearchResponse transactionSearchResponse = transactionService.searchTransactions(gatewayAccountId, searchParams, mockUriInfo);
+        TransactionSearchResponse transactionSearchResponse = transactionService.searchTransactions(List.of(gatewayAccountId), searchParams, mockUriInfo);
         PaginationBuilder paginationBuilder = transactionSearchResponse.getPaginationBuilder();
 
         assertThat(paginationBuilder.getFirstLink().getHref(), is("http://app.com/v1/transaction?account_id=gateway_account_id&page=1&display_size=10"));
@@ -188,7 +188,7 @@ public class TransactionServiceTest {
         setAllSearchParams();
         searchParams.setWithParentTransaction(true);
 
-        TransactionSearchResponse transactionSearchResponse = transactionService.searchTransactions(gatewayAccountId, searchParams, mockUriInfo);
+        TransactionSearchResponse transactionSearchResponse = transactionService.searchTransactions(List.of(gatewayAccountId), searchParams, mockUriInfo);
 
         verify(mockTransactionDao).searchTransactionsAndParent(searchParams);
         verify(mockTransactionDao).getTotalForSearchTransactionAndParent(searchParams);

--- a/src/test/java/uk/gov/pay/ledger/transactionmetadata/dao/TransactionMetadataDaoIT.java
+++ b/src/test/java/uk/gov/pay/ledger/transactionmetadata/dao/TransactionMetadataDaoIT.java
@@ -114,7 +114,7 @@ public class TransactionMetadataDaoIT {
         transactionMetadataDao.insertIfNotExist(transaction1.getId(), "test-key-1");
         transactionMetadataDao.insertIfNotExist(transaction2.getId(), "test-key-2");
 
-        searchParams.setAccountId(transaction1.getGatewayAccountId());
+        searchParams.setAccountIds(List.of(transaction1.getGatewayAccountId()));
         searchParams.setFromDate(ZonedDateTime.now().minusDays(10).toString());
         searchParams.setToDate(ZonedDateTime.now().plusDays(1).toString());
         searchParams.setFirstDigitsCardNumber(transaction1.getFirstDigitsCardNumber());


### PR DESCRIPTION
- Ledger now allows users to supply comma separated lists of account IDs
via the `account_id` parameter, this will then return payments for all
of the gateway accounts specified.

- Adds tests to test the functionality works as expected.