### PR TITLE
PP-6445 Use env var for Pact broker url

### DIFF
--- a/src/test/java/uk/gov/pay/ledger/pact/PublicApiContractTest.java
+++ b/src/test/java/uk/gov/pay/ledger/pact/PublicApiContractTest.java
@@ -8,7 +8,7 @@ import org.junit.runner.RunWith;
 
 @RunWith(PactRunner.class)
 @Provider("ledger")
-@PactBroker(scheme = "https", host = "pact-broker-test.cloudapps.digital", tags = {"${PACT_CONSUMER_TAG}", "test"},
+@PactBroker(scheme = "https", host = "${PACT_BROKER_HOST:pact-broker-test.cloudapps.digital}", tags = {"${PACT_CONSUMER_TAG}", "test"},
         authentication = @PactBrokerAuth(username = "${PACT_BROKER_USERNAME}", password = "${PACT_BROKER_PASSWORD}"),
         consumers = {"publicapi"})
 public class PublicApiContractTest extends ContractTest {

--- a/src/test/java/uk/gov/pay/ledger/pact/SelfServiceContractTest.java
+++ b/src/test/java/uk/gov/pay/ledger/pact/SelfServiceContractTest.java
@@ -8,7 +8,7 @@ import org.junit.runner.RunWith;
 
 @RunWith(PactRunner.class)
 @Provider("ledger")
-@PactBroker(scheme = "https", host = "pact-broker-test.cloudapps.digital", tags = {"${PACT_CONSUMER_TAG}", "test"},
+@PactBroker(scheme = "https", host = "${PACT_BROKER_HOST:pact-broker-test.cloudapps.digital}", tags = {"${PACT_CONSUMER_TAG}", "test"},
         authentication = @PactBrokerAuth(username = "${PACT_BROKER_USERNAME}", password = "${PACT_BROKER_PASSWORD}"),
         consumers = {"selfservice"})
 public class SelfServiceContractTest extends ContractTest {


### PR DESCRIPTION
We are using a different pact broker for ci running on concourse so
make the pact broker url configurable from an env var `PACT_BROKER_URL`.
Default value is the existing broker used for Jenkins CI.

See https://github.com/alphagov/pay-connector/pull/2376 for similar implementation for Connector