### PR TITLE
PP-6469 Pact test for PayoutCreated event

### DIFF
--- a/src/test/java/uk/gov/pay/ledger/pact/ConsumerContractTestSuite.java
+++ b/src/test/java/uk/gov/pay/ledger/pact/ConsumerContractTestSuite.java
@@ -20,6 +20,7 @@ public class ConsumerContractTestSuite {
         consumerToJUnitTest.put("connector", new JUnit4TestAdapter(RefundSucceededEventQueueContractTest.class));
         consumerToJUnitTest.put("connector", new JUnit4TestAdapter(CaptureSubmittedEventQueueContractTest.class));
         consumerToJUnitTest.put("connector", new JUnit4TestAdapter(PaymentNotificationCreatedEventQueueContractTest.class));
+        consumerToJUnitTest.put("connector", new JUnit4TestAdapter(PayoutCreatedEventQueueContractTest.class));
         return CreateTestSuite.create(consumerToJUnitTest.build());
     }
 

--- a/src/test/java/uk/gov/pay/ledger/pact/PayoutCreatedEventQueueContractTest.java
+++ b/src/test/java/uk/gov/pay/ledger/pact/PayoutCreatedEventQueueContractTest.java
@@ -1,0 +1,88 @@
+package uk.gov.pay.ledger.pact;
+
+import au.com.dius.pact.consumer.MessagePactBuilder;
+import au.com.dius.pact.consumer.MessagePactProviderRule;
+import au.com.dius.pact.consumer.Pact;
+import au.com.dius.pact.consumer.PactVerification;
+import au.com.dius.pact.model.v3.messaging.MessagePact;
+import com.google.gson.Gson;
+import org.junit.Rule;
+import org.junit.Test;
+import uk.gov.pay.ledger.payout.dao.PayoutDao;
+import uk.gov.pay.ledger.payout.entity.PayoutEntity;
+import uk.gov.pay.ledger.rule.AppWithPostgresAndSqsRule;
+import uk.gov.pay.ledger.rule.SqsTestDocker;
+import uk.gov.pay.ledger.util.fixture.QueuePayoutEventFixture;
+
+import java.time.ZonedDateTime;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+
+import static io.dropwizard.testing.ConfigOverride.config;
+import static org.awaitility.Awaitility.await;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static uk.gov.pay.ledger.payout.state.PayoutState.IN_TRANSIT;
+
+public class PayoutCreatedEventQueueContractTest {
+    @Rule
+    public MessagePactProviderRule mockProvider = new MessagePactProviderRule(this);
+
+    @Rule
+    public AppWithPostgresAndSqsRule appRule = new AppWithPostgresAndSqsRule(
+            config("queueMessageReceiverConfig.backgroundProcessingEnabled", "true")
+    );
+
+    private byte[] currentMessage;
+    private String gatewayPayoutId = "po_1234567890";
+    private ZonedDateTime eventDate = ZonedDateTime.parse("2020-05-13T18:45:00.000000Z");
+
+    @Pact(provider = "connector", consumer = "ledger")
+    public MessagePact createPayoutCreatedEventPact(MessagePactBuilder builder) {
+        QueuePayoutEventFixture payoutEventFixture = QueuePayoutEventFixture.aQueuePayoutEventFixture()
+                .withResourceExternalId("po_1234567890")
+                .withEventDate(eventDate)
+                .withDefaultEventDataForEventType("PAYOUT_CREATED");
+
+        Map<String, String> metadata = new HashMap<>();
+        metadata.put("contentType", "application/json");
+
+        return builder
+                .expectsToReceive("a payout created message")
+                .withMetadata(metadata)
+                .withContent(payoutEventFixture.getAsPact())
+                .toPact();
+    }
+
+    @Test
+    @PactVerification({"connector"})
+    public void test() {
+        appRule.getSqsClient().sendMessage(SqsTestDocker.getQueueUrl("event-queue"), new String(currentMessage));
+
+        PayoutDao payoutDao = new PayoutDao(appRule.getJdbi());
+
+        await().atMost(1, TimeUnit.SECONDS).until(
+                () -> payoutDao.findByGatewayPayoutId(gatewayPayoutId).isPresent()
+        );
+
+        Optional<PayoutEntity> payoutEntity = payoutDao.findByGatewayPayoutId(gatewayPayoutId);
+        assertThat(payoutEntity.isPresent(), is(true));
+        assertThat(payoutEntity.get().getCreatedDate().toString(), is("2020-05-13T18:45Z"));
+        assertThat(payoutEntity.get().getGatewayPayoutId(), is(gatewayPayoutId));
+        assertThat(payoutEntity.get().getAmount(), is(1000L));
+        assertThat(payoutEntity.get().getState(), is(IN_TRANSIT));
+
+        Map<String, Object> payoutDetails = new Gson().fromJson(payoutEntity.get().getPayoutDetails(), Map.class);
+
+        assertThat(payoutDetails.get("estimated_arrival_date_in_bank"), is("2020-05-13T18:45:33.000000Z"));
+        assertThat(payoutDetails.get("gateway_status"), is("pending"));
+        assertThat(payoutDetails.get("destination_type"), is("bank_account"));
+        assertThat(payoutDetails.get("statement_descriptor"), is("SERVICE NAME"));
+    }
+
+    public void setMessage(byte[] messageContents) {
+        currentMessage = messageContents;
+    }
+}

--- a/src/test/java/uk/gov/pay/ledger/util/fixture/QueueEventFixtureUtil.java
+++ b/src/test/java/uk/gov/pay/ledger/util/fixture/QueueEventFixtureUtil.java
@@ -10,6 +10,7 @@ import uk.gov.pay.ledger.event.model.ResourceType;
 import uk.gov.pay.ledger.rule.SqsTestDocker;
 
 import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
 
 public class QueueEventFixtureUtil {
 
@@ -39,8 +40,10 @@ public class QueueEventFixtureUtil {
                                      String parentResourceExternalId, ResourceType resourceType, String eventData) {
         PactDslJsonBody eventDetails = new PactDslJsonBody();
 
+        DateTimeFormatter formatToMicroseconds = DateTimeFormatter.ofPattern("uuuu-MM-dd'T'HH:mm:ss.SSSSSSX");
+
         eventDetails.stringType("event_type", eventType);
-        eventDetails.stringType("timestamp", eventDate.toString());
+        eventDetails.stringType("timestamp", eventDate.format(formatToMicroseconds));
         eventDetails.stringType("resource_external_id", resourceExternalId);
         eventDetails.stringType("resource_type", resourceType.toString().toLowerCase());
         if (parentResourceExternalId != null && !parentResourceExternalId.isEmpty()) {

--- a/src/test/java/uk/gov/pay/ledger/util/fixture/QueuePayoutEventFixture.java
+++ b/src/test/java/uk/gov/pay/ledger/util/fixture/QueuePayoutEventFixture.java
@@ -1,0 +1,75 @@
+package uk.gov.pay.ledger.util.fixture;
+
+import au.com.dius.pact.consumer.dsl.PactDslJsonBody;
+import com.amazonaws.services.sqs.AmazonSQS;
+import com.google.common.collect.ImmutableMap;
+import com.google.gson.GsonBuilder;
+import uk.gov.pay.ledger.event.model.Event;
+import uk.gov.pay.ledger.event.model.ResourceType;
+
+import java.time.ZonedDateTime;
+
+import static org.apache.commons.lang3.StringUtils.EMPTY;
+import static uk.gov.pay.ledger.event.model.ResourceType.PAYOUT;
+
+public class QueuePayoutEventFixture implements QueueFixture<QueuePayoutEventFixture, Event> {
+    private String sqsMessageId;
+    private ResourceType resourceType = PAYOUT;
+    private String resourceExternalId = "resource_external_id";
+    private ZonedDateTime eventDate = ZonedDateTime.parse("2020-05-13T18:45:00.000000Z");
+    private String eventType = "PAYOUT_CREATED";
+    private String eventData = "{\"event_data\": \"event data\"}";
+
+    private QueuePayoutEventFixture() {
+    }
+
+    public static QueuePayoutEventFixture aQueuePayoutEventFixture() {
+        return new QueuePayoutEventFixture();
+    }
+
+    public QueuePayoutEventFixture withResourceExternalId(String resourceExternalId) {
+        this.resourceExternalId = resourceExternalId;
+        return this;
+    }
+
+    public QueuePayoutEventFixture withEventDate(ZonedDateTime eventDate) {
+        this.eventDate = eventDate;
+        return this;
+    }
+
+    public QueuePayoutEventFixture withDefaultEventDataForEventType(String eventType) {
+        switch (eventType) {
+            case "PAYOUT_CREATED":
+                eventData = new GsonBuilder().create()
+                        .toJson(ImmutableMap.builder()
+                                .put("amount", 1000)
+                                .put("estimated_arrival_date_in_bank", "2020-05-13T18:45:33.000000Z")
+                                .put("gateway_status", "pending")
+                                .put("destination_type", "bank_account")
+                                .put("statement_descriptor", "SERVICE NAME")
+                                .build());
+                break;
+            default:
+                eventData = new GsonBuilder().create()
+                        .toJson(ImmutableMap.of("event_data", "event_data"));
+        }
+        return this;
+    }
+
+    @Override
+    public Event toEntity() {
+        return new Event(0L, sqsMessageId, resourceType, resourceExternalId, EMPTY, eventDate, eventType, eventData);
+    }
+
+    @Override
+    public QueuePayoutEventFixture insert(AmazonSQS sqsClient) {
+        this.sqsMessageId = QueueEventFixtureUtil.insert(sqsClient, eventType, eventDate, resourceExternalId,
+                EMPTY, resourceType, eventData);
+        return this;
+    }
+
+    public PactDslJsonBody getAsPact() {
+        return QueueEventFixtureUtil.getAsPact(eventType, eventDate, resourceExternalId,
+                EMPTY, resourceType, eventData);
+    }
+}


### PR DESCRIPTION
## WHAT
- Added consumer pact test for PayoutCreated event received from connector (provider)
- Fixes ZonedDateTime format when generating pact as json body, as toString() can give varying output based on input. That is, for date time `2020-05-13T18:45:00.000000Z`, toString() returns `2020-05-13T18:45` instead of full date time as string which breaks https://github.com/alphagov/pay-ledger/blob/f76e13cdf4f369e298f71a80f148355d5d4d6bf5/src/main/java/uk/gov/pay/ledger/event/model/serializer/MicrosecondPrecisionDateTimeSerializer.java#L35