### PR TITLE
PP-6421 Set event_count & payout_details on PayoutEntity

### DIFF
--- a/src/main/java/uk/gov/pay/ledger/payout/dao/PayoutDao.java
+++ b/src/main/java/uk/gov/pay/ledger/payout/dao/PayoutDao.java
@@ -41,7 +41,8 @@ public class PayoutDao {
             "status = EXCLUDED.status, " +
             "type = EXCLUDED.type, " +
             "event_count = EXCLUDED.event_count, " +
-            "payout_details = EXCLUDED.payout_details";
+            "payout_details = EXCLUDED.payout_details " +
+            "WHERE EXCLUDED.event_count >= payout.event_count";
 
     private Jdbi jdbi;
 

--- a/src/main/java/uk/gov/pay/ledger/payout/entity/PayoutEntity.java
+++ b/src/main/java/uk/gov/pay/ledger/payout/entity/PayoutEntity.java
@@ -115,6 +115,14 @@ public class PayoutEntity {
         this.type = type;
     }
 
+    public void setPayoutDetails(String payoutDetails) {
+        this.payoutDetails = payoutDetails;
+    }
+
+    public void setEventCount(Integer eventCount) {
+        this.eventCount = eventCount;
+    }
+
     public static final class PayoutEntityBuilder {
         private Long id;
         private String gatewayPayoutId;

--- a/src/main/java/uk/gov/pay/ledger/payout/model/PayoutEntityFactory.java
+++ b/src/main/java/uk/gov/pay/ledger/payout/model/PayoutEntityFactory.java
@@ -1,18 +1,24 @@
 package uk.gov.pay.ledger.payout.model;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.google.inject.Inject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import uk.gov.pay.ledger.event.model.EventDigest;
 import uk.gov.pay.ledger.payout.entity.PayoutEntity;
 import uk.gov.pay.ledger.payout.state.PayoutState;
 
+import java.util.Map;
+
 public class PayoutEntityFactory {
 
     private final ObjectMapper objectMapper;
+    private static final Logger LOGGER = LoggerFactory.getLogger(PayoutEntityFactory.class);
 
-    public PayoutEntityFactory(){
-        this.objectMapper = new ObjectMapper();
-        this.objectMapper.registerModule(new JavaTimeModule());
+    @Inject
+    public PayoutEntityFactory(ObjectMapper objectMapper){
+        this.objectMapper = objectMapper;
     }
 
     public PayoutEntity create(EventDigest eventDigest) {
@@ -21,11 +27,22 @@ public class PayoutEntityFactory {
                 .map(PayoutState::fromEventType)
                 .orElse(PayoutState.UNDEFINED);
 
+        String payoutDetails = convertToPayoutDetails(eventDigest.getEventPayload());
         PayoutEntity entity = objectMapper.convertValue(eventDigest.getEventPayload(), PayoutEntity.class);
         entity.setStatus(digestPayoutState);
         entity.setCreatedDate(eventDigest.getEventCreatedDate());
         entity.setGatewayPayoutId(eventDigest.getResourceExternalId());
+        entity.setEventCount(eventDigest.getEventCount());
+        entity.setPayoutDetails(payoutDetails);
         return entity;
     }
 
+    private String convertToPayoutDetails(Map<String, Object> payoutPayload) {
+        try {
+            return objectMapper.writeValueAsString(payoutPayload);
+        } catch (JsonProcessingException e) {
+            LOGGER.error("Unable to parse incoming event payload: {}", e.getMessage());
+        }
+        return "{}";
+    }
 }

--- a/src/test/java/uk/gov/pay/ledger/payout/dao/PayoutDaoIT.java
+++ b/src/test/java/uk/gov/pay/ledger/payout/dao/PayoutDaoIT.java
@@ -1,5 +1,6 @@
 package uk.gov.pay.ledger.payout.dao;
 
+import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.testcontainers.shaded.org.apache.commons.lang.RandomStringUtils;
@@ -20,9 +21,15 @@ public class PayoutDaoIT {
     public static AppWithPostgresAndSqsRule rule = new AppWithPostgresAndSqsRule();
 
     private PayoutDao payoutDao = new PayoutDao(rule.getJdbi());
+    private String gatewayPayoutId;
+
+    @Before
+    public void setUp(){
+        gatewayPayoutId = RandomStringUtils.random(6);
+    }
 
     @Test
-    public void shouldFetchTransaction() {
+    public void shouldFetchPayout() {
         var createdDate = ZonedDateTime.now(ZoneOffset.UTC);
         var paidOutDate = createdDate.minusDays(1);
         var id = RandomStringUtils.randomNumeric(4);
@@ -30,7 +37,7 @@ public class PayoutDaoIT {
                 .withId(Long.valueOf(id))
                 .withAmount(100L)
                 .withCreatedDate(createdDate)
-                .withGatewayPayoutId("po_asdasdasd")
+                .withGatewayPayoutId(gatewayPayoutId)
                 .withPaidOutDate(paidOutDate)
                 .withStatementDescriptor("a statement descriptor")
                 .withStatus(PayoutState.PAID_OUT)
@@ -38,10 +45,10 @@ public class PayoutDaoIT {
                 .withEventCount(1)
                 .withPayoutDetails("{\"key\": \"value\"}")
                 .build().insert(rule.getJdbi());
-        var payout = payoutDao.findByGatewayPayoutId("po_asdasdasd").get();
+        var payout = payoutDao.findByGatewayPayoutId(gatewayPayoutId).get();
         assertThat(payout.getId(), is(Long.valueOf(id)));
         assertThat(payout.getAmount(), is(100L));
-        assertThat(payout.getGatewayPayoutId(), is("po_asdasdasd"));
+        assertThat(payout.getGatewayPayoutId(), is(gatewayPayoutId));
         assertThat(payout.getStatementDescriptor(), is("a statement descriptor"));
         assertThat(payout.getStatus(), is(PayoutState.PAID_OUT));
         assertThat(payout.getType(), is("Bank Account"));
@@ -52,13 +59,13 @@ public class PayoutDaoIT {
     }
 
     @Test
-    public void shouldUpsertNonExistentTransaction(){
+    public void shouldUpsertNonExistentPayout(){
         var createdDate = ZonedDateTime.now(ZoneOffset.UTC);
         var paidOutDate = createdDate.minusDays(1);
 
         var payoutEntity = aPayoutEntity()
                 .withAmount(100L)
-                .withGatewayPayoutId("po_test2")
+                .withGatewayPayoutId(gatewayPayoutId)
                 .withPaidOutDate(paidOutDate)
                 .withStatementDescriptor("a statement descriptor")
                 .withStatus(PayoutState.IN_TRANSIT)
@@ -69,10 +76,10 @@ public class PayoutDaoIT {
 
         payoutDao.upsert(payoutEntity);
 
-        var payout = payoutDao.findByGatewayPayoutId("po_test2").get();
+        var payout = payoutDao.findByGatewayPayoutId(gatewayPayoutId).get();
         assertThat(payout.getId(), is(1L));
         assertThat(payout.getAmount(), is(100L));
-        assertThat(payout.getGatewayPayoutId(), is("po_test2"));
+        assertThat(payout.getGatewayPayoutId(), is(gatewayPayoutId));
         assertThat(payout.getStatementDescriptor(), is("a statement descriptor"));
         assertThat(payout.getStatus(), is(PayoutState.IN_TRANSIT));
         assertThat(payout.getType(), is("Bank Account"));
@@ -83,16 +90,17 @@ public class PayoutDaoIT {
     }
 
     @Test
-    public void shouldUpsertExistingTransaction() {
+    public void shouldUpsertExistingPayout() {
         var createdDate = ZonedDateTime.now(ZoneOffset.UTC);
         var paidOutDate = createdDate.minusDays(1);
 
         var payoutEntity = aPayoutEntity()
                 .withAmount(100L)
-                .withGatewayPayoutId("po_test2")
+                .withGatewayPayoutId(gatewayPayoutId)
                 .withPaidOutDate(paidOutDate)
                 .withStatementDescriptor("a statement descriptor")
                 .withStatus(PayoutState.IN_TRANSIT)
+                .withEventCount(1)
                 .withType("Bank Account")
                 .build();
 
@@ -100,23 +108,51 @@ public class PayoutDaoIT {
 
         var payoutEntity2 = aPayoutEntity()
                 .withAmount(1337L)
-                .withGatewayPayoutId("po_test2")
+                .withGatewayPayoutId(gatewayPayoutId)
                 .withPaidOutDate(paidOutDate)
                 .withStatementDescriptor("a descriptor")
                 .withStatus(PayoutState.PAID_OUT)
+                .withEventCount(2)
                 .withType("Test Account")
                 .build();
 
         payoutDao.upsert(payoutEntity2);
 
-        var payout = payoutDao.findByGatewayPayoutId("po_test2").get();
+        var payout = payoutDao.findByGatewayPayoutId(gatewayPayoutId).get();
 
         assertThat(payout.getAmount(), is(1337L));
-        assertThat(payout.getGatewayPayoutId(), is("po_test2"));
+        assertThat(payout.getGatewayPayoutId(), is(gatewayPayoutId));
         assertThat(payout.getStatementDescriptor(), is("a descriptor"));
         assertThat(payout.getStatus(), is(PayoutState.PAID_OUT));
         assertThat(payout.getType(), is("Test Account"));
         assertThat(payout.getCreatedDate(), is(notNullValue()));
         assertThat(payout.getPaidOutDate(), is(paidOutDate));
+    }
+
+    @Test
+    public void shouldNotUpsertPayoutIfPayoutConsistsOfFewerEvents() {
+        var payoutEntity = aPayoutEntity()
+                .withAmount(100L)
+                .withGatewayPayoutId(gatewayPayoutId)
+                .withStatus(PayoutState.IN_TRANSIT)
+                .withEventCount(3)
+                .build();
+
+        payoutDao.upsert(payoutEntity);
+
+        var payoutEntity2 = aPayoutEntity()
+                .withAmount(1337L)
+                .withGatewayPayoutId(gatewayPayoutId)
+                .withStatus(PayoutState.PAID_OUT)
+                .withEventCount(2)
+                .build();
+
+        payoutDao.upsert(payoutEntity2);
+
+        var payout = payoutDao.findByGatewayPayoutId(gatewayPayoutId).get();
+
+        assertThat(payout.getAmount(), is(100L));
+        assertThat(payout.getGatewayPayoutId(), is(gatewayPayoutId));
+        assertThat(payout.getStatus(), is(PayoutState.IN_TRANSIT));
     }
 }

--- a/src/test/java/uk/gov/pay/ledger/payout/model/PayoutEntityFactoryTest.java
+++ b/src/test/java/uk/gov/pay/ledger/payout/model/PayoutEntityFactoryTest.java
@@ -1,6 +1,9 @@
 package uk.gov.pay.ledger.payout.model;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.gson.GsonBuilder;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -25,10 +28,12 @@ public class PayoutEntityFactoryTest {
     private PayoutEntityFactory payoutEntityFactory;
 
     private GsonBuilder gsonBuilder = new GsonBuilder();
+    private ObjectMapper objectMapper;
 
     @Before
     public void setUp() {
-        payoutEntityFactory = new PayoutEntityFactory();
+        objectMapper = new ObjectMapper();
+        payoutEntityFactory = new PayoutEntityFactory(objectMapper);
     }
 
     @Test
@@ -58,6 +63,12 @@ public class PayoutEntityFactoryTest {
         assertThat(payoutEntity.getAmount(), is(10000L));
         assertThat(payoutEntity.getCreatedDate(), is(payoutCreatedEvent.getEventDate()));
         assertThat(payoutEntity.getPaidOutDate(), is(paidOutDate));
+        assertThat(payoutEntity.getEventCount(), is(2));
+
+        JsonObject payoutDetails = JsonParser.parseString(payoutEntity.getPayoutDetails()).getAsJsonObject();
+        assertThat(payoutDetails.get("amount").getAsInt(), is(10000));
+        assertThat(payoutDetails.get("statement_descriptor").getAsString(), is("SPECIAL TEST SERVICE"));
+        assertThat(payoutDetails.get("paid_out_date").getAsString(), is(paidOutDate.toString()));
     }
 
     @Test


### PR DESCRIPTION
## WHAT
- Sets event_count and payout_details when processing event digest for payouts
- Also updated DAO so we only update payouts when there a new event for payout

with @sandorarpa