### PR TITLE
BAU - Use optional for parent transaction entity

### DIFF
--- a/src/main/java/uk/gov/pay/ledger/transaction/dao/mapper/TransactionWithParentMapper.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/dao/mapper/TransactionWithParentMapper.java
@@ -1,6 +1,5 @@
 package uk.gov.pay.ledger.transaction.dao.mapper;
 
-import org.apache.commons.lang3.StringUtils;
 import org.jdbi.v3.core.mapper.RowMapper;
 import org.jdbi.v3.core.statement.StatementContext;
 import uk.gov.pay.ledger.transaction.entity.TransactionEntity;

--- a/src/main/java/uk/gov/pay/ledger/transaction/entity/TransactionEntity.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/entity/TransactionEntity.java
@@ -8,6 +8,7 @@ import uk.gov.pay.commons.model.Source;
 import uk.gov.pay.ledger.transaction.state.TransactionState;
 
 import java.time.ZonedDateTime;
+import java.util.Optional;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
@@ -212,8 +213,8 @@ public class TransactionEntity {
         return moto;
     }
 
-    public TransactionEntity getParentTransactionEntity() {
-        return parentTransactionEntity;
+    public Optional<TransactionEntity> getParentTransactionEntity() {
+        return Optional.ofNullable(parentTransactionEntity);
     }
 
     public String getGatewayTransactionId() {

--- a/src/main/java/uk/gov/pay/ledger/transaction/model/CsvTransactionFactory.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/model/CsvTransactionFactory.java
@@ -91,9 +91,10 @@ public class CsvTransactionFactory {
                 result.put(FIELD_STATE, PaymentState.getDisplayName(transactionEntity.getState()));
             }
             if (TransactionType.REFUND.toString().equals(transactionEntity.getTransactionType())) {
-                if (transactionEntity.getParentTransactionEntity() != null) {
+                Optional<TransactionEntity> parentTransactionEntity = transactionEntity.getParentTransactionEntity();
+                if (parentTransactionEntity.isPresent()) {
                     result.putAll(
-                            getPaymentTransactionAttributes(transactionEntity.getParentTransactionEntity())
+                            getPaymentTransactionAttributes(parentTransactionEntity.get())
                     );
                 }
 

--- a/src/main/java/uk/gov/pay/ledger/transaction/model/Refund.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/model/Refund.java
@@ -14,7 +14,7 @@ public class Refund extends Transaction {
     private final String refundedBy;
     private final String refundedByUserEmail;
     private final String parentExternalId;
-    private final Optional<Transaction> parentTransaction;
+    private final Transaction parentTransaction;
 
     public Refund(Builder builder) {
         super(builder.id, builder.gatewayAccountId, builder.amount, builder.externalId, builder.gatewayPayoutId);
@@ -58,7 +58,7 @@ public class Refund extends Transaction {
     }
 
     public Optional<Transaction> getParentTransaction() {
-        return parentTransaction;
+        return Optional.ofNullable(parentTransaction);
     }
 
     @Override
@@ -83,7 +83,7 @@ public class Refund extends Transaction {
         private Long amount;
         private String externalId;
         private String parentExternalId;
-        private Optional<Transaction> parentTransaction;
+        private Transaction parentTransaction;
         private String gatewayPayoutId;
 
         public Builder() {
@@ -153,7 +153,7 @@ public class Refund extends Transaction {
             return this;
         }
 
-        public Builder withParentTransaction(Optional<Transaction> transaction) {
+        public Builder withParentTransaction(Transaction transaction) {
             this.parentTransaction = transaction;
             return this;
         }

--- a/src/main/java/uk/gov/pay/ledger/transaction/model/TransactionFactory.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/model/TransactionFactory.java
@@ -109,8 +109,9 @@ public class TransactionFactory {
         try {
             JsonNode transactionDetails = objectMapper.readTree(Optional.ofNullable(entity.getTransactionDetails()).orElse("{}"));
 
-            Optional<Transaction> parentTransaction = Optional.ofNullable(entity.getParentTransactionEntity())
-                    .map(this::createTransactionEntity);
+            Transaction parentTransaction = entity.getParentTransactionEntity()
+                    .map(this::createTransactionEntity)
+                    .orElse(null);
 
             return new Refund.Builder()
                     .withGatewayAccountId(entity.getGatewayAccountId())

--- a/src/main/java/uk/gov/pay/ledger/transaction/service/TransactionService.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/service/TransactionService.java
@@ -45,18 +45,15 @@ public class TransactionService {
     private final EventDao eventDao;
     private TransactionEntityFactory transactionEntityFactory;
     private TransactionFactory transactionFactory;
-    private CsvTransactionFactory csvTransactionFactory;
     private ObjectMapper objectMapper;
 
     @Inject
     public TransactionService(TransactionDao transactionDao, EventDao eventDao, TransactionEntityFactory transactionEntityFactory,
-                              TransactionFactory transactionFactory, CsvTransactionFactory csvTransactionFactory,
-                              ObjectMapper objectMapper) {
+                              TransactionFactory transactionFactory, ObjectMapper objectMapper) {
         this.transactionDao = transactionDao;
         this.eventDao = eventDao;
         this.transactionEntityFactory = transactionEntityFactory;
         this.transactionFactory = transactionFactory;
-        this.csvTransactionFactory = csvTransactionFactory;
         this.objectMapper = objectMapper;
     }
 

--- a/src/test/java/uk/gov/pay/ledger/transaction/dao/TransactionDaoSearchIT.java
+++ b/src/test/java/uk/gov/pay/ledger/transaction/dao/TransactionDaoSearchIT.java
@@ -585,7 +585,7 @@ public class TransactionDaoSearchIT {
         assertThat(transactionList.size(), is(2));
 
         assertTransactionEquals(transactionList.get(0), transactionFixtureChild);
-        assertTransactionEquals(transactionList.get(0).getParentTransactionEntity(), transactionFixture);
+        assertTransactionEquals(transactionList.get(0).getParentTransactionEntity().get(), transactionFixture);
         assertTransactionEquals(transactionList.get(1), transactionFixture);
 
         Long total = transactionDao.getTotalForSearchTransactionAndParent(searchParams);
@@ -608,7 +608,7 @@ public class TransactionDaoSearchIT {
         assertThat(transactionList.size(), is(2));
 
         assertTransactionEquals(transactionList.get(0), transactionFixtureChild);
-        assertTransactionEquals(transactionList.get(0).getParentTransactionEntity(), transactionFixture);
+        assertTransactionEquals(transactionList.get(0).getParentTransactionEntity().get(), transactionFixture);
         assertTransactionEquals(transactionList.get(1), transactionFixture);
 
         Long total = transactionDao.getTotalForSearchTransactionAndParent(searchParams);
@@ -629,7 +629,7 @@ public class TransactionDaoSearchIT {
         assertThat(transactionList.size(), is(2));
 
         assertTransactionEquals(transactionList.get(0), transactionFixtureChild);
-        assertTransactionEquals(transactionList.get(0).getParentTransactionEntity(), transactionFixture);
+        assertTransactionEquals(transactionList.get(0).getParentTransactionEntity().get(), transactionFixture);
         assertTransactionEquals(transactionList.get(1), transactionFixture);
 
         Long total = transactionDao.getTotalForSearchTransactionAndParent(searchParams);
@@ -655,7 +655,7 @@ public class TransactionDaoSearchIT {
         assertThat(transactionList.size(), is(2));
 
         assertTransactionEquals(transactionList.get(0), transactionFixtureChild);
-        assertTransactionEquals(transactionList.get(0).getParentTransactionEntity(), transactionFixture);
+        assertTransactionEquals(transactionList.get(0).getParentTransactionEntity().get(), transactionFixture);
         assertTransactionEquals(transactionList.get(1), transactionFixture);
 
         Long total = transactionDao.getTotalForSearchTransactionAndParent(searchParams);
@@ -676,7 +676,7 @@ public class TransactionDaoSearchIT {
         assertThat(transactionList.size(), is(2));
 
         assertTransactionEquals(transactionList.get(0), transactionFixtureChild);
-        assertTransactionEquals(transactionList.get(0).getParentTransactionEntity(), transactionFixture);
+        assertTransactionEquals(transactionList.get(0).getParentTransactionEntity().get(), transactionFixture);
         assertTransactionEquals(transactionList.get(1), transactionFixture);
 
         Long total = transactionDao.getTotalForSearchTransactionAndParent(searchParams);
@@ -697,7 +697,7 @@ public class TransactionDaoSearchIT {
         assertThat(transactionList.size(), is(2));
 
         assertTransactionEquals(transactionList.get(0), transactionFixtureChild);
-        assertTransactionEquals(transactionList.get(0).getParentTransactionEntity(), transactionFixture);
+        assertTransactionEquals(transactionList.get(0).getParentTransactionEntity().get(), transactionFixture);
         assertTransactionEquals(transactionList.get(1), transactionFixture);
 
         Long total = transactionDao.getTotalForSearchTransactionAndParent(searchParams);
@@ -718,7 +718,7 @@ public class TransactionDaoSearchIT {
         List<TransactionEntity> transactionList = transactionDao.searchTransactionsAndParent(searchParams);
         assertThat(transactionList.size(), is(2));
         assertTransactionEquals(transactionList.get(0), transactionFixtureChild);
-        assertTransactionEquals(transactionList.get(0).getParentTransactionEntity(), transactionFixture);
+        assertTransactionEquals(transactionList.get(0).getParentTransactionEntity().get(), transactionFixture);
         assertTransactionEquals(transactionList.get(1), transactionFixture);
 
         Long total = transactionDao.getTotalForSearchTransactionAndParent(searchParams);
@@ -739,7 +739,7 @@ public class TransactionDaoSearchIT {
         assertThat(transactionList.size(), is(1));
 
         assertTransactionEquals(transactionList.get(0), transactionFixtureChild);
-        assertTransactionEquals(transactionList.get(0).getParentTransactionEntity(), transactionFixture);
+        assertTransactionEquals(transactionList.get(0).getParentTransactionEntity().get(), transactionFixture);
 
         Long total = transactionDao.getTotalForSearchTransactionAndParent(searchParams);
         assertThat(total, is(1L));

--- a/src/test/java/uk/gov/pay/ledger/transaction/model/CsvTransactionFactoryTest.java
+++ b/src/test/java/uk/gov/pay/ledger/transaction/model/CsvTransactionFactoryTest.java
@@ -10,7 +10,6 @@ import uk.gov.pay.ledger.transaction.state.TransactionState;
 import uk.gov.pay.ledger.util.fixture.TransactionFixture;
 
 import java.time.ZonedDateTime;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -86,7 +85,7 @@ public class CsvTransactionFactoryTest {
 
         Map<String, Object> csvDataMap = csvTransactionFactory.toMap(refundTransactionEntity);
 
-        assertPaymentDetails(csvDataMap, refundTransactionEntity.getParentTransactionEntity());
+        assertPaymentDetails(csvDataMap, refundTransactionEntity.getParentTransactionEntity().get());
         assertThat(csvDataMap.get("Amount"), is("-0.99"));
         assertThat(csvDataMap.get("State"), is("Refund error"));
         assertThat(csvDataMap.get("Finished"), is(true));

--- a/src/test/java/uk/gov/pay/ledger/transaction/service/TransactionServiceTest.java
+++ b/src/test/java/uk/gov/pay/ledger/transaction/service/TransactionServiceTest.java
@@ -69,9 +69,8 @@ public class TransactionServiceTest {
         ObjectMapper objectMapper = Jackson.newObjectMapper();
         TransactionEntityFactory transactionEntityFactory = new TransactionEntityFactory(objectMapper);
         TransactionFactory transactionFactory = new TransactionFactory(objectMapper);
-        CsvTransactionFactory csvTransactionFactory = new CsvTransactionFactory(objectMapper);
         transactionService = new TransactionService(mockTransactionDao, mockEventDao, transactionEntityFactory,
-                transactionFactory, csvTransactionFactory, objectMapper);
+                transactionFactory, objectMapper);
         searchParams = new TransactionSearchParams();
         searchParams.setAccountIds(List.of(gatewayAccountId));
 


### PR DESCRIPTION
## WHAT 
- Return Optional for parentTransactionEntity on Refund to avoid null checks/NullPointerExceptions for new changes
- Removes Optional as method parameter
- Code cleanup