### PR TITLE
Revert "Bump postgresql from 1.14.1 to 1.14.2"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
         <dropwizard.version>2.0.10</dropwizard.version>
         <jackson.version>2.11.0</jackson.version>
-        <testcontainers.version>1.14.2</testcontainers.version>
+        <testcontainers.version>1.14.1</testcontainers.version>
         <postgresql.version>42.2.12</postgresql.version>
         <pay-java-commons.version>1.0.20200526092753</pay-java-commons.version>
         <surefire.version>3.0.0-M3</surefire.version>


### PR DESCRIPTION
Getting the following in CI:
```
15:17:23  Caused by: org.testcontainers.containers.ContainerFetchException: Can't get Docker image: RemoteDockerImage(imageName=postgres:11.1, imagePullPolicy=DefaultPullPolicy())
``` 

Suspect it relates to this being bumped yesterday