### PR TITLE
BAU - Use dockerhub for ryuk image

### DIFF
--- a/src/test/resources/testcontainers.properties
+++ b/src/test/resources/testcontainers.properties
@@ -1,0 +1,2 @@
+# Digest of image testcontainersofficial/ryuk:latest for linux/amd64 from tags list on https://hub.docker.com/r/testcontainersofficial/ryuk
+ryuk.container.image=testcontainersofficial/ryuk@sha256:8fdd715bf34975d088273bcea497fe048f9b768ba4c7fc690ab6e4ddc995e317


### PR DESCRIPTION
## WHAT 
ryuk container used by testcontainers library is responsible for starting and cleaning up postgres/sqs containers used during the tests.

By default images is pulled from quay.io.

Added configuration to use dockerhub instead as for all other images. Image is still an official test containers ryuk image https://hub.docker.com/r/testcontainersofficial/ryuk

Custom images can be configured in multiple ways as per https://www.testcontainers.org/features/configuration/