### PR TITLE
PP-6469 Set Payout created_date from event digest

### DIFF
--- a/src/main/java/uk/gov/pay/ledger/payout/dao/PayoutDao.java
+++ b/src/main/java/uk/gov/pay/ledger/payout/dao/PayoutDao.java
@@ -14,20 +14,22 @@ public class PayoutDao {
 
     private final String UPSERT_PAYOUT = "INSERT INTO payout " +
             "(" +
-            "gateway_payout_id,\n" +
-            "amount,\n" +
-            "paid_out_date,\n" +
-            "state,\n" +
-            "event_count,\n" +
-            "payout_details\n" +
-            ")\n " +
+            "gateway_payout_id," +
+            "amount," +
+            "paid_out_date," +
+            "state," +
+            "event_count," +
+            "payout_details," +
+            "created_date" +
+            ") " +
             "VALUES (" +
-            ":gateway_payout_id, " +
+            ":gatewayPayoutId, " +
             ":amount, " +
-            ":paid_out_date, " +
+            ":paidOutDate, " +
             ":state, " +
-            ":event_count, " +
-            "CAST(:payout_details as jsonb) " +
+            ":eventCount, " +
+            "CAST(:payoutDetails as jsonb), " +
+            ":createdDate " +
             ") " +
             "ON CONFLICT (gateway_payout_id) DO UPDATE SET " +
             "gateway_payout_id = EXCLUDED.gateway_payout_id, " +
@@ -35,7 +37,8 @@ public class PayoutDao {
             "paid_out_date = EXCLUDED.paid_out_date, " +
             "state = EXCLUDED.state, " +
             "event_count = EXCLUDED.event_count, " +
-            "payout_details = EXCLUDED.payout_details " +
+            "payout_details = EXCLUDED.payout_details, " +
+            "created_date = EXCLUDED.created_date " +
             "WHERE EXCLUDED.event_count >= payout.event_count";
 
     private Jdbi jdbi;
@@ -55,12 +58,7 @@ public class PayoutDao {
     public void upsert(PayoutEntity payout) {
         jdbi.withHandle(handle ->
                 handle.createUpdate(UPSERT_PAYOUT)
-                        .bind("gateway_payout_id", payout.getGatewayPayoutId())
-                        .bind("amount", payout.getAmount())
-                        .bind("paid_out_date", payout.getPaidOutDate())
-                        .bind("state", payout.getState())
-                        .bind("event_count", payout.getEventCount())
-                        .bind("payout_details", payout.getPayoutDetails())
+                        .bindBean(payout)
                         .execute());
     }
 

--- a/src/test/java/uk/gov/pay/ledger/util/fixture/PayoutFixture.java
+++ b/src/test/java/uk/gov/pay/ledger/util/fixture/PayoutFixture.java
@@ -6,6 +6,8 @@ import uk.gov.pay.ledger.payout.state.PayoutState;
 
 import java.time.ZonedDateTime;
 
+import static java.time.ZoneOffset.UTC;
+import static java.time.ZonedDateTime.now;
 import static uk.gov.pay.ledger.payout.entity.PayoutEntity.PayoutEntityBuilder.aPayoutEntity;
 
 public class PayoutFixture implements DbFixture<PayoutFixture, PayoutEntity> {
@@ -13,7 +15,7 @@ public class PayoutFixture implements DbFixture<PayoutFixture, PayoutEntity> {
     private Long id;
     private String gatewayPayoutId;
     private Long amount;
-    private ZonedDateTime createdDate;
+    private ZonedDateTime createdDate = now(UTC);
     private ZonedDateTime paidOutDate;
     private PayoutState state;
     private Integer eventCount;


### PR DESCRIPTION
## WHAT
- Sets payout `created_date` derived from event digest instead of defaulting to DB date `now`.
- Cleaned up some static imports, brittle test, PayoutDao