### PR TITLE
PP-6486 Pact tests for payout events

### DIFF
--- a/src/test/java/uk/gov/pay/ledger/pact/PayoutFailedEventQueueContractTest.java
+++ b/src/test/java/uk/gov/pay/ledger/pact/PayoutFailedEventQueueContractTest.java
@@ -1,0 +1,87 @@
+package uk.gov.pay.ledger.pact;
+
+import au.com.dius.pact.consumer.MessagePactBuilder;
+import au.com.dius.pact.consumer.MessagePactProviderRule;
+import au.com.dius.pact.consumer.Pact;
+import au.com.dius.pact.consumer.PactVerification;
+import au.com.dius.pact.model.v3.messaging.MessagePact;
+import com.google.gson.Gson;
+import org.junit.Rule;
+import org.junit.Test;
+import uk.gov.pay.ledger.payout.dao.PayoutDao;
+import uk.gov.pay.ledger.payout.entity.PayoutEntity;
+import uk.gov.pay.ledger.rule.AppWithPostgresAndSqsRule;
+import uk.gov.pay.ledger.rule.SqsTestDocker;
+import uk.gov.pay.ledger.util.fixture.QueuePayoutEventFixture;
+
+import java.time.ZonedDateTime;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+
+import static io.dropwizard.testing.ConfigOverride.config;
+import static java.time.ZonedDateTime.parse;
+import static org.awaitility.Awaitility.await;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static uk.gov.pay.ledger.payout.state.PayoutState.FAILED;
+
+public class PayoutFailedEventQueueContractTest {
+    @Rule
+    public MessagePactProviderRule mockProvider = new MessagePactProviderRule(this);
+
+    @Rule
+    public AppWithPostgresAndSqsRule appRule = new AppWithPostgresAndSqsRule(
+            config("queueMessageReceiverConfig.backgroundProcessingEnabled", "true")
+    );
+
+    private byte[] currentMessage;
+    private String gatewayPayoutId = "po_failed_1234567890";
+    private ZonedDateTime eventDate = parse("2020-05-13T18:50:00Z");
+    private String eventType = "PAYOUT_FAILED";
+
+    @Pact(provider = "connector", consumer = "ledger")
+    public MessagePact createPayoutFailedEventPact(MessagePactBuilder builder) {
+        QueuePayoutEventFixture payoutEventFixture = QueuePayoutEventFixture.aQueuePayoutEventFixture()
+                .withResourceExternalId(gatewayPayoutId)
+                .withEventDate(eventDate)
+                .withEventType(eventType)
+                .withDefaultEventDataForEventType(eventType);
+
+        Map<String, String> metadata = new HashMap<>();
+        metadata.put("contentType", "application/json");
+
+        return builder
+                .expectsToReceive("a payout failed message")
+                .withMetadata(metadata)
+                .withContent(payoutEventFixture.getAsPact())
+                .toPact();
+    }
+
+    @Test
+    @PactVerification({"connector"})
+    public void test() {
+        appRule.getSqsClient().sendMessage(SqsTestDocker.getQueueUrl("event-queue"), new String(currentMessage));
+        PayoutDao payoutDao = new PayoutDao(appRule.getJdbi());
+
+        await().atMost(1, TimeUnit.SECONDS).until(
+                () -> payoutDao.findByGatewayPayoutId(gatewayPayoutId).isPresent()
+        );
+
+        Optional<PayoutEntity> payoutEntity = payoutDao.findByGatewayPayoutId(gatewayPayoutId);
+        assertThat(payoutEntity.isPresent(), is(true));
+        assertThat(payoutEntity.get().getGatewayPayoutId(), is(gatewayPayoutId));
+        assertThat(payoutEntity.get().getState(), is(FAILED));
+
+        Map<String, Object> payoutDetails = new Gson().fromJson(payoutEntity.get().getPayoutDetails(), Map.class);
+        assertThat(payoutDetails.get("gateway_status"), is("failed"));
+        assertThat(payoutDetails.get("failure_code"), is("account_closed"));
+        assertThat(payoutDetails.get("failure_message"), is("The bank account has been closed"));
+        assertThat(payoutDetails.get("failure_balance_transaction"), is("ba_aaaaaaaaaa"));
+    }
+
+    public void setMessage(byte[] messageContents) {
+        currentMessage = messageContents;
+    }
+}

--- a/src/test/java/uk/gov/pay/ledger/pact/PayoutPaidEventQueueContractTest.java
+++ b/src/test/java/uk/gov/pay/ledger/pact/PayoutPaidEventQueueContractTest.java
@@ -1,0 +1,88 @@
+package uk.gov.pay.ledger.pact;
+
+import au.com.dius.pact.consumer.MessagePactBuilder;
+import au.com.dius.pact.consumer.MessagePactProviderRule;
+import au.com.dius.pact.consumer.Pact;
+import au.com.dius.pact.consumer.PactVerification;
+import au.com.dius.pact.model.v3.messaging.MessagePact;
+import com.google.gson.Gson;
+import org.junit.Rule;
+import org.junit.Test;
+import uk.gov.pay.ledger.payout.dao.PayoutDao;
+import uk.gov.pay.ledger.payout.entity.PayoutEntity;
+import uk.gov.pay.ledger.rule.AppWithPostgresAndSqsRule;
+import uk.gov.pay.ledger.rule.SqsTestDocker;
+import uk.gov.pay.ledger.util.fixture.PayoutFixture;
+import uk.gov.pay.ledger.util.fixture.QueuePayoutEventFixture;
+
+import java.time.ZonedDateTime;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+
+import static io.dropwizard.testing.ConfigOverride.config;
+import static java.time.ZonedDateTime.parse;
+import static org.awaitility.Awaitility.await;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static uk.gov.pay.ledger.payout.state.PayoutState.PAID_OUT;
+import static uk.gov.pay.ledger.payout.state.PayoutState.UNDEFINED;
+import static uk.gov.pay.ledger.util.fixture.PayoutFixture.PayoutFixtureBuilder.aPayoutFixture;
+
+public class PayoutPaidEventQueueContractTest {
+    @Rule
+    public MessagePactProviderRule mockProvider = new MessagePactProviderRule(this);
+
+    @Rule
+    public AppWithPostgresAndSqsRule appRule = new AppWithPostgresAndSqsRule(
+            config("queueMessageReceiverConfig.backgroundProcessingEnabled", "true")
+    );
+
+    private byte[] currentMessage;
+    private String gatewayPayoutId = "po_paid_1234567890";
+    private ZonedDateTime eventDate = parse("2020-05-13T18:50:00Z");
+    private String eventType = "PAYOUT_PAID";
+
+    @Pact(provider = "connector", consumer = "ledger")
+    public MessagePact createPayoutPaidEventPact(MessagePactBuilder builder) {
+        QueuePayoutEventFixture payoutEventFixture = QueuePayoutEventFixture.aQueuePayoutEventFixture()
+                .withResourceExternalId(gatewayPayoutId)
+                .withEventDate(eventDate)
+                .withEventType(eventType)
+                .withDefaultEventDataForEventType(eventType);
+
+        Map<String, String> metadata = new HashMap<>();
+        metadata.put("contentType", "application/json");
+
+        return builder
+                .expectsToReceive("a payout paid message")
+                .withMetadata(metadata)
+                .withContent(payoutEventFixture.getAsPact())
+                .toPact();
+    }
+
+    @Test
+    @PactVerification({"connector"})
+    public void test() {
+        appRule.getSqsClient().sendMessage(SqsTestDocker.getQueueUrl("event-queue"), new String(currentMessage));
+        PayoutDao payoutDao = new PayoutDao(appRule.getJdbi());
+
+        await().atMost(1, TimeUnit.SECONDS).until(
+                () -> payoutDao.findByGatewayPayoutId(gatewayPayoutId).isPresent()
+        );
+
+        Optional<PayoutEntity> payoutEntity = payoutDao.findByGatewayPayoutId(gatewayPayoutId);
+        assertThat(payoutEntity.isPresent(), is(true));
+        assertThat(payoutEntity.get().getGatewayPayoutId(), is(gatewayPayoutId));
+        assertThat(payoutEntity.get().getPaidOutDate().toString(), is("2020-05-13T18:50Z"));
+        assertThat(payoutEntity.get().getState(), is(PAID_OUT));
+
+        Map<String, Object> payoutDetails = new Gson().fromJson(payoutEntity.get().getPayoutDetails(), Map.class);
+        assertThat(payoutDetails.get("gateway_status"), is("paid"));
+    }
+
+    public void setMessage(byte[] messageContents) {
+        currentMessage = messageContents;
+    }
+}

--- a/src/test/java/uk/gov/pay/ledger/pact/PayoutUpdatedEventQueueContractTest.java
+++ b/src/test/java/uk/gov/pay/ledger/pact/PayoutUpdatedEventQueueContractTest.java
@@ -1,0 +1,87 @@
+package uk.gov.pay.ledger.pact;
+
+import au.com.dius.pact.consumer.MessagePactBuilder;
+import au.com.dius.pact.consumer.MessagePactProviderRule;
+import au.com.dius.pact.consumer.Pact;
+import au.com.dius.pact.consumer.PactVerification;
+import au.com.dius.pact.model.v3.messaging.MessagePact;
+import com.google.gson.Gson;
+import org.junit.Rule;
+import org.junit.Test;
+import uk.gov.pay.ledger.payout.dao.PayoutDao;
+import uk.gov.pay.ledger.payout.entity.PayoutEntity;
+import uk.gov.pay.ledger.rule.AppWithPostgresAndSqsRule;
+import uk.gov.pay.ledger.rule.SqsTestDocker;
+import uk.gov.pay.ledger.util.fixture.PayoutFixture;
+import uk.gov.pay.ledger.util.fixture.QueuePayoutEventFixture;
+
+import java.time.ZonedDateTime;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+
+import static io.dropwizard.testing.ConfigOverride.config;
+import static java.time.ZonedDateTime.parse;
+import static org.awaitility.Awaitility.await;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static uk.gov.pay.ledger.payout.state.PayoutState.PAID_OUT;
+import static uk.gov.pay.ledger.payout.state.PayoutState.UNDEFINED;
+import static uk.gov.pay.ledger.util.fixture.PayoutFixture.PayoutFixtureBuilder.aPayoutFixture;
+
+public class PayoutUpdatedEventQueueContractTest {
+    @Rule
+    public MessagePactProviderRule mockProvider = new MessagePactProviderRule(this);
+
+    @Rule
+    public AppWithPostgresAndSqsRule appRule = new AppWithPostgresAndSqsRule(
+            config("queueMessageReceiverConfig.backgroundProcessingEnabled", "true")
+    );
+
+    private byte[] currentMessage;
+    private String gatewayPayoutId = "po_updated_1234567890";
+    private ZonedDateTime eventDate = parse("2020-05-13T18:50:00Z");
+    private String eventType = "PAYOUT_UPDATED";
+
+    @Pact(provider = "connector", consumer = "ledger")
+    public MessagePact createPayoutUpdatedEventPact(MessagePactBuilder builder) {
+        QueuePayoutEventFixture payoutEventFixture = QueuePayoutEventFixture.aQueuePayoutEventFixture()
+                .withResourceExternalId(gatewayPayoutId)
+                .withEventDate(eventDate)
+                .withEventType(eventType)
+                .withDefaultEventDataForEventType(eventType);
+
+        Map<String, String> metadata = new HashMap<>();
+        metadata.put("contentType", "application/json");
+
+        return builder
+                .expectsToReceive("a payout updated message")
+                .withMetadata(metadata)
+                .withContent(payoutEventFixture.getAsPact())
+                .toPact();
+    }
+
+    @Test
+    @PactVerification({"connector"})
+    public void test() {
+        appRule.getSqsClient().sendMessage(SqsTestDocker.getQueueUrl("event-queue"), new String(currentMessage));
+        PayoutDao payoutDao = new PayoutDao(appRule.getJdbi());
+
+        await().atMost(1, TimeUnit.SECONDS).until(
+                () -> payoutDao.findByGatewayPayoutId(gatewayPayoutId).isPresent()
+        );
+
+        Optional<PayoutEntity> payoutEntity = payoutDao.findByGatewayPayoutId(gatewayPayoutId);
+        assertThat(payoutEntity.isPresent(), is(true));
+        assertThat(payoutEntity.get().getGatewayPayoutId(), is(gatewayPayoutId));
+        assertThat(payoutEntity.get().getState(), is(UNDEFINED));
+
+        Map<String, Object> payoutDetails = new Gson().fromJson(payoutEntity.get().getPayoutDetails(), Map.class);
+        assertThat(payoutDetails.get("gateway_status"), is("pending"));
+    }
+
+    public void setMessage(byte[] messageContents) {
+        currentMessage = messageContents;
+    }
+}

--- a/src/test/java/uk/gov/pay/ledger/util/fixture/QueuePayoutEventFixture.java
+++ b/src/test/java/uk/gov/pay/ledger/util/fixture/QueuePayoutEventFixture.java
@@ -37,6 +37,11 @@ public class QueuePayoutEventFixture implements QueueFixture<QueuePayoutEventFix
         return this;
     }
 
+    public QueuePayoutEventFixture withEventType(String eventType) {
+        this.eventType = eventType;
+        return this;
+    }
+
     public QueuePayoutEventFixture withDefaultEventDataForEventType(String eventType) {
         switch (eventType) {
             case "PAYOUT_CREATED":
@@ -48,6 +53,28 @@ public class QueuePayoutEventFixture implements QueueFixture<QueuePayoutEventFix
                                 .put("gateway_status", "pending")
                                 .put("destination_type", "bank_account")
                                 .put("statement_descriptor", "SERVICE NAME")
+                                .build());
+                break;
+            case "PAYOUT_PAID":
+                eventData = new GsonBuilder().create()
+                        .toJson(ImmutableMap.builder()
+                                .put("paid_out_date", "2020-05-13T18:50:00.000000Z")
+                                .put("gateway_status", "paid")
+                                .build());
+                break;
+            case "PAYOUT_UPDATED":
+                eventData = new GsonBuilder().create()
+                        .toJson(ImmutableMap.builder()
+                                .put("gateway_status", "pending")
+                                .build());
+                break;
+            case "PAYOUT_FAILED":
+                eventData = new GsonBuilder().create()
+                        .toJson(ImmutableMap.builder()
+                                .put("gateway_status", "failed")
+                                .put("failure_code", "account_closed")
+                                .put("failure_message", "The bank account has been closed")
+                                .put("failure_balance_transaction", "ba_aaaaaaaaaa")
                                 .build());
                 break;
             default:


### PR DESCRIPTION
## WHAT 
- Added pact tests for rest of the payout events (failed, updated, paid) from connector