### PR TITLE
PP-6310 Fix pact bug

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -403,9 +403,7 @@
         <profile>
             <id>default</id>
             <activation>
-                <property>
-                    <name>!runContractTests</name>
-                </property>
+                <activeByDefault>true</activeByDefault>
             </activation>
             <build>
                 <plugins>
@@ -415,7 +413,8 @@
                         <configuration>
                             <excludes>
                                 <exclude>**/*ContractTest.java</exclude>
-                                <exclude>**/*ContractTestSuite.java</exclude>
+                                <exclude>**/*ProviderContractTestSuite.java</exclude>
+                                <exclude>**/*ConsumerContractTestSuite.java</exclude>
                             </excludes>
                         </configuration>
                     </plugin>
@@ -423,7 +422,7 @@
             </build>
         </profile>
         <profile>
-            <id>contract-tests</id>
+            <id>provider-contract-tests</id>
             <activation>
                 <property>
                     <name>runContractTests</name>
@@ -436,7 +435,28 @@
                         <version>${surefire.version}</version>
                         <configuration>
                             <includes>
-                                <include>**/*ContractTestSuite.java</include>
+                                <include>**/*ProviderContractTestSuite.java</include>
+                            </includes>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>consumer-contract-tests</id>
+            <activation>
+                <property>
+                    <name>runConsumerContractTests</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <version>${surefire.version}</version>
+                        <configuration>
+                            <includes>
+                                <include>**/*ConsumerContractTestSuite.java</include>
                             </includes>
                         </configuration>
                     </plugin>
@@ -444,5 +464,4 @@
             </build>
         </profile>
     </profiles>
-
 </project>

--- a/src/test/java/uk/gov/pay/ledger/pact/ConsumerContractTestSuite.java
+++ b/src/test/java/uk/gov/pay/ledger/pact/ConsumerContractTestSuite.java
@@ -8,12 +8,10 @@ import org.junit.runners.AllTests;
 import uk.gov.pay.commons.testing.pact.provider.CreateTestSuite;
 
 @RunWith(AllTests.class)
-public class ContractTestSuite {
+public class ConsumerContractTestSuite {
 
     public static TestSuite suite() {
         ImmutableSetMultimap.Builder<String, JUnit4TestAdapter> consumerToJUnitTest = ImmutableSetMultimap.builder();
-        consumerToJUnitTest.put("publicapi", new JUnit4TestAdapter(PublicApiContractTest.class));
-        consumerToJUnitTest.put("selfservice", new JUnit4TestAdapter(SelfServiceContractTest.class));
         consumerToJUnitTest.put("connector", new JUnit4TestAdapter(PaymentCreatedEventQueueContractTest.class));
         consumerToJUnitTest.put("connector", new JUnit4TestAdapter(PaymentDetailsEnteredEventQueueContractTest.class));
         consumerToJUnitTest.put("connector", new JUnit4TestAdapter(CaptureConfirmedEventQueueContractTest.class));

--- a/src/test/java/uk/gov/pay/ledger/pact/ProviderContractTestSuite.java
+++ b/src/test/java/uk/gov/pay/ledger/pact/ProviderContractTestSuite.java
@@ -1,0 +1,19 @@
+package uk.gov.pay.ledger.pact;
+
+import com.google.common.collect.ImmutableSetMultimap;
+import junit.framework.JUnit4TestAdapter;
+import junit.framework.TestSuite;
+import org.junit.runner.RunWith;
+import org.junit.runners.AllTests;
+import uk.gov.pay.commons.testing.pact.provider.CreateTestSuite;
+
+@RunWith(AllTests.class)
+public class ProviderContractTestSuite {
+
+    public static TestSuite suite() {
+        ImmutableSetMultimap.Builder<String, JUnit4TestAdapter> consumerToJUnitTest = ImmutableSetMultimap.builder();
+        consumerToJUnitTest.put("publicapi", new JUnit4TestAdapter(PublicApiContractTest.class));
+        consumerToJUnitTest.put("selfservice", new JUnit4TestAdapter(SelfServiceContractTest.class));
+        return CreateTestSuite.create(consumerToJUnitTest.build());
+    }
+}


### PR DESCRIPTION
Ledger is the only Pay microservice that is both a consumer (of connector) and a provider (to publicapi and selfservice). This led to a weird bug in the Ledger pact tests. In order to run a pact test you need to specify the `CONSUMER_TAG`. When you run a consumer pact test, this is used to tag the pact that the test produces. When you run a provider test, it specifies the tag to use when retrieving pacts from a consumer to be validated. The pact tests were run against Ledger with the command
```
mvn clean package pact:publish -DrunContractTests=true -DPACT_CONSUMER_TAG=${branchName} …
```
This command ran both the set of tests where Ledger is a provider and those where Ledger is a consumer. For the provider tests it fetched the pacts from the consumer tagged with the value of `branchName`. However, `branchName` was set to be the value of the name (actually not the name, but an identifier from Jenkins like `PR-691`) of the current Ledger branch. All of this fed into the failure of this build https://build.ci.pymnt.uk/job/pay-ledger/job/PR-691/3/execution/node/32/log/ The build asks for the publicapi pact tagged with `PP-691` to be validated against the current version of ledger. Because `PR-691` is the Ledger "branch name" (not the publicapi pact tag), this is obviously wrong. Unfortunately there _was_ a pact tagged `PP-691`, but it was from 7 months ago. Ledger no longer satisfied this pact, so the build failed.

To fix this problem, I have separated pact tests where Ledger is the consumer from those where it is the provider, and run them separately from the Jenkinsfile, ensuring the correct consumer tag is being set in each case.
To do this I have introduced a new maven profile, activated by the system property `runConsumerContractTests`. I have modified the existing profile activated by `runContractTests`, to only run the contract tests where Ledger is the provider. I have not changed the name of the property `runContractTests` to `runProviderContractTests` because other builds invoke Ledger's provider contract tests using this flag. I have also made a small change to the default profile to set it to `activeByDefault` which makes it play nicely with the other flags, and also seems more intuitive.