### PR TITLE
BAU Fix gateway transaction id transaction search filter

### DIFF
--- a/src/main/java/uk/gov/pay/ledger/transaction/search/common/TransactionSearchParams.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/search/common/TransactionSearchParams.java
@@ -83,6 +83,7 @@ public class TransactionSearchParams extends SearchParams {
     @QueryParam("display_size")
     private Long displaySize = DEFAULT_MAX_DISPLAY_SIZE;
     private Map<String, Object> queryMap;
+    @QueryParam("gateway_transaction_id")
     private String gatewayTransactionId;
 
     public void setAccountIds(List<String> accountIds) {


### PR DESCRIPTION
Everything is correctly in place to filter on `gateway_transaction_id`
but as there is no `QueryParam` annotation on the attribute this will
never be set by the resource. 

Add this so it can be parsed and set appropriately.