### PR TITLE
PP-6467 Transaction CSV resource is case insensitive

### DIFF
--- a/src/main/java/uk/gov/pay/ledger/transaction/model/CsvTransactionFactory.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/model/CsvTransactionFactory.java
@@ -121,7 +121,7 @@ public class CsvTransactionFactory {
 
             externalMetadata.ifPresent(metadata ->
                     metadata.forEach((key, value) ->
-                            result.put(String.format("%s (metadata)", key), value)));
+                            result.put(String.format("%s (metadata)", key.toLowerCase()), value)));
         } catch (IOException e) {
             LOGGER.error("Error during the parsing transaction entity data [{}] [errorMessage={}]",
                     transactionEntity.getExternalId(), e.getMessage());
@@ -194,7 +194,11 @@ public class CsvTransactionFactory {
         }
 
         if (metadataKeys != null) {
-            metadataKeys.stream().sorted()
+            metadataKeys
+                    .stream()
+                    .map(String::toLowerCase)
+                    .distinct()
+                    .sorted()
                     .forEach(key -> {
                         String header = String.format("%s (metadata)", key);
                         headers.put(header, header);

--- a/src/test/java/uk/gov/pay/ledger/transaction/model/CsvTransactionFactoryTest.java
+++ b/src/test/java/uk/gov/pay/ledger/transaction/model/CsvTransactionFactoryTest.java
@@ -117,6 +117,23 @@ public class CsvTransactionFactoryTest {
     }
 
     @Test
+    public void toMapShouldIgnoreDuplicateCaseSensitiveMetadataFields() {
+        TransactionEntity transactionEntity = transactionFixture.withTransactionDetails(
+                new GsonBuilder().create().toJson(ImmutableMap.builder()
+                        .put("external_metadata",
+                                ImmutableMap.builder()
+                                        .put("some-key", "value-1").put("SOME-KEY", "value-2").put("Some-key", "value-1").build())
+                        .build()
+                )).toEntity();
+
+        Map<String, Object> csvDataMap = csvTransactionFactory.toMap(transactionEntity);
+
+        assertThat(csvDataMap.get("some-key (metadata)"), is("value-1"));
+        assertThat(csvDataMap.containsKey("SOME-KEY (metadata)"), is(false));
+        assertThat(csvDataMap.containsKey("Some-key (metadata)"), is(false));
+    }
+
+    @Test
     public void toMapShouldIncludeFeeAndNetAmountForStripePayments() {
         TransactionEntity transactionEntity = transactionFixture.withNetAmount(594)
                 .withPaymentProvider("stripe")


### PR DESCRIPTION
All metadata keys are treated as lowercase, we validate against this
when creating payments but then show case sensitive columns in the CSV
download. `lower` all of the keys when generating and populating
headers.