### PR TITLE
PP-6469 Drop foreign key to payout

### DIFF
--- a/src/main/resources/migrations/00052_drop_payout_foriegn_key_from_transaction.sql
+++ b/src/main/resources/migrations/00052_drop_payout_foriegn_key_from_transaction.sql
@@ -1,0 +1,7 @@
+--liquibase formatted sql
+
+--changeset uk.gov.pay:drop_payout_foreign_key_from_transaction
+ALTER TABLE transaction drop constraint transaction_gateway_payout_id_fkey;
+
+--rollback ALTER TABLE transaction ADD CONSTRAINT transaction_gateway_payout_id_fkey FOREIGN KEY (gateway_payout_id) REFERENCES payout (gateway_payout_id);
+


### PR DESCRIPTION
## WHAT 

- Drop foreign key to payout from transaction, as events can arrive in Ledger in any order, and transaction related events shouldn't break due to payout record not being available yet.