### PR TITLE
PP-6503 Improve validation for transaction CSV endpoint

### DIFF
--- a/src/main/java/uk/gov/pay/ledger/transaction/search/common/TransactionSearchParamsValidator.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/search/common/TransactionSearchParamsValidator.java
@@ -14,14 +14,31 @@ public class TransactionSearchParamsValidator {
     private static final String TO_DATE_FIELD = "to_date";
 
     public static void validateSearchParams(TransactionSearchParams searchParams, CommaDelimitedSetParameter gatewayAccountIds) {
+        validateDates(searchParams);
+
+        if (searchParams.getWithParentTransaction() && isEmpty(gatewayAccountIds)) {
+            throw new ValidationException("gateway_account_id is mandatory to search with parent transaction");
+        }
+    }
+
+    public static void validateSearchParamsForCsv(TransactionSearchParams searchParams, CommaDelimitedSetParameter gatewayAccountIds) {
+        validateDates(searchParams);
+
+        if (isEmpty(gatewayAccountIds)) {
+            throw new ValidationException("gateway_account_id is mandatory to search transactions for CSV");
+        }
+    }
+
+    private static boolean isEmpty(CommaDelimitedSetParameter gatewayAccountIds) {
+        return gatewayAccountIds == null || gatewayAccountIds.getParameters().isEmpty();
+    }
+
+    private static void validateDates(TransactionSearchParams searchParams) {
         if (isNotBlank(searchParams.getFromDate())) {
             validateDate(FROM_DATE_FIELD, searchParams.getFromDate());
         }
         if (isNotBlank(searchParams.getToDate())) {
             validateDate(TO_DATE_FIELD, searchParams.getToDate());
-        }
-        if(searchParams.getWithParentTransaction() && gatewayAccountIds.getParameters().isEmpty()){
-            throw new ValidationException("gateway_account_id is mandatory to search with parent transaction");
         }
     }
 

--- a/src/test/java/uk/gov/pay/ledger/transaction/resource/TransactionResourceTest.java
+++ b/src/test/java/uk/gov/pay/ledger/transaction/resource/TransactionResourceTest.java
@@ -1,6 +1,7 @@
 package uk.gov.pay.ledger.transaction.resource;
 
 import io.dropwizard.testing.junit.ResourceTestRule;
+import org.hamcrest.Matchers;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -157,8 +158,23 @@ public class TransactionResourceTest {
         });
         List errors = (List) responseMessage.get("errors");
 
-        System.out.println(errors);
         assertThat(response.getStatus(), is(400));
         assertThat(errors.get(0), is("query param payment_provider must not be empty"));
+    }
+
+    @Test
+    public void searchTransactionForCsvShouldReturn400IfGatewayAccountIdIsNotAvailable() {
+        Response response = resources
+                .target("/v1/transaction")
+                .request()
+                .accept("text/csv")
+                .get();
+
+        HashMap<String, Object> responseMessage = response.readEntity(HashMap.class);
+
+        assertThat(response.getStatus(), is(400));
+        assertThat(responseMessage.get("error_identifier"), is("GENERIC"));
+        assertThat((List<String>) responseMessage.get("message"),
+                Matchers.containsInAnyOrder("gateway_account_id is mandatory to search transactions for CSV"));
     }
 }

--- a/src/test/java/uk/gov/pay/ledger/transaction/search/common/TransactionSearchParamsValidatorTest.java
+++ b/src/test/java/uk/gov/pay/ledger/transaction/search/common/TransactionSearchParamsValidatorTest.java
@@ -1,13 +1,17 @@
 package uk.gov.pay.ledger.transaction.search.common;
 
+import junitparams.JUnitParamsRunner;
+import junitparams.Parameters;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
 import uk.gov.pay.ledger.exception.UnparsableDateException;
 import uk.gov.pay.ledger.exception.ValidationException;
 import uk.gov.pay.ledger.util.CommaDelimitedSetParameter;
 
+@RunWith(JUnitParamsRunner.class)
 public class TransactionSearchParamsValidatorTest {
 
     @Rule
@@ -16,7 +20,7 @@ public class TransactionSearchParamsValidatorTest {
     TransactionSearchParams searchParams;
 
     @Before
-    public void setup(){
+    public void setup() {
         searchParams = new TransactionSearchParams();
     }
 
@@ -33,14 +37,14 @@ public class TransactionSearchParamsValidatorTest {
         searchParams.setToDate("wrong-date");
         thrown.expect(UnparsableDateException.class);
         thrown.expectMessage("Input to_date (wrong-date) is wrong format");
-        TransactionSearchParamsValidator.validateSearchParams(searchParams,null);
+        TransactionSearchParamsValidator.validateSearchParams(searchParams, null);
     }
 
     @Test
     public void shouldNotThrowException_whenValidDateFormats() {
         searchParams.setFromDate("2019-05-01T10:15:30Z");
         searchParams.setToDate("2019-05-01T10:15:30Z");
-        TransactionSearchParamsValidator.validateSearchParams(searchParams,null);
+        TransactionSearchParamsValidator.validateSearchParams(searchParams, null);
     }
 
     @Test
@@ -54,12 +58,42 @@ public class TransactionSearchParamsValidatorTest {
         searchParams.setWithParentTransaction(true);
         thrown.expect(ValidationException.class);
         thrown.expectMessage("gateway_account_id is mandatory to search with parent transaction");
-        TransactionSearchParamsValidator.validateSearchParams(searchParams,new CommaDelimitedSetParameter(""));
+        TransactionSearchParamsValidator.validateSearchParams(searchParams, new CommaDelimitedSetParameter(""));
     }
 
     @Test
     public void shouldNotThrowException_whenGatewayAccountIdIsNotAvailableAndWithParentTransactionIsTrue() {
         searchParams.setWithParentTransaction(true);
-        TransactionSearchParamsValidator.validateSearchParams(searchParams,new CommaDelimitedSetParameter("1,2"));
+        TransactionSearchParamsValidator.validateSearchParams(searchParams, new CommaDelimitedSetParameter("1,2"));
+    }
+
+    @Test
+    public void validateSearchParamsForCsvShouldNotThrowExceptionForValidParams() {
+        searchParams.setFromDate("2019-05-01T10:15:30Z");
+        searchParams.setToDate("2019-05-01T10:15:30Z");
+        TransactionSearchParamsValidator.validateSearchParamsForCsv(
+                searchParams, new CommaDelimitedSetParameter("1,2"));
+    }
+
+    @Test(expected = ValidationException.class)
+    public void validateSearchParamsForCsvShouldThrowExceptionIfGatewayAccountIsNotAvailable() {
+        TransactionSearchParamsValidator.validateSearchParamsForCsv(
+                searchParams, new CommaDelimitedSetParameter(""));
+
+        TransactionSearchParamsValidator.validateSearchParamsForCsv(
+                searchParams, null);
+    }
+
+    @Parameters({
+            "wrong-date, 2019-05-01T10:15:30Z",
+            "2019-05-01T10:15:30Z, wrong-date"
+    })
+    @Test(expected = UnparsableDateException.class)
+    public void validateSearchParamsForCsvShouldThrowExceptionForInvalidDates(String fromDate, String toDate) {
+        searchParams.setFromDate(fromDate);
+        searchParams.setToDate(toDate);
+
+        TransactionSearchParamsValidator.validateSearchParamsForCsv(
+                searchParams, new CommaDelimitedSetParameter("1"));
     }
 }


### PR DESCRIPTION
## WHAT
- Added validation on TransactionResource for CSV endpoint inline with transactions search endpoint.
  At present, CSV endpoint could cause NPE or date format exceptions if query params are invalid or not available.
- gateway_account_ids are mandatory for CSV download as there is no use case to search transactions for csv without associated accounts. As a result `override_account_id_restriction` query param has been removed which is unused and not needed.

- Added relevant tests
- Also added ITest to get transactions as CSV for payouts