### PR TITLE
PP-6262 Create Payouts Dao/Entity

### DIFF
--- a/src/main/java/uk/gov/pay/ledger/payout/dao/PayoutDao.java
+++ b/src/main/java/uk/gov/pay/ledger/payout/dao/PayoutDao.java
@@ -1,0 +1,66 @@
+package uk.gov.pay.ledger.payout.dao;
+
+import com.google.inject.Inject;
+import org.jdbi.v3.core.Jdbi;
+import uk.gov.pay.ledger.payout.dao.mapper.PayoutMapper;
+import uk.gov.pay.ledger.payout.entity.PayoutEntity;
+
+import java.util.Optional;
+
+public class PayoutDao {
+
+    private final String SELECT_PAYOUT_BY_GATEWAY_PAYOUT_ID = "SELECT * FROM payouts " +
+            "WHERE gateway_payout_id = :gatewayPayoutId";
+
+    private final String UPSERT_PAYOUT = "INSERT INTO payouts " +
+            "(" +
+            "gateway_payout_id,\n" +
+            "amount,\n" +
+            "paid_out_date,\n" +
+            "statement_descriptor,\n" +
+            "status,\n" +
+            "type\n" +
+            ")\n " +
+            "VALUES (" +
+            ":gateway_payout_id, " +
+            ":amount, " +
+            ":paid_out_date, " +
+            ":statement_descriptor, " +
+            ":status, " +
+            ":type" +
+            ") " +
+            "ON CONFLICT (gateway_payout_id) DO UPDATE SET " +
+            "gateway_payout_id = EXCLUDED.gateway_payout_id, " +
+            "amount = EXCLUDED.amount, " +
+            "paid_out_date = EXCLUDED.paid_out_date, " +
+            "statement_descriptor = EXCLUDED.statement_descriptor, " +
+            "status = EXCLUDED.status, " +
+            "type = EXCLUDED.type";
+
+    private Jdbi jdbi;
+
+    @Inject
+    PayoutDao(Jdbi jdbi) {
+        this.jdbi = jdbi;
+    }
+
+    public Optional<PayoutEntity> findByGatewayPayoutId(String gatewayPayoutId) {
+        return jdbi.withHandle(handle -> handle.createQuery(SELECT_PAYOUT_BY_GATEWAY_PAYOUT_ID)
+                .bind("gatewayPayoutId", gatewayPayoutId)
+                .map(new PayoutMapper())
+                .findFirst());
+    }
+
+    public void upsert(PayoutEntity payout) {
+        jdbi.withHandle(handle ->
+                handle.createUpdate(UPSERT_PAYOUT)
+                        .bind("gateway_payout_id", payout.getGatewayPayoutId())
+                        .bind("amount", payout.getAmount())
+                        .bind("paid_out_date", payout.getPaidOutDate())
+                        .bind("statement_descriptor", payout.getStatementDescriptor())
+                        .bind("status", payout.getStatus())
+                        .bind("type", payout.getType())
+                        .execute());
+    }
+
+}

--- a/src/main/java/uk/gov/pay/ledger/payout/dao/mapper/PayoutMapper.java
+++ b/src/main/java/uk/gov/pay/ledger/payout/dao/mapper/PayoutMapper.java
@@ -1,0 +1,36 @@
+package uk.gov.pay.ledger.payout.dao.mapper;
+
+import org.jdbi.v3.core.mapper.RowMapper;
+import org.jdbi.v3.core.statement.StatementContext;
+import uk.gov.pay.ledger.payout.entity.PayoutEntity;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.util.Optional;
+
+public class PayoutMapper implements RowMapper<PayoutEntity> {
+
+    @Override
+    public PayoutEntity map(ResultSet rs, StatementContext ctx) throws SQLException {
+       var builder = PayoutEntity.PayoutEntityBuilder.aPayoutEntity()
+               .withId(rs.getLong("id"))
+               .withGatewayPayoutId(rs.getString("gateway_payout_id"))
+               .withAmount(rs.getLong("amount"))
+               .withStatementDescriptor(rs.getString("statement_descriptor"))
+               .withType(rs.getString("type"))
+               .withStatus(rs.getString("status"))
+               .withCreatedDate(getZonedDateTime(rs, "created_date").orElse(null))
+               .withPaidOutDate(getZonedDateTime(rs, "paid_out_date").orElse(null));
+        return builder.build();
+    }
+
+    private Optional<ZonedDateTime> getZonedDateTime(ResultSet rs, String columnLabel) throws SQLException {
+        Timestamp timestamp = rs.getTimestamp(columnLabel);
+
+        return Optional.ofNullable(timestamp)
+                .map(t -> ZonedDateTime.ofInstant(t.toInstant(), ZoneOffset.UTC));
+    }
+}

--- a/src/main/java/uk/gov/pay/ledger/payout/entity/PayoutEntity.java
+++ b/src/main/java/uk/gov/pay/ledger/payout/entity/PayoutEntity.java
@@ -1,0 +1,132 @@
+package uk.gov.pay.ledger.payout.entity;
+
+import java.time.ZonedDateTime;
+
+public class PayoutEntity {
+
+    private final Long id;
+    private final String gatewayPayoutId;
+    private final Long amount;
+    private final ZonedDateTime createdDate;
+    private final ZonedDateTime paidOutDate;
+    private final String statementDescriptor;
+    private final String status;
+    private final String type;
+    private final Long version;
+
+    public PayoutEntity(PayoutEntityBuilder builder) {
+        this.id = builder.id;
+        this.gatewayPayoutId = builder.gatewayPayoutId;
+        this.amount = builder.amount;
+        this.createdDate = builder.createdDate;
+        this.paidOutDate = builder.paidOutDate;
+        this.statementDescriptor = builder.statementDescriptor;
+        this.status = builder.status;
+        this.type = builder.type;
+        this.version = builder.version;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getGatewayPayoutId() {
+        return gatewayPayoutId;
+    }
+
+    public Long getAmount() {
+        return amount;
+    }
+
+    public ZonedDateTime getCreatedDate() {
+        return createdDate;
+    }
+
+    public ZonedDateTime getPaidOutDate() {
+        return paidOutDate;
+    }
+
+    public String getStatementDescriptor() {
+        return statementDescriptor;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public Long getVersion() {
+        return version;
+    }
+
+    public static final class PayoutEntityBuilder {
+        private Long id;
+        private String gatewayPayoutId;
+        private Long amount;
+        private ZonedDateTime createdDate;
+        private ZonedDateTime paidOutDate;
+        private String statementDescriptor;
+        private String status;
+        private String type;
+        private Long version;
+
+        private PayoutEntityBuilder() {
+        }
+
+        public static PayoutEntityBuilder aPayoutEntity() {
+            return new PayoutEntityBuilder();
+        }
+
+        public PayoutEntityBuilder withId(Long id) {
+            this.id = id;
+            return this;
+        }
+
+        public PayoutEntityBuilder withGatewayPayoutId(String gatewayPayoutId) {
+            this.gatewayPayoutId = gatewayPayoutId;
+            return this;
+        }
+
+        public PayoutEntityBuilder withAmount(Long amount) {
+            this.amount = amount;
+            return this;
+        }
+
+        public PayoutEntityBuilder withCreatedDate(ZonedDateTime createdDate) {
+            this.createdDate = createdDate;
+            return this;
+        }
+
+        public PayoutEntityBuilder withPaidOutDate(ZonedDateTime paidOutDate) {
+            this.paidOutDate = paidOutDate;
+            return this;
+        }
+
+        public PayoutEntityBuilder withStatementDescriptor(String statementDescriptor) {
+            this.statementDescriptor = statementDescriptor;
+            return this;
+        }
+
+        public PayoutEntityBuilder withStatus(String status) {
+            this.status = status;
+            return this;
+        }
+
+        public PayoutEntityBuilder withType(String type) {
+            this.type = type;
+            return this;
+        }
+
+        public PayoutEntityBuilder withVersion(Long version) {
+            this.version = version;
+            return this;
+        }
+
+        public PayoutEntity build() {
+            return new PayoutEntity(this);
+        }
+    }
+}

--- a/src/test/java/uk/gov/pay/ledger/payout/dao/PayoutDaoIT.java
+++ b/src/test/java/uk/gov/pay/ledger/payout/dao/PayoutDaoIT.java
@@ -1,0 +1,117 @@
+package uk.gov.pay.ledger.payout.dao;
+
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.testcontainers.shaded.org.apache.commons.lang.RandomStringUtils;
+import uk.gov.pay.ledger.rule.AppWithPostgresAndSqsRule;
+
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static uk.gov.pay.ledger.payout.entity.PayoutEntity.PayoutEntityBuilder.aPayoutEntity;
+import static uk.gov.pay.ledger.util.fixture.PayoutFixture.PayoutFixtureBuilder.aPayoutFixture;
+
+public class PayoutDaoIT {
+    @ClassRule
+    public static AppWithPostgresAndSqsRule rule = new AppWithPostgresAndSqsRule();
+
+    private PayoutDao payoutDao = new PayoutDao(rule.getJdbi());
+
+    @Test
+    public void shouldFetchTransaction() {
+        var createdDate = ZonedDateTime.now(ZoneOffset.UTC);
+        var paidOutDate = createdDate.minusDays(1);
+        var id = RandomStringUtils.randomNumeric(4);
+        aPayoutFixture()
+                .withId(Long.valueOf(id))
+                .withAmount(100L)
+                .withCreatedDate(createdDate)
+                .withGatewayPayoutId("po_asdasdasd")
+                .withPaidOutDate(paidOutDate)
+                .withStatementDescriptor("a statement descriptor")
+                .withStatus("PAYOUT")
+                .withType("Bank Account")
+                .withVersion(0L)
+                .build().insert(rule.getJdbi());
+        var payout = payoutDao.findByGatewayPayoutId("po_asdasdasd").get();
+        assertThat(payout.getId(), is(Long.valueOf(id)));
+        assertThat(payout.getAmount(), is(100L));
+        assertThat(payout.getGatewayPayoutId(), is("po_asdasdasd"));
+        assertThat(payout.getStatementDescriptor(), is("a statement descriptor"));
+        assertThat(payout.getStatus(), is("PAYOUT"));
+        assertThat(payout.getType(), is("Bank Account"));
+        assertThat(payout.getCreatedDate(), is(notNullValue()));
+        assertThat(payout.getPaidOutDate(), is(paidOutDate));
+    }
+
+    @Test
+    public void shouldUpsertNonExistentTransaction(){
+        var createdDate = ZonedDateTime.now(ZoneOffset.UTC);
+        var paidOutDate = createdDate.minusDays(1);
+
+        var payoutEntity = aPayoutEntity()
+                .withAmount(100L)
+                .withGatewayPayoutId("po_test2")
+                .withPaidOutDate(paidOutDate)
+                .withStatementDescriptor("a statement descriptor")
+                .withStatus("PAYOUT")
+                .withType("Bank Account")
+                .withVersion(0L)
+                .build();
+
+        payoutDao.upsert(payoutEntity);
+
+        var payout = payoutDao.findByGatewayPayoutId("po_test2").get();
+        assertThat(payout.getId(), is(1L));
+        assertThat(payout.getAmount(), is(100L));
+        assertThat(payout.getGatewayPayoutId(), is("po_test2"));
+        assertThat(payout.getStatementDescriptor(), is("a statement descriptor"));
+        assertThat(payout.getStatus(), is("PAYOUT"));
+        assertThat(payout.getType(), is("Bank Account"));
+        assertThat(payout.getCreatedDate(), is(notNullValue()));
+        assertThat(payout.getPaidOutDate(), is(paidOutDate));
+    }
+
+    @Test
+    public void shouldUpsertExistingTransaction() {
+        var createdDate = ZonedDateTime.now(ZoneOffset.UTC);
+        var paidOutDate = createdDate.minusDays(1);
+
+        var payoutEntity = aPayoutEntity()
+                .withAmount(100L)
+                .withGatewayPayoutId("po_test2")
+                .withPaidOutDate(paidOutDate)
+                .withStatementDescriptor("a statement descriptor")
+                .withStatus("PAYOUT")
+                .withType("Bank Account")
+                .withVersion(0L)
+                .build();
+
+        payoutDao.upsert(payoutEntity);
+
+        var payoutEntity2 = aPayoutEntity()
+                .withAmount(1337L)
+                .withGatewayPayoutId("po_test2")
+                .withPaidOutDate(paidOutDate)
+                .withStatementDescriptor("a descriptor")
+                .withStatus("PAID")
+                .withType("Test Account")
+                .withVersion(0L)
+                .build();
+
+        payoutDao.upsert(payoutEntity2);
+
+        var payout = payoutDao.findByGatewayPayoutId("po_test2").get();
+
+        assertThat(payout.getAmount(), is(1337L));
+        assertThat(payout.getGatewayPayoutId(), is("po_test2"));
+        assertThat(payout.getStatementDescriptor(), is("a descriptor"));
+        assertThat(payout.getStatus(), is("PAID"));
+        assertThat(payout.getType(), is("Test Account"));
+        assertThat(payout.getCreatedDate(), is(notNullValue()));
+        assertThat(payout.getPaidOutDate(), is(paidOutDate));
+    }
+}

--- a/src/test/java/uk/gov/pay/ledger/util/fixture/PayoutFixture.java
+++ b/src/test/java/uk/gov/pay/ledger/util/fixture/PayoutFixture.java
@@ -1,0 +1,135 @@
+package uk.gov.pay.ledger.util.fixture;
+
+import org.jdbi.v3.core.Jdbi;
+import uk.gov.pay.ledger.payout.entity.PayoutEntity;
+
+import java.time.ZonedDateTime;
+
+import static uk.gov.pay.ledger.payout.entity.PayoutEntity.PayoutEntityBuilder.aPayoutEntity;
+
+public class PayoutFixture implements DbFixture<PayoutFixture, PayoutEntity> {
+
+    private Long id;
+    private String gatewayPayoutId;
+    private Long amount;
+    private ZonedDateTime createdDate;
+    private ZonedDateTime paidOutDate;
+    private String statementDescriptor;
+    private String status;
+    private String type;
+    private Long version;
+
+    @Override
+    public PayoutFixture insert(Jdbi jdbi) {
+        jdbi.withHandle(handle ->
+                handle.execute(
+                        "INSERT INTO" +
+                                " payouts(\n" +
+                                "   id,\n" +
+                                "   gateway_payout_id,\n" +
+                                "   amount,\n" +
+                                "   created_date,\n" +
+                                "   paid_out_date,\n" +
+                                "   statement_descriptor,\n" +
+                                "   status,\n" +
+                                "   type\n" +
+                                " )\n" +
+                                " VALUES (?,?,?,?,?,?,?,?)",
+                        id, gatewayPayoutId, amount, createdDate, paidOutDate, statementDescriptor, status, type
+                ));
+        return this;
+    }
+
+    @Override
+    public PayoutEntity toEntity() {
+        return aPayoutEntity()
+                .withAmount(amount)
+                .withCreatedDate(createdDate)
+                .withGatewayPayoutId(gatewayPayoutId)
+                .withId(id)
+                .withPaidOutDate(paidOutDate)
+                .withStatementDescriptor(statementDescriptor)
+                .withStatus(status)
+                .withType(type)
+                .withVersion(version)
+                .build();
+    }
+
+    public static final class PayoutFixtureBuilder {
+        private Long id;
+        private String gatewayPayoutId;
+        private Long amount;
+        private ZonedDateTime createdDate;
+        private ZonedDateTime paidOutDate;
+        private String statementDescriptor;
+        private String status;
+        private String type;
+        private Long version;
+
+        private PayoutFixtureBuilder() {
+        }
+
+        public static PayoutFixtureBuilder aPayoutFixture() {
+            return new PayoutFixtureBuilder();
+        }
+
+        public PayoutFixtureBuilder withId(Long id) {
+            this.id = id;
+            return this;
+        }
+
+        public PayoutFixtureBuilder withGatewayPayoutId(String gatewayPayoutId) {
+            this.gatewayPayoutId = gatewayPayoutId;
+            return this;
+        }
+
+        public PayoutFixtureBuilder withAmount(Long amount) {
+            this.amount = amount;
+            return this;
+        }
+
+        public PayoutFixtureBuilder withCreatedDate(ZonedDateTime createdDate) {
+            this.createdDate = createdDate;
+            return this;
+        }
+
+        public PayoutFixtureBuilder withPaidOutDate(ZonedDateTime paidOutDate) {
+            this.paidOutDate = paidOutDate;
+            return this;
+        }
+
+        public PayoutFixtureBuilder withStatementDescriptor(String statementDescriptor) {
+            this.statementDescriptor = statementDescriptor;
+            return this;
+        }
+
+        public PayoutFixtureBuilder withStatus(String status) {
+            this.status = status;
+            return this;
+        }
+
+        public PayoutFixtureBuilder withType(String type) {
+            this.type = type;
+            return this;
+        }
+
+        public PayoutFixtureBuilder withVersion(Long version) {
+            this.version = version;
+            return this;
+        }
+
+        public PayoutFixture build() {
+            PayoutFixture payoutFixture = new PayoutFixture();
+            payoutFixture.amount = this.amount;
+            payoutFixture.gatewayPayoutId = this.gatewayPayoutId;
+            payoutFixture.id = this.id;
+            payoutFixture.status = this.status;
+            payoutFixture.statementDescriptor = this.statementDescriptor;
+            payoutFixture.version = this.version;
+            payoutFixture.createdDate = this.createdDate;
+            payoutFixture.paidOutDate = this.paidOutDate;
+            payoutFixture.type = this.type;
+            return payoutFixture;
+        }
+    }
+}


### PR DESCRIPTION
- Creates the PayoutEntity, PayoutDao and PayoutFixture to allow for the
representation of the `payouts` database table in Java objects.

- Adds tests to ensure the DAO methods we have chosed to start with work
as expected.