### PR TITLE
PP-6201 Capture sentry event when event processing fails

### DIFF
--- a/src/main/java/uk/gov/pay/ledger/queue/EventMessageHandler.java
+++ b/src/main/java/uk/gov/pay/ledger/queue/EventMessageHandler.java
@@ -2,6 +2,7 @@ package uk.gov.pay.ledger.queue;
 
 import com.codahale.metrics.MetricRegistry;
 import com.google.inject.Inject;
+import io.sentry.Sentry;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.pay.ledger.event.model.Event;
@@ -47,6 +48,7 @@ public class EventMessageHandler {
             try {
                 processSingleMessage(message);
             } catch (Exception e) {
+                Sentry.capture(e);
                 LOGGER.warn("Error during handling the event message. [id={}] [queueMessageId={}] [errorMessage={}]",
                         message.getId(),
                         message.getQueueMessageId(),


### PR DESCRIPTION
Currently, we catch all exceptions thrown processing events and log a
line including the exception message.

However, sometimes the message is null which makes it hard to diagnose
what has gone wrong. Send an event to Sentry to capture the stack trace
when this happens.