### PR TITLE
PP-6421 Add event_count and payout_details to payout

### DIFF
--- a/src/main/resources/migrations/00046_add_event_count_payout_details_to_payout.sql
+++ b/src/main/resources/migrations/00046_add_event_count_payout_details_to_payout.sql
@@ -1,0 +1,8 @@
+--liquibase formatted sql
+
+--changeset uk.gov.pay:add_event_count_payout_details_to_payout
+ALTER TABLE payouts ADD COLUMN event_count INTEGER;
+ALTER TABLE payouts ADD COLUMN payout_details jsonb;
+
+--rollback ALTER TABLE transaction DROP COLUMN event_count;
+--rollback ALTER TABLE transaction DROP COLUMN payout_details;


### PR DESCRIPTION
## WHAT 
- Added event_count so we upsert payouts only when there are new payout events
- Also added payout_details to store entire payout payload in json blob and table level fields only need to hold searchable/aggregate fields