### PR TITLE
PP-6421 Payout entity factory

### DIFF
--- a/src/main/java/uk/gov/pay/ledger/payout/entity/PayoutEntity.java
+++ b/src/main/java/uk/gov/pay/ledger/payout/entity/PayoutEntity.java
@@ -1,17 +1,36 @@
 package uk.gov.pay.ledger.payout.entity;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import uk.gov.pay.ledger.event.model.serializer.MicrosecondPrecisionDateTimeDeserializer;
+import uk.gov.pay.ledger.event.model.serializer.MicrosecondPrecisionDateTimeSerializer;
+
 import java.time.ZonedDateTime;
 
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
 public class PayoutEntity {
 
-    private final Long id;
-    private final String gatewayPayoutId;
-    private final Long amount;
-    private final ZonedDateTime createdDate;
-    private final ZonedDateTime paidOutDate;
-    private final String statementDescriptor;
-    private final String status;
-    private final String type;
+    @JsonIgnore
+    private Long id;
+    private String gatewayPayoutId;
+    private Long amount;
+    @JsonIgnore
+    private ZonedDateTime createdDate;
+    @JsonSerialize(using = MicrosecondPrecisionDateTimeSerializer.class)
+    @JsonDeserialize(using = MicrosecondPrecisionDateTimeDeserializer.class)
+    private ZonedDateTime paidOutDate;
+    private String statementDescriptor;
+
+    private String status;
+    private String type;
+
+    public PayoutEntity() {
+    }
 
     public PayoutEntity(PayoutEntityBuilder builder) {
         this.id = builder.id;
@@ -54,6 +73,34 @@ public class PayoutEntity {
 
     public String getType() {
         return type;
+    }
+
+    public void setGatewayPayoutId(String gatewayPayoutId) {
+        this.gatewayPayoutId = gatewayPayoutId;
+    }
+
+    public void setAmount(Long amount) {
+        this.amount = amount;
+    }
+
+    public void setCreatedDate(ZonedDateTime createdDate) {
+        this.createdDate = createdDate;
+    }
+
+    public void setPaidOutDate(ZonedDateTime paidOutDate) {
+        this.paidOutDate = paidOutDate;
+    }
+
+    public void setStatementDescriptor(String statementDescriptor) {
+        this.statementDescriptor = statementDescriptor;
+    }
+
+    public void setStatus(String status) {
+        this.status = status;
+    }
+
+    public void setType(String type) {
+        this.type = type;
     }
 
     public static final class PayoutEntityBuilder {

--- a/src/main/java/uk/gov/pay/ledger/payout/model/PayoutEntityFactory.java
+++ b/src/main/java/uk/gov/pay/ledger/payout/model/PayoutEntityFactory.java
@@ -1,0 +1,24 @@
+package uk.gov.pay.ledger.payout.model;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import uk.gov.pay.ledger.event.model.EventDigest;
+import uk.gov.pay.ledger.payout.entity.PayoutEntity;
+
+public class PayoutEntityFactory {
+
+    private final ObjectMapper objectMapper;
+
+    public PayoutEntityFactory(){
+        this.objectMapper = new ObjectMapper();
+        this.objectMapper.registerModule(new JavaTimeModule());
+    }
+
+    public PayoutEntity create(EventDigest eventDigest) {
+        PayoutEntity entity = objectMapper.convertValue(eventDigest.getEventPayload(), PayoutEntity.class);
+        entity.setCreatedDate(eventDigest.getEventCreatedDate());
+        entity.setGatewayPayoutId(eventDigest.getResourceExternalId());
+        return entity;
+    }
+
+}

--- a/src/main/java/uk/gov/pay/ledger/payout/service/PayoutService.java
+++ b/src/main/java/uk/gov/pay/ledger/payout/service/PayoutService.java
@@ -1,0 +1,24 @@
+package uk.gov.pay.ledger.payout.service;
+
+import com.google.inject.Inject;
+import uk.gov.pay.ledger.event.model.EventDigest;
+import uk.gov.pay.ledger.payout.dao.PayoutDao;
+import uk.gov.pay.ledger.payout.entity.PayoutEntity;
+import uk.gov.pay.ledger.payout.model.PayoutEntityFactory;
+
+public class PayoutService {
+
+    private final PayoutDao payoutDao;
+    private final PayoutEntityFactory payoutEntityFactory;
+
+    @Inject
+    public PayoutService(PayoutDao payoutDao, PayoutEntityFactory payoutEntityFactory) {
+        this.payoutDao = payoutDao;
+        this.payoutEntityFactory = payoutEntityFactory;
+    }
+
+    public void upsertPayoutFor(EventDigest eventDigest) {
+        PayoutEntity payoutEntity = payoutEntityFactory.create(eventDigest);
+        payoutDao.upsert(payoutEntity);
+    }
+}

--- a/src/test/java/uk/gov/pay/ledger/payout/model/PayoutEntityFactoryTest.java
+++ b/src/test/java/uk/gov/pay/ledger/payout/model/PayoutEntityFactoryTest.java
@@ -1,0 +1,62 @@
+package uk.gov.pay.ledger.payout.model;
+
+import com.google.gson.GsonBuilder;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import uk.gov.pay.ledger.event.model.Event;
+import uk.gov.pay.ledger.event.model.EventDigest;
+import uk.gov.pay.ledger.payout.entity.PayoutEntity;
+
+import java.time.ZonedDateTime;
+import java.util.List;
+import java.util.Map;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static uk.gov.pay.ledger.util.fixture.QueuePaymentEventFixture.aQueuePaymentEventFixture;
+
+public class PayoutEntityFactoryTest {
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    private PayoutEntityFactory payoutEntityFactory;
+
+    private GsonBuilder gsonBuilder = new GsonBuilder();
+
+    @Before
+    public void setUp() {
+        payoutEntityFactory = new PayoutEntityFactory();
+    }
+
+    @Test
+    public void shouldConvertEventDigestToPayoutEntity() {
+        ZonedDateTime paidOutDate = ZonedDateTime.parse("2020-05-04T00:20:00.123456Z");
+        Event payoutCreatedEvent = aQueuePaymentEventFixture()
+                .withEventType("PAYOUT_CREATED")
+                .withEventData(gsonBuilder.create()
+                        .toJson(Map.of(
+                                "amount", 10000,
+                                "statement_descriptor", "SPECIAL TEST SERVICE"
+                        ))
+                )
+                .toEntity();
+        Event payoutPaidOutEvent = aQueuePaymentEventFixture()
+                .withEventType("PAYOUT_PAID_OUT")
+                .withEventData(gsonBuilder.create()
+                        .toJson(Map.of(
+                                "paid_out_date", paidOutDate.toString()
+                        ))
+                )
+                .toEntity();
+        EventDigest eventDigest = EventDigest.fromEventList(List.of(payoutCreatedEvent, payoutPaidOutEvent));
+        PayoutEntity payoutEntity = payoutEntityFactory.create(eventDigest);
+
+        assertThat(payoutEntity.getGatewayPayoutId(), is(payoutCreatedEvent.getResourceExternalId()));
+        assertThat(payoutEntity.getAmount(), is(10000L));
+        assertThat(payoutEntity.getCreatedDate(), is(payoutCreatedEvent.getEventDate()));
+        assertThat(payoutEntity.getPaidOutDate(), is(paidOutDate));
+    }
+
+}


### PR DESCRIPTION
* add `PayoutEntityFactory` to parse payouts from event digests
* simple service method to combine the factory and writing to the DB

Note the object mapper used to convert the event digest payload has to register the java time module (`this.objectMapper.registerModule(new JavaTimeModule())`) otherwise it isn't able to serialise `ZonedDateTime`.

---

What this PR does not do:
* setting state based on PayoutState and known salient events (1 PR)
* setting the event count on the payout to ensure latest event is applied (depends on https://github.com/alphagov/pay-ledger/pull/715)
* setting the payout details to contain anything not at the column level (depends on https://github.com/alphagov/pay-ledger/pull/715)
* handling events at the top level based on resource type (1 PR)