### PR TITLE
PP-6261 Transaction Table References Payouts

### DIFF
--- a/src/main/resources/migrations/00044_add_payouts_foreign_key_to_transaction.sql
+++ b/src/main/resources/migrations/00044_add_payouts_foreign_key_to_transaction.sql
@@ -1,0 +1,9 @@
+--liquibase formatted sql
+
+--changeset uk.gov.pay:add_payouts_foreign_key_to_transaction
+ALTER TABLE transaction ADD COLUMN gateway_payout_id VARCHAR(50) REFERENCES payouts(gateway_payout_id);
+--rollback ALTER TABLE transaction DROP COLUMN gateway_payout_id; 
+
+--changeset uk.gov.pay:create_index_on_transaction_gateway_payout_id runInTransaction:false
+CREATE INDEX CONCURRENTLY transaction_gateway_payout_id_idx ON transaction(gateway_payout_id);
+--rollback DROP INDEX transaction_gateway_payout_id_idx;


### PR DESCRIPTION
- The `transaction` table now has a foreign key relationship to the
`payouts` table via the `gateway_payout_id`.