### PR TITLE
PP-6585 Calculate parent_external_id from events

### DIFF
--- a/src/main/java/uk/gov/pay/ledger/event/model/EventDigest.java
+++ b/src/main/java/uk/gov/pay/ledger/event/model/EventDigest.java
@@ -9,6 +9,8 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+import static org.apache.commons.lang3.StringUtils.isNotEmpty;
+
 public class EventDigest {
     private static final ObjectMapper objectMapper = new ObjectMapper();
     private final ZonedDateTime mostRecentEventTimestamp;
@@ -58,16 +60,26 @@ public class EventDigest {
                 .min(ZonedDateTime::compareTo)
                 .orElseThrow();
 
+        String parentResourceExternalId = deriveParentResourceExternalId(events);
+
         return new EventDigest(
                 latestEvent.getEventDate(),
                 latestSalientEventType,
                 latestEvent.getResourceType(),
                 latestEvent.getResourceExternalId(),
-                latestEvent.getParentResourceExternalId(),
+                parentResourceExternalId,
                 events.size(),
                 eventPayload,
                 earliestDate
         );
+    }
+
+    private static String deriveParentResourceExternalId(List<Event> events) {
+        return events.stream()
+                .filter(event -> isNotEmpty(event.getParentResourceExternalId()))
+                .map(Event::getParentResourceExternalId)
+                .findFirst()
+                .orElse(null);
     }
 
     private static Map<String, Object> buildEventPayload(List<Event> events) {

--- a/src/test/java/uk/gov/pay/ledger/event/model/EventDigestTest.java
+++ b/src/test/java/uk/gov/pay/ledger/event/model/EventDigestTest.java
@@ -1,0 +1,57 @@
+package uk.gov.pay.ledger.event.model;
+
+import org.junit.Test;
+
+import java.time.ZonedDateTime;
+import java.util.List;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static uk.gov.pay.ledger.util.fixture.EventFixture.anEventFixture;
+
+public class EventDigestTest {
+
+    @Test
+    public void shouldDeriveNonNullParentExternalIdCorrectlyFromEventDigest() {
+        Event eventWithParentExternalId = anEventFixture()
+                .withEventDate(ZonedDateTime.now().minusHours(2L))
+                .withParentResourceExternalId("parent_external_id")
+                .toEntity();
+
+        Event eventWithOutParentExternalId = anEventFixture()
+                .withEventDate(ZonedDateTime.now())
+                .withParentResourceExternalId(null)
+                .toEntity();
+
+        Event latestEventWithOutParentExternalId = anEventFixture()
+                .withEventDate(ZonedDateTime.now().plusDays(2))
+                .withParentResourceExternalId(null)
+                .toEntity();
+
+        EventDigest eventDigest = EventDigest.fromEventList(
+                List.of(latestEventWithOutParentExternalId, eventWithOutParentExternalId, eventWithParentExternalId));
+
+        assertThat(eventDigest.getParentResourceExternalId(), is("parent_external_id"));
+    }
+
+    @Test
+    public void shouldDeriveParentExternalIdToNullIfNoEventsHasParentExternalId() {
+        Event eventWithoutParentExternalId = anEventFixture()
+                .withParentResourceExternalId(null)
+                .toEntity();
+
+        Event event2WithoutParentExternalId = anEventFixture()
+                .withParentResourceExternalId(null)
+                .toEntity();
+
+        Event event3WithoutParentExternalId = anEventFixture()
+                .withParentResourceExternalId(null)
+                .toEntity();
+
+        EventDigest eventDigest = EventDigest.fromEventList(
+                List.of(eventWithoutParentExternalId, event2WithoutParentExternalId, event3WithoutParentExternalId));
+
+        assertThat(eventDigest.getParentResourceExternalId(), is(nullValue()));
+    }
+}


### PR DESCRIPTION
## WHAT 

- Derived parent_external_id if any one event in the given list has parent_external_id set
  This allows to send events without parent_external_id as in the case of refunds where payout
  notifications are received from Stripe and connector can send refund related events without looking further into refunds table.
- This also protects against processing new events in future without parent_external_id