### PR TITLE
PP-6421 Rename payouts table

### DIFF
--- a/src/main/java/uk/gov/pay/ledger/payout/dao/PayoutDao.java
+++ b/src/main/java/uk/gov/pay/ledger/payout/dao/PayoutDao.java
@@ -9,10 +9,10 @@ import java.util.Optional;
 
 public class PayoutDao {
 
-    private final String SELECT_PAYOUT_BY_GATEWAY_PAYOUT_ID = "SELECT * FROM payouts " +
+    private final String SELECT_PAYOUT_BY_GATEWAY_PAYOUT_ID = "SELECT * FROM payout " +
             "WHERE gateway_payout_id = :gatewayPayoutId";
 
-    private final String UPSERT_PAYOUT = "INSERT INTO payouts " +
+    private final String UPSERT_PAYOUT = "INSERT INTO payout " +
             "(" +
             "gateway_payout_id,\n" +
             "amount,\n" +

--- a/src/main/resources/migrations/00047_rename_payouts_table.sql
+++ b/src/main/resources/migrations/00047_rename_payouts_table.sql
@@ -1,0 +1,6 @@
+--liquibase formatted sql
+
+--changeset uk.gov.pay:rename_payouts_table
+ALTER TABLE payouts RENAME to payout;
+
+--rollback ALTER TABLE payout rename to payouts;

--- a/src/test/java/uk/gov/pay/ledger/util/fixture/PayoutFixture.java
+++ b/src/test/java/uk/gov/pay/ledger/util/fixture/PayoutFixture.java
@@ -24,7 +24,7 @@ public class PayoutFixture implements DbFixture<PayoutFixture, PayoutEntity> {
         jdbi.withHandle(handle ->
                 handle.execute(
                         "INSERT INTO" +
-                                " payouts(\n" +
+                                " payout(\n" +
                                 "   id,\n" +
                                 "   gateway_payout_id,\n" +
                                 "   amount,\n" +


### PR DESCRIPTION
## WHAT
- Renames `payouts` to `payout` (singular) to be consistent with naming convention (transaction, event) in ledger