### PR TITLE
PP-6262 Alter Index Migrations

### DIFF
--- a/src/main/resources/migrations/00041_alter_index_on_payouts_gateway_id.sql
+++ b/src/main/resources/migrations/00041_alter_index_on_payouts_gateway_id.sql
@@ -1,0 +1,9 @@
+--liquibase formatted sql
+
+--changeset uk.gov.pay:drop_index_gateway_payout_id
+DROP INDEX index_gateway_payout_id;
+--rollback CREATE INDEX index_gateway_payout_id ON payouts(gateway_payout_id);
+
+--changeset uk.gov.pay:constraint_index_gateway_payout_id
+ALTER TABLE payouts ADD CONSTRAINT gateway_payout_id_unique  UNIQUE (gateway_payout_id);
+--rollback ALTER TABLE payouts DROP CONSTRAINT gateway_payout_id_unique;


### PR DESCRIPTION
- The index on the payouts table needs to be a unique constraint, this
drops the previous one and adds a new index that the unique constraint
can then be placed against