### PR TITLE
BAU Add Live Parameter To Search Resource

### DIFF
--- a/src/main/java/uk/gov/pay/ledger/transaction/search/common/TransactionSearchParams.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/search/common/TransactionSearchParams.java
@@ -32,6 +32,7 @@ public class TransactionSearchParams {
     private static final String STATE_FIELD = "state";
     private static final String TRANSACTION_TYPE_FIELD = "transaction_type";
     private static final String GATEWAY_TRANSACTION_ID_FIELD = "gateway_transaction_id";
+    private static final String LIVE_FIELD = "live";
     private static final long DEFAULT_PAGE_NUMBER = 1L;
     private static final long DEFAULT_MAX_DISPLAY_SIZE = 500L;
 
@@ -69,6 +70,8 @@ public class TransactionSearchParams {
     private String fromDate;
     @QueryParam("to_date")
     private String toDate;
+    @QueryParam("live")
+    private Boolean live;
     @QueryParam(TRANSACTION_TYPE_FIELD)
     private TransactionType transactionType;
     @DefaultValue("true")
@@ -153,6 +156,10 @@ public class TransactionSearchParams {
         this.maxDisplaySize = maxDisplaySize;
     }
 
+    public void setLive(Boolean live) {
+        this.live = live;
+    }
+
     public List<String> getFilterTemplates() {
         List<String> filters = new ArrayList<>();
 
@@ -179,6 +186,9 @@ public class TransactionSearchParams {
         }
         if (isNotBlank(gatewayTransactionId)) {
             filters.add(" t.gateway_transaction_id = :" + GATEWAY_TRANSACTION_ID_FIELD);
+        }
+        if (live != null) {
+            filters.add(" t.live = :"+LIVE_FIELD);
         }
 
         return List.copyOf(filters);
@@ -299,6 +309,9 @@ public class TransactionSearchParams {
             if (gatewayTransactionId != null) {
                 queryMap.put(GATEWAY_TRANSACTION_ID_FIELD, gatewayTransactionId);
             }
+            if (live != null) {
+                queryMap.put(LIVE_FIELD, live);
+            }
         }
         return queryMap;
     }
@@ -387,6 +400,9 @@ public class TransactionSearchParams {
         }
         if (transactionType != null) {
             queries.add(TRANSACTION_TYPE_FIELD + "=" + transactionType);
+        }
+        if (live != null) {
+            queries.add(LIVE_FIELD + "=" + live);
         }
         queries.add("page=" + forPage);
         queries.add("display_size=" + getDisplaySize());

--- a/src/test/java/uk/gov/pay/ledger/transaction/dao/TransactionDaoSearchIT.java
+++ b/src/test/java/uk/gov/pay/ledger/transaction/dao/TransactionDaoSearchIT.java
@@ -947,6 +947,53 @@ public class TransactionDaoSearchIT {
         assertThat(fourthPage.size(), is(0));
     }
 
+    @Test
+    public void shouldOnlyReturnLiveTransactions_whenLiveParameterIsSetToTrue() {
+        transactionFixture = aTransactionFixture()
+                .withId(1337L)
+                .withLive(true)
+                .withGatewayAccountId("1")
+                .withCreatedDate(now(ZoneOffset.UTC).minusDays(3))
+                .insert(rule.getJdbi());
+
+        transactionFixture = aTransactionFixture()
+                .withId(1336L)
+                .withLive(false)
+                .withGatewayAccountId("1")
+                .withCreatedDate(now(ZoneOffset.UTC).minusDays(3))
+                .insert(rule.getJdbi());
+
+        searchParams.setLive(true);
+
+        List<TransactionEntity> transactionList = transactionDao.searchTransactions(searchParams);
+
+        assertThat(transactionList.size(), is(1));
+        assertThat(transactionList.get(0).getId(), is(1337L));
+    }
+
+    @Test
+    public void shouldReturnAllTransactions_whenLiveParameterIsSetToNull() {
+        transactionFixture = aTransactionFixture()
+                .withId(1337L)
+                .withLive(true)
+                .withGatewayAccountId("1")
+                .withCreatedDate(now(ZoneOffset.UTC).minusDays(3))
+                .insert(rule.getJdbi());
+
+        transactionFixture = aTransactionFixture()
+                .withId(1336L)
+                .withLive(false)
+                .withGatewayAccountId("1")
+                .withCreatedDate(now(ZoneOffset.UTC).minusDays(3))
+                .insert(rule.getJdbi());
+
+        searchParams.setLive(null);
+
+        List<TransactionEntity> transactionList = transactionDao.searchTransactions(searchParams);
+
+        assertThat(transactionList.size(), is(2));
+    }
+
     private void assertTransactionEquals(TransactionEntity actualTransactionEntity, TransactionFixture transactionFixture) {
         assertThat(actualTransactionEntity.getId(), is(transactionFixture.getId()));
         assertThat(actualTransactionEntity.getGatewayAccountId(), is(transactionFixture.getGatewayAccountId()));

--- a/src/test/java/uk/gov/pay/ledger/transaction/resource/TransactionResourceSearchIT.java
+++ b/src/test/java/uk/gov/pay/ledger/transaction/resource/TransactionResourceSearchIT.java
@@ -446,4 +446,45 @@ public class TransactionResourceSearchIT {
                 .contentType(JSON)
                 .body("count", is(2));
     }
+
+    @Test
+    public void shouldReturnOnlyLiveTransactionsWhenLiveParameterIsSet() {
+        String targetGatewayAccountId = "1030";
+
+        aTransactionFixture()
+                .withTransactionType("PAYMENT")
+                .withLive(true)
+                .withState(TransactionState.SUBMITTED)
+                .withGatewayAccountId(targetGatewayAccountId)
+                .insert(rule.getJdbi());
+
+        aTransactionFixture()
+                .withTransactionType("PAYMENT")
+                .withLive(true)
+                .withState(TransactionState.SUBMITTED)
+                .withGatewayAccountId(targetGatewayAccountId)
+                .insert(rule.getJdbi());
+
+        aTransactionFixture()
+                .withTransactionType("PAYMENT")
+                .withLive(false)
+                .withState(TransactionState.SUBMITTED)
+                .withGatewayAccountId(targetGatewayAccountId)
+                .insert(rule.getJdbi());
+
+        given().port(port)
+                .contentType(JSON)
+                .accept(JSON)
+                .get("/v1/transaction?" +
+                        "account_id=1030" +
+                        "&live=true" +
+                        "&page=1" +
+                        "&display_size=5"
+                )
+                .then()
+                .statusCode(Response.Status.OK.getStatusCode())
+                .contentType(JSON)
+                .body("count", is(2));
+    }
+
 }

--- a/src/test/java/uk/gov/pay/ledger/transaction/search/common/TransactionSearchParamsTest.java
+++ b/src/test/java/uk/gov/pay/ledger/transaction/search/common/TransactionSearchParamsTest.java
@@ -247,4 +247,16 @@ public class TransactionSearchParamsTest {
         transactionSearchParams.setToDate("2018-09-22T10:14:16.067Z");
         assertThat(transactionSearchParams.buildQueryParamString(1L), containsString("to_date=2018-09-22T10:14:16.067Z"));
     }
+
+    @Test
+    public void getsQueryParamStringWithLiveNotIncludedWhenItIsNull() {
+        transactionSearchParams.setLive(null);
+        assertThat(transactionSearchParams.buildQueryParamString(1L), not(containsString("live")));
+    }
+
+    @Test
+    public void getsQueryParamStringWithLiveSetWhenItIsSet() {
+        transactionSearchParams.setLive(true);
+        assertThat(transactionSearchParams.buildQueryParamString(1L), containsString("live=true"));
+    }
 }


### PR DESCRIPTION
- This PR adds the ability for ledger to receive a new query pameter
(`live`) on transaction searches, this will return transactions on live
accounts if it is set to `true` and on test accounts if it is set to
`false`.

- Adds a test to ensure that the functionality works as expected on all
levels of Ledger.