### PR TITLE
PP-6502 add search to payout service

### DIFF
--- a/src/main/java/uk/gov/pay/ledger/common/search/SearchParams.java
+++ b/src/main/java/uk/gov/pay/ledger/common/search/SearchParams.java
@@ -1,0 +1,16 @@
+package uk.gov.pay.ledger.common.search;
+
+import uk.gov.pay.ledger.util.CommaDelimitedSetParameter;
+
+public abstract class SearchParams {
+
+    public abstract String buildQueryParamString(Long forPage);
+
+    public abstract Long getPageNumber();
+
+    public abstract Long getDisplaySize();
+
+    protected boolean isSet(CommaDelimitedSetParameter commaDelimitedSetParameter) {
+        return commaDelimitedSetParameter != null && commaDelimitedSetParameter.isNotEmpty();
+    }
+}

--- a/src/main/java/uk/gov/pay/ledger/payout/model/PayoutSearchResponse.java
+++ b/src/main/java/uk/gov/pay/ledger/payout/model/PayoutSearchResponse.java
@@ -1,12 +1,11 @@
-package uk.gov.pay.ledger.transaction.model;
+package uk.gov.pay.ledger.payout.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import uk.gov.pay.ledger.util.pagination.PaginationBuilder;
-import uk.gov.pay.ledger.transaction.search.model.TransactionView;
 
 import java.util.List;
 
-public class TransactionSearchResponse {
+public class PayoutSearchResponse {
 
     @JsonProperty("total")
     private Long total;
@@ -15,19 +14,19 @@ public class TransactionSearchResponse {
     @JsonProperty("page")
     private long page;
     @JsonProperty("results")
-    List<TransactionView> transactionViewList;
+    List<PayoutView> payoutViewList;
     @JsonProperty("_links")
     private PaginationBuilder paginationBuilder;
 
-    public TransactionSearchResponse(Long total, Long count, Long page,
-                                     List<TransactionView> transactionViewList) {
+    public PayoutSearchResponse(Long total, long count, long page,
+                                List<PayoutView> payoutViewList) {
         this.total = total;
         this.count = count;
         this.page = page;
-        this.transactionViewList = transactionViewList;
+        this.payoutViewList = payoutViewList;
     }
 
-    public TransactionSearchResponse withPaginationBuilder(PaginationBuilder paginationBuilder) {
+    public PayoutSearchResponse withPaginationBuilder(PaginationBuilder paginationBuilder) {
         this.paginationBuilder = paginationBuilder;
         return this;
     }
@@ -36,16 +35,16 @@ public class TransactionSearchResponse {
         return total;
     }
 
-    public Long getCount() {
+    public long getCount() {
         return count;
     }
 
-    public Long getPage() {
+    public long getPage() {
         return page;
     }
 
-    public List<TransactionView> getTransactionViewList() {
-        return transactionViewList;
+    public List<PayoutView> getPayoutViewList() {
+        return payoutViewList;
     }
 
     public PaginationBuilder getPaginationBuilder() {

--- a/src/main/java/uk/gov/pay/ledger/payout/model/PayoutView.java
+++ b/src/main/java/uk/gov/pay/ledger/payout/model/PayoutView.java
@@ -1,0 +1,63 @@
+package uk.gov.pay.ledger.payout.model;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import uk.gov.pay.commons.api.json.ApiResponseDateTimeSerializer;
+import uk.gov.pay.ledger.payout.entity.PayoutEntity;
+import uk.gov.pay.ledger.payout.state.PayoutState;
+
+import java.time.ZonedDateTime;
+
+@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+public class PayoutView {
+
+    private Long amount;
+    @JsonSerialize(using = ApiResponseDateTimeSerializer.class)
+    private ZonedDateTime createdDate;
+    private String gatewayPayoutId;
+    private String gatewayAccountId;
+    @JsonSerialize(using = ApiResponseDateTimeSerializer.class)
+    private ZonedDateTime paidOutDate;
+    private PayoutState state;
+
+    private PayoutView(Long amount, ZonedDateTime createdDate, String gatewayPayoutId,
+                       String gatewayAccountId, ZonedDateTime paidOutDate, PayoutState state) {
+        this.amount = amount;
+        this.createdDate = createdDate;
+        this.gatewayPayoutId = gatewayPayoutId;
+        this.gatewayAccountId = gatewayAccountId;
+        this.paidOutDate = paidOutDate;
+        this.state = state;
+    }
+
+    public static PayoutView from(PayoutEntity payoutEntity) {
+
+        return new PayoutView(payoutEntity.getAmount(), payoutEntity.getCreatedDate(), payoutEntity.getGatewayPayoutId(),
+                payoutEntity.getGatewayAccountId(), payoutEntity.getPaidOutDate(), payoutEntity.getState());
+    }
+
+    public Long getAmount() {
+        return amount;
+    }
+
+    public ZonedDateTime getCreatedDate() {
+        return createdDate;
+    }
+
+    public String getGatewayPayoutId() {
+        return gatewayPayoutId;
+    }
+
+    public String getGatewayAccountId() {
+        return gatewayAccountId;
+    }
+
+    public ZonedDateTime getPaidOutDate() {
+        return paidOutDate;
+    }
+
+    public PayoutState getState() {
+        return state;
+    }
+}

--- a/src/main/java/uk/gov/pay/ledger/payout/service/PayoutService.java
+++ b/src/main/java/uk/gov/pay/ledger/payout/service/PayoutService.java
@@ -5,6 +5,16 @@ import uk.gov.pay.ledger.event.model.EventDigest;
 import uk.gov.pay.ledger.payout.dao.PayoutDao;
 import uk.gov.pay.ledger.payout.entity.PayoutEntity;
 import uk.gov.pay.ledger.payout.model.PayoutEntityFactory;
+import uk.gov.pay.ledger.payout.model.PayoutSearchResponse;
+import uk.gov.pay.ledger.payout.model.PayoutView;
+import uk.gov.pay.ledger.payout.search.PayoutSearchParams;
+import uk.gov.pay.ledger.util.pagination.PaginationBuilder;
+
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriInfo;
+import java.util.List;
+import java.util.stream.Collectors;
 
 public class PayoutService {
 
@@ -20,5 +30,32 @@ public class PayoutService {
     public void upsertPayoutFor(EventDigest eventDigest) {
         PayoutEntity payoutEntity = payoutEntityFactory.create(eventDigest);
         payoutDao.upsert(payoutEntity);
+    }
+
+    public PayoutSearchResponse searchPayouts(PayoutSearchParams searchParams, UriInfo uriInfo) {
+        List<PayoutView> payoutViewList = payoutDao.searchPayouts(searchParams)
+                .stream()
+                .map(PayoutView::from)
+                .collect(Collectors.toList());
+
+        Long total = payoutDao.getTotalForSearch(searchParams);
+
+        long size = searchParams.getDisplaySize();
+        if (total > 0 && searchParams.getDisplaySize() > 0) {
+            long lastPage = (total + size - 1) / size;
+            if (searchParams.getPageNumber() > lastPage || searchParams.getPageNumber() < 1) {
+                throw new WebApplicationException("the requested page not found",
+                        Response.Status.NOT_FOUND);
+            }
+        }
+
+        PaginationBuilder paginationBuilder = new PaginationBuilder(searchParams, uriInfo)
+                .withTotalCount(total)
+                .buildResponse();
+
+
+        return new PayoutSearchResponse(total, payoutViewList.size(),
+                searchParams.getPageNumber(), payoutViewList)
+                .withPaginationBuilder(paginationBuilder);
     }
 }

--- a/src/main/java/uk/gov/pay/ledger/transaction/search/common/TransactionSearchParams.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/search/common/TransactionSearchParams.java
@@ -1,5 +1,6 @@
 package uk.gov.pay.ledger.transaction.search.common;
 
+import uk.gov.pay.ledger.common.search.SearchParams;
 import uk.gov.pay.ledger.transaction.model.TransactionType;
 import uk.gov.pay.ledger.transaction.state.TransactionState;
 import uk.gov.pay.ledger.util.CommaDelimitedSetParameter;
@@ -17,7 +18,7 @@ import java.util.stream.Collectors;
 
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
-public class TransactionSearchParams {
+public class TransactionSearchParams extends SearchParams {
 
     private static final String GATEWAY_ACCOUNT_EXTERNAL_FIELD = "account_id";
     private static final String CARDHOLDER_NAME_FIELD = "cardholder_name";
@@ -314,10 +315,12 @@ public class TransactionSearchParams {
         return accountIds;
     }
 
+    @Override
     public Long getPageNumber() {
         return pageNumber;
     }
 
+    @Override
     public Long getDisplaySize() {
         if (this.displaySize > this.maxDisplaySize) {
             return this.maxDisplaySize;
@@ -346,6 +349,7 @@ public class TransactionSearchParams {
         return withParentTransaction;
     }
 
+    @Override
     public String buildQueryParamString(Long forPage) {
         List<String> queries = new ArrayList<>();
 
@@ -435,10 +439,6 @@ public class TransactionSearchParams {
 
     private String likeClause(String rawUserInputText) {
         return "%" + rawUserInputText + "%";
-    }
-
-    private boolean isSet(CommaDelimitedSetParameter commaDelimitedSetParameter) {
-        return commaDelimitedSetParameter != null && commaDelimitedSetParameter.isNotEmpty();
     }
 
     public void setExactReferenceMatch(boolean exactReferenceMatch) {

--- a/src/main/java/uk/gov/pay/ledger/transaction/service/TransactionService.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/service/TransactionService.java
@@ -19,7 +19,7 @@ import uk.gov.pay.ledger.transaction.model.TransactionSearchResponse;
 import uk.gov.pay.ledger.transaction.model.TransactionType;
 import uk.gov.pay.ledger.transaction.model.TransactionsForTransactionResponse;
 import uk.gov.pay.ledger.transaction.search.common.TransactionSearchParams;
-import uk.gov.pay.ledger.transaction.search.model.PaginationBuilder;
+import uk.gov.pay.ledger.util.pagination.PaginationBuilder;
 import uk.gov.pay.ledger.transaction.search.model.TransactionView;
 
 import javax.ws.rs.WebApplicationException;

--- a/src/main/java/uk/gov/pay/ledger/util/pagination/PaginationBuilder.java
+++ b/src/main/java/uk/gov/pay/ledger/util/pagination/PaginationBuilder.java
@@ -1,9 +1,9 @@
-package uk.gov.pay.ledger.transaction.search.model;
+package uk.gov.pay.ledger.util.pagination;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import uk.gov.pay.ledger.transaction.search.common.TransactionSearchParams;
+import uk.gov.pay.ledger.common.search.SearchParams;
 
 import javax.ws.rs.core.UriInfo;
 import java.net.URI;
@@ -18,7 +18,7 @@ public class PaginationBuilder {
     private static final String LAST_LINK = "last_page";
     private static final String PREV_LINK = "prev_page";
     private static final String NEXT_LINK = "next_page";
-    private TransactionSearchParams searchParams;
+    private SearchParams searchParams;
     private UriInfo uriInfo;
 
     @JsonIgnore
@@ -36,7 +36,7 @@ public class PaginationBuilder {
     @JsonProperty(NEXT_LINK)
     private PaginationLink nextLink;
 
-    public PaginationBuilder(TransactionSearchParams searchParams, UriInfo uriInfo) {
+    public PaginationBuilder(SearchParams searchParams, UriInfo uriInfo) {
         this.searchParams = searchParams;
         this.uriInfo = uriInfo;
         selfPageNum = searchParams.getPageNumber();

--- a/src/main/java/uk/gov/pay/ledger/util/pagination/PaginationLink.java
+++ b/src/main/java/uk/gov/pay/ledger/util/pagination/PaginationLink.java
@@ -1,4 +1,4 @@
-package uk.gov.pay.ledger.transaction.search.model;
+package uk.gov.pay.ledger.util.pagination;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 

--- a/src/test/java/uk/gov/pay/ledger/payout/dao/PayoutDaoSearchIT.java
+++ b/src/test/java/uk/gov/pay/ledger/payout/dao/PayoutDaoSearchIT.java
@@ -63,7 +63,7 @@ public class PayoutDaoSearchIT {
                 .insert(rule.getJdbi())
                 .toEntity();
 
-        searchParams.setAccountIds(List.of(payoutEntity2.getGatewayAccountId()));
+        searchParams.setGatewayAccountIds(List.of(payoutEntity2.getGatewayAccountId()));
 
         List<PayoutEntity> payoutList = payoutDao.searchPayouts(searchParams);
         assertThat(payoutList.size(), is(1));
@@ -108,7 +108,7 @@ public class PayoutDaoSearchIT {
                     .insert(rule.getJdbi());
         }
 
-        searchParams.setAccountIds(List.of(gatewayAccountId));
+        searchParams.setGatewayAccountIds(List.of(gatewayAccountId));
         searchParams.setDisplaySize(10L);
 
         searchParams.setPayoutStates(new CommaDelimitedSetParameter(PayoutState.IN_TRANSIT.name()));
@@ -131,7 +131,7 @@ public class PayoutDaoSearchIT {
                     .insert(rule.getJdbi());
         }
 
-        searchParams.setAccountIds(List.of(gatewayAccountId));
+        searchParams.setGatewayAccountIds(List.of(gatewayAccountId));
         searchParams.setDisplaySize(10L);
         searchParams.setPageNumber(2l);
 
@@ -179,7 +179,7 @@ public class PayoutDaoSearchIT {
                     .insert(rule.getJdbi());
         }
 
-        searchParams.setAccountIds(List.of(gatewayAccountId1, gatewayAccountId4));
+        searchParams.setGatewayAccountIds(List.of(gatewayAccountId1, gatewayAccountId4));
         List<PayoutEntity> payoutList = payoutDao.searchPayouts(searchParams);
         assertThat(payoutList.size(), is(10));
         assertThat(payoutList.get(0).getGatewayAccountId(), is(gatewayAccountId4));

--- a/src/test/java/uk/gov/pay/ledger/payout/service/PayoutServiceTest.java
+++ b/src/test/java/uk/gov/pay/ledger/payout/service/PayoutServiceTest.java
@@ -1,0 +1,134 @@
+package uk.gov.pay.ledger.payout.service;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.pay.ledger.payout.dao.PayoutDao;
+import uk.gov.pay.ledger.payout.entity.PayoutEntity;
+import uk.gov.pay.ledger.payout.model.PayoutEntityFactory;
+import uk.gov.pay.ledger.payout.model.PayoutSearchResponse;
+import uk.gov.pay.ledger.payout.search.PayoutSearchParams;
+
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.UriBuilder;
+import javax.ws.rs.core.UriInfo;
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.when;
+import static uk.gov.pay.ledger.util.fixture.PayoutFixture.aPayoutList;
+
+@RunWith(MockitoJUnitRunner.class)
+public class PayoutServiceTest {
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+    @Mock
+    private PayoutDao mockPayoutDao;
+    @Mock
+    private PayoutEntityFactory payoutEntityFactory;
+    @Mock
+    private UriInfo mockUriInfo;
+    private PayoutService payoutService;
+    private String gatewayAccountId = "12345";
+    private PayoutSearchParams searchParams;
+
+    @Before
+    public void setUp() {
+        payoutService = new PayoutService(mockPayoutDao, payoutEntityFactory);
+        when(mockUriInfo.getBaseUriBuilder()).thenReturn(UriBuilder.fromUri("http://example.com"));
+        when(mockUriInfo.getPath()).thenReturn("/v1/payout");
+    }
+
+    @Test
+    public void shouldReturnAPaginatedPayoutSearchResponse() {
+        searchParams = new PayoutSearchParams();
+        searchParams.setPageNumber(1L);
+        searchParams.setGatewayAccountIds(List.of(gatewayAccountId));
+
+        List<PayoutEntity> entityList = aPayoutList(gatewayAccountId, 10);
+        when(mockPayoutDao.searchPayouts(searchParams)).thenReturn(entityList);
+        when(mockPayoutDao.getTotalForSearch(searchParams)).thenReturn(10L);
+
+        PayoutSearchResponse response = payoutService.searchPayouts(searchParams, mockUriInfo);
+        assertThat(response.getTotal(), is(10L));
+        assertThat(response.getCount(), is(10L));
+        assertThat(response.getPage(), is(1L));
+        assertThat(response.getPayoutViewList().size(), is(10));
+        assertThat(response.getPayoutViewList().get(2).getGatewayAccountId(), is(gatewayAccountId));
+        assertThat(response.getPaginationBuilder().getSelfLink().getHref(), is("http://example.com/v1/payout?gateway_account_id=12345&page=1&display_size=20"));
+        assertThat(response.getPaginationBuilder().getFirstLink().getHref(), is("http://example.com/v1/payout?gateway_account_id=12345&page=1&display_size=20"));
+        assertThat(response.getPaginationBuilder().getLastLink().getHref(), is("http://example.com/v1/payout?gateway_account_id=12345&page=1&display_size=20"));
+        assertThat(response.getPaginationBuilder().getLastLink().getHref(), is("http://example.com/v1/payout?gateway_account_id=12345&page=1&display_size=20"));
+        assertThat(response.getPaginationBuilder().getNextLink(), is(nullValue()));
+    }
+
+    @Test
+    public void shouldThrowException_whenInvalidPageNumberIsRequested() {
+        searchParams = new PayoutSearchParams();
+        searchParams.setPageNumber(2L);
+        searchParams.setGatewayAccountIds(List.of(gatewayAccountId));
+        when(mockPayoutDao.searchPayouts(searchParams)).thenReturn(List.of());
+        when(mockPayoutDao.getTotalForSearch(searchParams)).thenReturn(10L);
+
+        thrown.expect(WebApplicationException.class);
+        thrown.expectMessage("the requested page not found");
+
+        PayoutSearchResponse response = payoutService.searchPayouts(searchParams, mockUriInfo);
+    }
+
+    @Test
+    public void shouldReturnAPaginatedPayoutSearchResponse_withNextLink() {
+        searchParams = new PayoutSearchParams();
+        searchParams.setPageNumber(1L);
+        searchParams.setGatewayAccountIds(List.of(gatewayAccountId));
+        searchParams.setDisplaySize(5L);
+
+        List<PayoutEntity> entityList = aPayoutList(gatewayAccountId, 10);
+        when(mockPayoutDao.searchPayouts(searchParams)).thenReturn(entityList);
+        when(mockPayoutDao.getTotalForSearch(searchParams)).thenReturn(10L);
+
+        PayoutSearchResponse response = payoutService.searchPayouts(searchParams, mockUriInfo);
+
+        assertThat(response.getTotal(), is(10L));
+        assertThat(response.getCount(), is(10L));
+        assertThat(response.getPage(), is(1L));
+        assertThat(response.getPayoutViewList().size(), is(10));
+        assertThat(response.getPayoutViewList().get(2).getGatewayAccountId(), is(gatewayAccountId));
+        assertThat(response.getPaginationBuilder().getSelfLink().getHref(), is("http://example.com/v1/payout?gateway_account_id=12345&page=1&display_size=5"));
+        assertThat(response.getPaginationBuilder().getFirstLink().getHref(), is("http://example.com/v1/payout?gateway_account_id=12345&page=1&display_size=5"));
+        assertThat(response.getPaginationBuilder().getLastLink().getHref(), is("http://example.com/v1/payout?gateway_account_id=12345&page=2&display_size=5"));
+        assertThat(response.getPaginationBuilder().getLastLink().getHref(), is("http://example.com/v1/payout?gateway_account_id=12345&page=2&display_size=5"));
+        assertThat(response.getPaginationBuilder().getNextLink().getHref(), is("http://example.com/v1/payout?gateway_account_id=12345&page=2&display_size=5"));
+    }
+
+    @Test
+    public void shouldReturnAPaginatedPayoutSearchResponse_withMultipleGatewayAccounts() {
+        String gatewayAccountId2 = "12346";
+        searchParams = new PayoutSearchParams();
+        searchParams.setPageNumber(1L);
+        searchParams.setGatewayAccountIds(List.of(gatewayAccountId, gatewayAccountId2));
+        searchParams.setDisplaySize(14L);
+
+        List<PayoutEntity> entityList = aPayoutList(gatewayAccountId, 10);
+        entityList.addAll(aPayoutList(gatewayAccountId2, 5));
+        when(mockPayoutDao.searchPayouts(searchParams)).thenReturn(entityList);
+        when(mockPayoutDao.getTotalForSearch(searchParams)).thenReturn(15L);
+        PayoutSearchResponse response = payoutService.searchPayouts(searchParams, mockUriInfo);
+
+        assertThat(response.getPayoutViewList().size(), is(15));
+
+        assertThat(response.getPayoutViewList().get(2).getGatewayAccountId(), is(gatewayAccountId));
+        assertThat(response.getPaginationBuilder().getSelfLink().getHref(), is("http://example.com/v1/payout?gateway_account_id=12345%2C12346&page=1&display_size=14"));
+        assertThat(response.getPaginationBuilder().getFirstLink().getHref(), is("http://example.com/v1/payout?gateway_account_id=12345%2C12346&page=1&display_size=14"));
+        assertThat(response.getPaginationBuilder().getLastLink().getHref(), is("http://example.com/v1/payout?gateway_account_id=12345%2C12346&page=2&display_size=14"));
+        assertThat(response.getPaginationBuilder().getLastLink().getHref(), is("http://example.com/v1/payout?gateway_account_id=12345%2C12346&page=2&display_size=14"));
+        assertThat(response.getPaginationBuilder().getNextLink().getHref(), is("http://example.com/v1/payout?gateway_account_id=12345%2C12346&page=2&display_size=14"));
+    }
+}

--- a/src/test/java/uk/gov/pay/ledger/transaction/service/TransactionServiceTest.java
+++ b/src/test/java/uk/gov/pay/ledger/transaction/service/TransactionServiceTest.java
@@ -23,7 +23,7 @@ import uk.gov.pay.ledger.transaction.model.TransactionFactory;
 import uk.gov.pay.ledger.transaction.model.TransactionSearchResponse;
 import uk.gov.pay.ledger.util.CommaDelimitedSetParameter;
 import uk.gov.pay.ledger.transaction.search.common.TransactionSearchParams;
-import uk.gov.pay.ledger.transaction.search.model.PaginationBuilder;
+import uk.gov.pay.ledger.util.pagination.PaginationBuilder;
 import uk.gov.pay.ledger.transaction.search.model.TransactionView;
 import uk.gov.pay.ledger.transaction.state.TransactionState;
 import uk.gov.pay.ledger.util.fixture.EventFixture;

--- a/src/test/java/uk/gov/pay/ledger/util/fixture/PayoutFixture.java
+++ b/src/test/java/uk/gov/pay/ledger/util/fixture/PayoutFixture.java
@@ -7,10 +7,13 @@ import uk.gov.pay.ledger.payout.entity.PayoutEntity;
 import uk.gov.pay.ledger.payout.state.PayoutState;
 
 import java.time.ZonedDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 import static java.time.ZoneOffset.UTC;
 import static java.time.ZonedDateTime.now;
 import static uk.gov.pay.ledger.payout.entity.PayoutEntity.PayoutEntityBuilder.aPayoutEntity;
+import static uk.gov.pay.ledger.util.fixture.PayoutFixture.PayoutFixtureBuilder.aPayoutFixture;
 
 public class PayoutFixture implements DbFixture<PayoutFixture, PayoutEntity> {
 
@@ -60,6 +63,18 @@ public class PayoutFixture implements DbFixture<PayoutFixture, PayoutEntity> {
                 .withPayoutDetails(payoutDetails)
                 .withGatewayAccountId(gatewayAccountId)
                 .build();
+    }
+
+    public static List<PayoutEntity> aPayoutList(String gatewayAccountId, int noOfPayouts) {
+        List<PayoutEntity> payoutEntityList = new ArrayList<>();
+
+        for (int i = 0; i < noOfPayouts; i++) {
+            payoutEntityList.add(aPayoutFixture()
+                    .withGatewayAccountId(gatewayAccountId)
+                    .build()
+                    .toEntity());
+        }
+        return payoutEntityList;
     }
 
     public static final class PayoutFixtureBuilder {

--- a/src/test/java/uk/gov/pay/ledger/util/pagination/PaginationBuilderTest.java
+++ b/src/test/java/uk/gov/pay/ledger/util/pagination/PaginationBuilderTest.java
@@ -1,10 +1,12 @@
-package uk.gov.pay.ledger.transaction.search.model;
+package uk.gov.pay.ledger.util.pagination;
 
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.pay.ledger.payout.search.PayoutSearchParams;
 import uk.gov.pay.ledger.transaction.search.common.TransactionSearchParams;
 
 import javax.ws.rs.core.UriBuilder;
@@ -15,7 +17,6 @@ import java.net.URISyntaxException;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class PaginationBuilderTest {
@@ -23,24 +24,26 @@ public class PaginationBuilderTest {
     @Mock
     private UriInfo mockedUriInfo;
 
-    TransactionSearchParams searchParams;
+    TransactionSearchParams transactionSearchParams;
+    PayoutSearchParams payoutSearchParams;
     private final String gatewayAccountExternalId = "a-gateway-account-external-id";
 
     @Before
     public void setUp() throws URISyntaxException {
         URI uri = new URI("http://example.org");
-        when(mockedUriInfo.getBaseUriBuilder()).thenReturn(UriBuilder.fromUri(uri), UriBuilder.fromUri(uri));
-        when(mockedUriInfo.getPath()).thenReturn("/transaction");
+        Mockito.when(mockedUriInfo.getBaseUriBuilder()).thenReturn(UriBuilder.fromUri(uri), UriBuilder.fromUri(uri));
+        Mockito.when(mockedUriInfo.getPath()).thenReturn("/transaction");
 
-        searchParams = new TransactionSearchParams();
+        transactionSearchParams = new TransactionSearchParams();
+        payoutSearchParams = new PayoutSearchParams();
     }
 
     @Test
     public void shouldBuildLinksWithoutPrevAndNextLinks_whenTotalIsLessThanDisplaySize() {
-        searchParams.setPageNumber(1L);
-        searchParams.setDisplaySize(500L);
+        transactionSearchParams.setPageNumber(1L);
+        transactionSearchParams.setDisplaySize(500L);
 
-        PaginationBuilder builder = new PaginationBuilder(searchParams, mockedUriInfo)
+        PaginationBuilder builder = new PaginationBuilder(transactionSearchParams, mockedUriInfo)
                 .withTotalCount(120L);
         builder = builder.buildResponse();
         assertThat(builder.getPrevLink(), is(nullValue()));
@@ -52,10 +55,10 @@ public class PaginationBuilderTest {
 
     @Test
     public void shouldBuildPrevFirstLastLinksWithPageSetTo1_whenRequestedPageIsGreaterThanLastPage() {
-        searchParams.setPageNumber(777L);
-        searchParams.setDisplaySize(500L);
+        payoutSearchParams.setPageNumber(777L);
+        payoutSearchParams.setDisplaySize(500L);
 
-        PaginationBuilder builder = new PaginationBuilder(searchParams, mockedUriInfo)
+        PaginationBuilder builder = new PaginationBuilder(payoutSearchParams, mockedUriInfo)
                 .withTotalCount(120L);
         builder = builder.buildResponse();
         assertThat(builder.getPrevLink().getHref().contains("page=1&display_size=500"), is(true));
@@ -67,9 +70,9 @@ public class PaginationBuilderTest {
 
     @Test
     public void shouldShowPrevAndFirstLinkAsEqualsAndLastAndNextLinkAsEquals() {
-        searchParams.setPageNumber(2L);
-        searchParams.setDisplaySize(50L);
-        PaginationBuilder builder = new PaginationBuilder(searchParams, mockedUriInfo)
+        transactionSearchParams.setPageNumber(2L);
+        transactionSearchParams.setDisplaySize(50L);
+        PaginationBuilder builder = new PaginationBuilder(transactionSearchParams, mockedUriInfo)
                 .withTotalCount(120L);
         builder = builder.buildResponse();
         assertThat(builder.getPrevLink().getHref().contains("page=1&display_size=50"), is(true));
@@ -81,9 +84,9 @@ public class PaginationBuilderTest {
 
     @Test
     public void shouldShowAllLinksCorrectly_whenMultiplePagesExists() {
-        searchParams.setPageNumber(3L);
-        searchParams.setDisplaySize(10L);
-        PaginationBuilder builder = new PaginationBuilder(searchParams, mockedUriInfo)
+        payoutSearchParams.setPageNumber(3L);
+        payoutSearchParams.setDisplaySize(10L);
+        PaginationBuilder builder = new PaginationBuilder(payoutSearchParams, mockedUriInfo)
                 .withTotalCount(120L);
         builder = builder.buildResponse();
         assertThat(builder.getFirstLink().getHref().contains("page=1&display_size=10"), is(true));


### PR DESCRIPTION
## WHAT
- add search by PayoutSearchParams to PayoutService
- add an abstract SearchParams class to be used for pagination
- refactor PaginationBuilder to use SearchParams
- move PaginationBuilder to util.pagination
- refactor TransactionSearchParams and PayoutSearchParams to extend
  SearchParams
- add PayoutSearchResponse and PayoutView classes
- add/update/refactor relevant tests