### PR TITLE
PP-6486 Drop not null constraint on payout.amount

### DIFF
--- a/src/main/resources/migrations/00053_payout_drop_not_null_constraint_on_amount.sql
+++ b/src/main/resources/migrations/00053_payout_drop_not_null_constraint_on_amount.sql
@@ -1,0 +1,7 @@
+--liquibase formatted sql
+
+--changeset uk.gov.pay:payout_drop_not_null_constraint_on_amount
+ALTER TABLE payout alter amount drop not null ;
+
+--rollback ALTER TABLE payout ALTER COLUMN amount SET NOT NULL;
+


### PR DESCRIPTION
## WHAT
- Drops not null constraint on `payout.amount` column so ledger can process out of order payout events.
  `amount` is only available for PAYOUT_CREATED event.