### PR TITLE
PP-6472 Persist and return gateway_payout_id on transaction

### DIFF
--- a/src/main/java/uk/gov/pay/ledger/transaction/dao/TransactionDao.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/dao/TransactionDao.java
@@ -43,7 +43,8 @@ public class TransactionDao {
             " parent.refund_amount_available as parent_refund_amount_available, " +
             " parent.fee as parent_fee," +
             " parent.type as parent_type, " +
-            " parent.moto as parent_moto " +
+            " parent.moto as parent_moto, " +
+            " parent.gateway_payout_id as parent_gateway_payout_id " +
             " FROM transaction t LEFT OUTER JOIN transaction parent " +
             " ON t.parent_external_id = parent.external_id ";
 
@@ -115,7 +116,8 @@ public class TransactionDao {
                     "live, " +
                     "moto, " +
                     "gateway_transaction_id, " +
-                    "source" +
+                    "source, " +
+                    "gateway_payout_id" +
                     ") " +
                     "VALUES (" +
                     ":externalId," +
@@ -143,7 +145,8 @@ public class TransactionDao {
                     ":live, " +
                     ":moto, " +
                     ":gatewayTransactionId, " +
-                    ":source::source" +
+                    ":source::source, " +
+                    ":gatewayPayoutId" +
                     ") " +
                     "ON CONFLICT (external_id) " +
                     "DO UPDATE SET " +
@@ -172,7 +175,8 @@ public class TransactionDao {
                     "live = EXCLUDED.live, " +
                     "moto = EXCLUDED.moto, " +
                     "gateway_transaction_id = EXCLUDED.gateway_transaction_id, " +
-                    "source = EXCLUDED.source " +
+                    "source = EXCLUDED.source, " +
+                    "gateway_payout_id = EXCLUDED.gateway_payout_id " +
                     "WHERE EXCLUDED.event_count >= transaction.event_count;";
 
     private static final String GET_SOURCE_TYPE_ENUM_VALUES =

--- a/src/main/java/uk/gov/pay/ledger/transaction/dao/mapper/TransactionMapper.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/dao/mapper/TransactionMapper.java
@@ -43,7 +43,8 @@ public class TransactionMapper implements RowMapper<TransactionEntity> {
                 .withTransactionType(rs.getString("type"))
                 .withLive(rs.getBoolean("live"))
                 .withMoto(rs.getBoolean("moto"))
-                .withGatewayTransactionId(rs.getString("gateway_transaction_id"));
+                .withGatewayTransactionId(rs.getString("gateway_transaction_id"))
+                .withGatewayPayoutId(rs.getString("gateway_payout_id"));
         Source.from(rs.getString("source")).ifPresent(builder::withSource);
         return builder.build();
     }

--- a/src/main/java/uk/gov/pay/ledger/transaction/dao/mapper/TransactionWithParentMapper.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/dao/mapper/TransactionWithParentMapper.java
@@ -43,6 +43,7 @@ public class TransactionWithParentMapper implements RowMapper<TransactionEntity>
                 .withTransactionType(rs.getString("parent_type"))
                 .withLive(rs.getBoolean("live"))
                 .withMoto(rs.getBoolean("parent_moto"))
+                .withGatewayPayoutId(rs.getString("parent_gateway_payout_id"))
                 .build();
 
         return new TransactionEntity.Builder()
@@ -71,6 +72,7 @@ public class TransactionWithParentMapper implements RowMapper<TransactionEntity>
                 .withTransactionType(rs.getString("type"))
                 .withLive(rs.getBoolean("live"))
                 .withMoto(rs.getBoolean("moto"))
+                .withGatewayPayoutId("gateway_payout_id")
                 .withParentTransactionEntity(parentTransactionEntity)
                 .build();
     }

--- a/src/main/java/uk/gov/pay/ledger/transaction/entity/TransactionEntity.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/entity/TransactionEntity.java
@@ -47,6 +47,7 @@ public class TransactionEntity {
     private TransactionEntity parentTransactionEntity;
     private String gatewayTransactionId;
     private Source source;
+    private String gatewayPayoutId;
 
     public TransactionEntity() {
     }
@@ -80,6 +81,7 @@ public class TransactionEntity {
         this.moto = builder.moto;
         this.gatewayTransactionId = builder.gatewayTransactionId;
         this.source = builder.source;
+        this.gatewayPayoutId = builder.gatewayPayoutId;
     }
 
     public Long getId() {
@@ -222,6 +224,10 @@ public class TransactionEntity {
         return source;
     }
 
+    public String getGatewayPayoutId() {
+        return gatewayPayoutId;
+    }
+
     public static class Builder {
         private Long fee;
         private Long id;
@@ -251,6 +257,7 @@ public class TransactionEntity {
         private Source source;
         private String gatewayTransactionId;
         private boolean moto;
+        private String gatewayPayoutId;
 
         public Builder() {
         }
@@ -396,6 +403,11 @@ public class TransactionEntity {
 
         public Builder withMoto(boolean moto) {
             this.moto = moto;
+            return this;
+        }
+
+        public Builder withGatewayPayoutId(String gatewayPayoutId) {
+            this.gatewayPayoutId = gatewayPayoutId;
             return this;
         }
     }

--- a/src/main/java/uk/gov/pay/ledger/transaction/model/Payment.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/model/Payment.java
@@ -56,8 +56,8 @@ public class Payment extends Transaction {
                    CardDetails cardDetails, Boolean delayedCapture, Map<String, Object> externalMetaData,
                    Integer eventCount, String gatewayTransactionId, Long corporateCardSurcharge, Long fee,
                    Long netAmount, Long totalAmount, RefundSummary refundSummary, SettlementSummary settlementSummary,
-                   Boolean moto, Boolean live, Source source, String walletType) {
-        super(id, gatewayAccountId, amount, externalId);
+                   Boolean moto, Boolean live, Source source, String walletType, String gatewayPayoutId) {
+        super(id, gatewayAccountId, amount, externalId, gatewayPayoutId);
         this.corporateCardSurcharge = corporateCardSurcharge;
         this.fee = fee;
         this.netAmount = netAmount;
@@ -94,12 +94,12 @@ public class Payment extends Transaction {
                    CardDetails cardDetails, Boolean delayedCapture, Map<String, Object> externalMetaData,
                    Integer eventCount, String gatewayTransactionId, Long corporateCardSurcharge, Long fee,
                    Long netAmount, RefundSummary refundSummary, Long totalAmount, SettlementSummary settlementSummary,
-                   Boolean moto, Boolean live, Source source, String walletType) {
+                   Boolean moto, Boolean live, Source source, String walletType, String gatewayPayoutId) {
 
         this(null, gatewayAccountId, amount, reference, description, state, language, externalId, returnUrl, email,
                 paymentProvider, createdDate, cardDetails, delayedCapture, externalMetaData, eventCount,
                 gatewayTransactionId, corporateCardSurcharge, fee, netAmount, totalAmount, refundSummary,
-                settlementSummary, moto, live, source, walletType);
+                settlementSummary, moto, live, source, walletType, gatewayPayoutId);
     }
 
     @Override

--- a/src/main/java/uk/gov/pay/ledger/transaction/model/Refund.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/model/Refund.java
@@ -17,7 +17,7 @@ public class Refund extends Transaction {
     private final Optional<Transaction> parentTransaction;
 
     public Refund(Builder builder) {
-        super(builder.id, builder.gatewayAccountId, builder.amount, builder.externalId);
+        super(builder.id, builder.gatewayAccountId, builder.amount, builder.externalId, builder.gatewayPayoutId);
         this.reference = builder.reference;
         this.description = builder.description;
         this.state = builder.state;
@@ -84,6 +84,7 @@ public class Refund extends Transaction {
         private String externalId;
         private String parentExternalId;
         private Optional<Transaction> parentTransaction;
+        private String gatewayPayoutId;
 
         public Builder() {
         }
@@ -154,6 +155,11 @@ public class Refund extends Transaction {
 
         public Builder withParentTransaction(Optional<Transaction> transaction) {
             this.parentTransaction = transaction;
+            return this;
+        }
+
+        public Builder withGatewayPayoutId(String gatewayPayoutId) {
+            this.gatewayPayoutId = gatewayPayoutId;
             return this;
         }
     }

--- a/src/main/java/uk/gov/pay/ledger/transaction/model/Transaction.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/model/Transaction.java
@@ -12,15 +12,17 @@ public abstract class Transaction {
     protected String gatewayAccountId;
     protected Long amount;
     protected String externalId;
+    private String gatewayPayoutId;
 
     public Transaction() {
     }
 
-    public Transaction(Long id, String gatewayAccountId, Long amount, String externalId) {
+    public Transaction(Long id, String gatewayAccountId, Long amount, String externalId, String gatewayPayoutId) {
         this.id = id;
         this.gatewayAccountId = gatewayAccountId;
         this.amount = amount;
         this.externalId = externalId;
+        this.gatewayPayoutId = gatewayPayoutId;
     }
 
     public Long getId() {
@@ -39,5 +41,9 @@ public abstract class Transaction {
 
     public String getExternalId() {
         return externalId;
+    }
+
+    public String getGatewayPayoutId() {
+        return gatewayPayoutId;
     }
 }

--- a/src/main/java/uk/gov/pay/ledger/transaction/model/TransactionFactory.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/model/TransactionFactory.java
@@ -95,7 +95,8 @@ public class TransactionFactory {
                     entity.isMoto(),
                     entity.isLive(),
                     entity.getSource(),
-                    safeGetAsString(transactionDetails, "wallet")
+                    safeGetAsString(transactionDetails, "wallet"),
+                    entity.getGatewayPayoutId()
             );
         } catch (IOException e) {
             LOGGER.error("Error during the parsing transaction entity data [{}] [errorMessage={}]", entity.getExternalId(), e.getMessage());
@@ -124,6 +125,7 @@ public class TransactionFactory {
                     .withRefundedByUserEmail(safeGetAsString(transactionDetails, "user_email"))
                     .withParentExternalId(entity.getParentExternalId())
                     .withParentTransaction(parentTransaction)
+                    .withGatewayPayoutId(entity.getGatewayPayoutId())
                     .build();
 
         } catch (IOException e) {

--- a/src/main/java/uk/gov/pay/ledger/transaction/search/model/TransactionView.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/search/model/TransactionView.java
@@ -58,6 +58,7 @@ public class TransactionView {
     private Boolean live;
     private Source source;
     private String walletType;
+    private String gatewayPayoutId;
 
     public TransactionView(Builder builder) {
         this.id = builder.id;
@@ -91,6 +92,7 @@ public class TransactionView {
         this.live = builder.live;
         this.source = builder.source;
         this.walletType = builder.walletType;
+        this.gatewayPayoutId = builder.gatewayPayoutId;
     }
 
     public TransactionView() {
@@ -129,6 +131,7 @@ public class TransactionView {
                     .withLive(payment.isLive())
                     .withSource(payment.getSource())
                     .withWalletType(payment.getWalletType())
+                    .withGatewayPayoutId(payment.getGatewayPayoutId())
                     .build();
         }
 
@@ -147,6 +150,7 @@ public class TransactionView {
                 .withRefundedByUserEmail(refund.getRefundedByUserEmail())
                 .withTransactionType(refund.getTransactionType())
                 .withParentTransaction(refund.getParentTransaction().map(parentTransaction -> from(parentTransaction, statusVersion)).orElse(null))
+                .withGatewayPayoutId(refund.getGatewayPayoutId())
                 .build();
     }
 
@@ -289,8 +293,11 @@ public class TransactionView {
         return walletType;
     }
 
+    public String getGatewayPayoutId() {
+        return gatewayPayoutId;
+    }
+
     public static class Builder {
-        public String walletType;
         private TransactionView parentTransaction;
         private Long id;
         private String gatewayAccountId;
@@ -322,6 +329,8 @@ public class TransactionView {
         private Boolean moto;
         private Boolean live;
         private Source source;
+        private String walletType;
+        private String gatewayPayoutId;
 
         public Builder() {
         }
@@ -482,6 +491,11 @@ public class TransactionView {
 
         public Builder withWalletType(String walletType) {
             this.walletType = walletType;
+            return this;
+        }
+
+        public Builder withGatewayPayoutId(String gatewayPayoutId) {
+            this.gatewayPayoutId = gatewayPayoutId;
             return this;
         }
     }

--- a/src/test/java/uk/gov/pay/ledger/event/model/TransactionEntityFactoryTest.java
+++ b/src/test/java/uk/gov/pay/ledger/event/model/TransactionEntityFactoryTest.java
@@ -52,7 +52,13 @@ public class TransactionEntityFactoryTest {
                 .withEventData("{\"net_amount\": 55, \"total_amount\": 105, \"fee\": 33}")
                 .withResourceType(ResourceType.PAYMENT)
                 .toEntity();
-        EventDigest eventDigest = EventDigest.fromEventList(List.of(paymentCreatedEvent, paymentDetailsEvent, captureConfirmedEvent));
+        Event paymentIncludedInPayoutEvent = aQueuePaymentEventFixture()
+                .withEventType("PAYMENT_INCLUDED_IN_PAYOUT")
+                .withEventData("{\"gateway_payout_id\": \"payout-id\"}")
+                .withResourceType(ResourceType.PAYMENT)
+                .toEntity();
+        EventDigest eventDigest = EventDigest.fromEventList(List.of(paymentCreatedEvent, paymentDetailsEvent,
+                captureConfirmedEvent, paymentIncludedInPayoutEvent));
 
         TransactionEntity transactionEntity = transactionEntityFactory.create(eventDigest);
 
@@ -75,6 +81,7 @@ public class TransactionEntityFactoryTest {
         assertThat(transactionEntity.getTransactionType(), is("PAYMENT"));
         assertThat(transactionEntity.getSource(), is(notNullValue()));
         assertThat(transactionEntity.isLive(), is(true));
+        assertThat(transactionEntity.getGatewayPayoutId(), is("payout-id"));
 
         JsonObject transactionDetails = JsonParser.parseString(transactionEntity.getTransactionDetails()).getAsJsonObject();
         assertThat(transactionDetails.get("language").getAsString(), is("en"));

--- a/src/test/java/uk/gov/pay/ledger/transaction/dao/TransactionDaoIT.java
+++ b/src/test/java/uk/gov/pay/ledger/transaction/dao/TransactionDaoIT.java
@@ -42,6 +42,7 @@ public class TransactionDaoIT {
                 .withTransactionType("PAYMENT")
                 .withLive(true)
                 .withGatewayTransactionId("gateway_transaction_id")
+                .withGatewayPayoutId("payout-id")
                 .withDefaultTransactionDetails();
         TransactionEntity transactionEntity = fixture.toEntity();
 
@@ -117,6 +118,7 @@ public class TransactionDaoIT {
         assertThat(transaction.getRefundAmountRefunded(), is(fixture.getRefundAmountRefunded()));
         assertThat(transaction.getRefundStatus(), is(fixture.getRefundStatus()));
         assertThat(transaction.getGatewayTransactionId(), is(fixture.getGatewayTransactionId()));
+        assertThat(transaction.getGatewayPayoutId(), is(fixture.getGatewayPayoutId()));
     }
 
     @Test
@@ -144,6 +146,7 @@ public class TransactionDaoIT {
         TransactionEntity parentTransactionEntity = aTransactionFixture()
                 .withTransactionType(TransactionType.PAYMENT.name())
                 .withDefaultTransactionDetails()
+                .withGatewayPayoutId("payment-payout-id")
                 .insert(rule.getJdbi())
                 .toEntity();
 
@@ -151,6 +154,7 @@ public class TransactionDaoIT {
                 .withTransactionType(TransactionType.REFUND.name())
                 .withParentExternalId(parentTransactionEntity.getExternalId())
                 .withDefaultTransactionDetails()
+                .withGatewayPayoutId("refund-payout-id")
                 .insert(rule.getJdbi())
                 .toEntity();
 
@@ -170,6 +174,7 @@ public class TransactionDaoIT {
         assertThat(transaction.getCreatedDate(), is(transactionEntity.getCreatedDate()));
         assertThat(transaction.getEventCount(), is(transactionEntity.getEventCount()));
         assertThat(transaction.getTransactionType(), is(transactionEntity.getTransactionType()));
+        assertThat(transaction.getGatewayPayoutId(), is(transactionEntity.getGatewayPayoutId()));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/ledger/transaction/resource/TransactionResourceIT.java
+++ b/src/test/java/uk/gov/pay/ledger/transaction/resource/TransactionResourceIT.java
@@ -39,12 +39,14 @@ public class TransactionResourceIT {
 
     @Test
     public void shouldGetTransaction() {
+        var gatewayPayoutId = "payout-id";
 
         transactionFixture = aTransactionFixture()
                 .withDefaultCardDetails()
                 .withDefaultTransactionDetails()
                 .withLive(Boolean.TRUE)
-                .withSource(String.valueOf(Source.CARD_API));
+                .withSource(String.valueOf(Source.CARD_API))
+                .withGatewayPayoutId(gatewayPayoutId);
         transactionFixture.insert(rule.getJdbi());
 
         given().port(port)
@@ -60,7 +62,8 @@ public class TransactionResourceIT {
                 .body("card_details.billing_address.line1", is(transactionFixture.getCardDetails().getBillingAddress().getAddressLine1()))
                 .body("live", is(Boolean.TRUE))
                 .body("wallet_type", is("APPLE_PAY"))
-                .body("source", is(String.valueOf(Source.CARD_API)));
+                .body("source", is(String.valueOf(Source.CARD_API)))
+                .body("gateway_payout_id", is(gatewayPayoutId));
     }
 
     @Test
@@ -133,6 +136,7 @@ public class TransactionResourceIT {
         var now = ZonedDateTime.parse("2019-07-31T14:52:07.073Z");
         var refundedBy = "some_user_id";
         var refundedByUserEmail = "test@example.com";
+        var gatewayPayoutId = "payout-id";
 
         transactionFixture = aTransactionFixture()
                 .withTransactionType("REFUND")
@@ -140,7 +144,8 @@ public class TransactionResourceIT {
                 .withCreatedDate(now)
                 .withRefundedById(refundedBy)
                 .withRefundedByUserEmail(refundedByUserEmail)
-                .withDefaultTransactionDetails();
+                .withDefaultTransactionDetails()
+                .withGatewayPayoutId(gatewayPayoutId);
         transactionFixture.insert(rule.getJdbi());
 
         given().port(port)
@@ -155,7 +160,8 @@ public class TransactionResourceIT {
                 .body("reference", is(transactionFixture.getReference()))
                 .body("created_date", is(now.toString()))
                 .body("refunded_by", is(refundedBy))
-                .body("refunded_by_user_email", is(refundedByUserEmail));
+                .body("refunded_by_user_email", is(refundedByUserEmail))
+                .body("gateway_payout_id", is(gatewayPayoutId));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/ledger/util/fixture/TransactionFixture.java
+++ b/src/test/java/uk/gov/pay/ledger/util/fixture/TransactionFixture.java
@@ -71,6 +71,7 @@ public class TransactionFixture implements DbFixture<TransactionFixture, Transac
     private String refundedByUserEmail;
     private TransactionEntity parentTransactionEntity;
     private String source;
+    private String gatewayPayoutId;
 
     private TransactionFixture() {
     }
@@ -300,6 +301,11 @@ public class TransactionFixture implements DbFixture<TransactionFixture, Transac
         return this;
     }
 
+    public TransactionFixture withGatewayPayoutId(String gatewayPayoutId) {
+        this.gatewayPayoutId = gatewayPayoutId;
+        return this;
+    }
+
     @Override
     public TransactionFixture insert(Jdbi jdbi) {
         jdbi.withHandle(h ->
@@ -332,9 +338,10 @@ public class TransactionFixture implements DbFixture<TransactionFixture, Transac
                                 "        live,\n" +
                                 "        moto,\n" +
                                 "        gateway_transaction_id,\n" +
-                                "        source\n" +
+                                "        source,\n" +
+                                "        gateway_payout_id\n" +
                                 "    )\n" +
-                                "VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, CAST(? as jsonb), ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?::transaction_type, ?, ?, ?, ?::source)\n",
+                                "VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, CAST(? as jsonb), ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?::transaction_type, ?, ?, ?, ?::source, ?)\n",
                         id,
                         externalId,
                         parentExternalId,
@@ -361,7 +368,8 @@ public class TransactionFixture implements DbFixture<TransactionFixture, Transac
                         live,
                         moto,
                         gatewayTransactionId,
-                        source
+                        source,
+                        gatewayPayoutId
                 )
         );
         return this;
@@ -437,7 +445,8 @@ public class TransactionFixture implements DbFixture<TransactionFixture, Transac
                 .withLive(live)
                 .withMoto(moto)
                 .withGatewayTransactionId(gatewayTransactionId)
-                .withParentTransactionEntity(parentTransactionEntity);
+                .withParentTransactionEntity(parentTransactionEntity)
+                .withGatewayPayoutId(gatewayPayoutId);
         Source.from(source).ifPresent(builder::withSource);
         return builder.build();
     }
@@ -496,6 +505,30 @@ public class TransactionFixture implements DbFixture<TransactionFixture, Transac
 
     public String getParentExternalId() {
         return parentExternalId;
+    }
+
+    public String getTransactionType() {
+        return transactionType;
+    }
+
+    public Long getRefundAmountAvailable() {
+        return refundAmountAvailable;
+    }
+
+    public Long getRefundAmountRefunded() {
+        return refundAmountRefunded;
+    }
+
+    public String getRefundStatus() {
+        return refundStatus;
+    }
+
+    public String getGatewayTransactionId() {
+        return gatewayTransactionId;
+    }
+
+    public String getGatewayPayoutId() {
+        return gatewayPayoutId;
     }
 
     public TransactionFixture withDefaultCardDetails(boolean includeCardDetails) {
@@ -559,25 +592,5 @@ public class TransactionFixture implements DbFixture<TransactionFixture, Transac
     public TransactionFixture withRefundedByUserEmail(String refundedByUserEmail) {
         this.refundedByUserEmail = refundedByUserEmail;
         return this;
-    }
-
-    public String getTransactionType() {
-        return transactionType;
-    }
-
-    public Long getRefundAmountAvailable() {
-        return refundAmountAvailable;
-    }
-
-    public Long getRefundAmountRefunded() {
-        return refundAmountRefunded;
-    }
-
-    public String getRefundStatus() {
-        return refundStatus;
-    }
-
-    public String getGatewayTransactionId() {
-        return gatewayTransactionId;
     }
 }


### PR DESCRIPTION
Add gateway_payout_id column to TransactionEntity and persist it as a
top-level field.

Return gateway_payout_id as field on transactions returned by the get
transactions API endpoints.