### PR TITLE
PP-6502 refactor AccountIdListSupplierManager

### DIFF
--- a/src/main/java/uk/gov/pay/ledger/payout/resource/PayoutResource.java
+++ b/src/main/java/uk/gov/pay/ledger/payout/resource/PayoutResource.java
@@ -26,7 +26,7 @@ import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 @Produces(APPLICATION_JSON)
 public class PayoutResource {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(PayoutResource.class);
+    private static final String ACCOUNT_MANAGER_FIELD_NAME = "gateway_account_id";
     private PayoutService payoutService;
 
     @Inject
@@ -58,6 +58,6 @@ public class PayoutResource {
         return accountIdSupplierManager
                 .withSupplier(accountId -> payoutService.searchPayouts(gatewayAccountIds, transactionSearchParams, uriInfo))
                 .withPrivilegedSupplier(() -> payoutService.searchPayouts(transactionSearchParams, uriInfo))
-                .validateAndGet();
+                .validateAndGet(ACCOUNT_MANAGER_FIELD_NAME);
     }
 }

--- a/src/main/java/uk/gov/pay/ledger/transaction/resource/TransactionResource.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/resource/TransactionResource.java
@@ -49,6 +49,7 @@ import static uk.gov.pay.ledger.transaction.search.common.TransactionSearchParam
 public class TransactionResource {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(TransactionResource.class);
+    private static final String ACCOUNT_MANAGER_FIELD_NAME = "account_id";
     private final TransactionService transactionService;
     private final CsvService csvService;
     private final LedgerConfig configuration;
@@ -152,7 +153,7 @@ public class TransactionResource {
         return accountIdSupplierManager
                 .withSupplier(accountId -> transactionService.searchTransactions(gatewayAccountIds, transactionSearchParams, uriInfo))
                 .withPrivilegedSupplier(() -> transactionService.searchTransactions(transactionSearchParams, uriInfo))
-                .validateAndGet();
+                .validateAndGet(ACCOUNT_MANAGER_FIELD_NAME);
     }
 
     @Path("{transactionExternalId}/event")

--- a/src/main/java/uk/gov/pay/ledger/transaction/service/AccountIdListSupplierManager.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/service/AccountIdListSupplierManager.java
@@ -11,8 +11,6 @@ import static java.lang.String.format;
 
 public class AccountIdListSupplierManager<T> {
 
-    private static final String ACCOUNT_ID = "account_id";
-
     private final boolean overrideAccountRestriction;
     private final List<String> gatewayAccountIds;
 
@@ -38,9 +36,9 @@ public class AccountIdListSupplierManager<T> {
         return this;
     }
 
-    public T validateAndGet() {
+    public T validateAndGet(String fieldName) {
         if (!overrideAccountRestriction && gatewayAccountIds.isEmpty()) {
-            throw new ValidationException(format("Field [%s] cannot be empty", ACCOUNT_ID));
+            throw new ValidationException(format("Field [%s] cannot be empty", fieldName));
         }
 
         if (gatewayAccountIds.isEmpty()) {

--- a/src/test/java/uk/gov/pay/ledger/transaction/service/AccountIdSupplierManagerTest.java
+++ b/src/test/java/uk/gov/pay/ledger/transaction/service/AccountIdSupplierManagerTest.java
@@ -69,6 +69,6 @@ public class AccountIdSupplierManagerTest {
         new AccountIdListSupplierManager(overrideAccountRestriction, gatewayAccountId)
                 .withPrivilegedSupplier(privilegedSupplier)
                 .withSupplier(supplier)
-                .validateAndGet();
+                .validateAndGet("account_id");
     }
 }


### PR DESCRIPTION
- refactor AccountIdListSupplierManager to take a field name when validating gateway account id. This is needed as a workaround for the naming discrepancy between transaction (account_id) and payout (gateway account id)