### PR TITLE
PP-6261 Extend Length of `gateway_payout_id`

### DIFF
--- a/src/main/resources/migrations/00043_extend_payouts_gateway_payout_id_column.sql
+++ b/src/main/resources/migrations/00043_extend_payouts_gateway_payout_id_column.sql
@@ -1,0 +1,5 @@
+--liquibase formatted sql
+
+--changeset uk.gov.pay:extend_gateway_payout_id_column
+ALTER TABLE payouts ALTER COLUMN gateway_payout_id TYPE VARCHAR(50);
+--rollback ALTER TABLE payouts ALTER COLUMN gateway_payout_id TYPE VARCHAR(26)


### PR DESCRIPTION
- Extend the length of the VARCHAR `gateway_payout_id` column on the
payouts table to reflect the real length of Stripe `payout_id` column.