### PR TITLE
PP-6234: Remove dev SQS config options from PaaS environment variables

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -25,7 +25,7 @@ applications:
       DB_SSL_OPTION: ''
 
       # Provided by the sqs service - see src/main/resources/env-map.yml
-      AWS_SQS_ENDPOINT: ''
+      AWS_SQS_REGION: ''
       AWS_SQS_PAYMENT_EVENT_QUEUE_URL: ''
 
       # Provided by ledger-secret-service see src/main/resource/env-map.yml

--- a/manifest.yml
+++ b/manifest.yml
@@ -36,8 +36,6 @@ applications:
       # Other sqs settings
       AWS_SQS_MESSAGE_MAXIMUM_WAIT_TIME_IN_SECONDS: '20'
       QUEUE_MESSAGE_RECEIVER_THREAD_DELAY_IN_MILLISECONDS: '1000'
-      AWS_SQS_NON_STANDARD_SERVICE_ENDPOINT: 'true'
-      AWS_SQS_REGION: region-1
 
       ADMIN_PORT: '10701'
       DISABLE_INTERNAL_HTTPS: ((disable_internal_https))

--- a/src/main/resources/env-map.yml
+++ b/src/main/resources/env-map.yml
@@ -4,7 +4,6 @@ env_vars:
   DB_PASSWORD:                      '.[][] | select(.name == "ledger-db") | .credentials.password                     '
   DB_USER:                          '.[][] | select(.name == "ledger-db") | .credentials.username                     '
   DB_SSL_OPTION:                    '.[][] | select(.name == "ledger-db") | .credentials.ssl_option      // "ssl=true"'
-  AWS_SQS_ENDPOINT:                 '.[][] | select(.name == "sqs")       | .credentials.endpoint                     '
   AWS_SQS_PAYMENT_EVENT_QUEUE_URL:  '.[][] | select(.name == "sqs")       | .credentials.event_queue_url              '
   AWS_ACCESS_KEY:                   '.[][] | select(.name == "ledger-secret-service") | .credentials.aws_access_key   '
   AWS_SECRET_KEY:                   '.[][] | select(.name == "ledger-secret-service") | .credentials.aws_secret_key   '

--- a/src/main/resources/env-map.yml
+++ b/src/main/resources/env-map.yml
@@ -4,6 +4,7 @@ env_vars:
   DB_PASSWORD:                      '.[][] | select(.name == "ledger-db") | .credentials.password                     '
   DB_USER:                          '.[][] | select(.name == "ledger-db") | .credentials.username                     '
   DB_SSL_OPTION:                    '.[][] | select(.name == "ledger-db") | .credentials.ssl_option      // "ssl=true"'
+  AWS_SQS_REGION:                   '.[][] | select(.name == "sqs")       | .credentials.region                       '
   AWS_SQS_PAYMENT_EVENT_QUEUE_URL:  '.[][] | select(.name == "sqs")       | .credentials.event_queue_url              '
   AWS_ACCESS_KEY:                   '.[][] | select(.name == "ledger-secret-service") | .credentials.aws_access_key   '
   AWS_SECRET_KEY:                   '.[][] | select(.name == "ledger-secret-service") | .credentials.aws_secret_key   '


### PR DESCRIPTION
According to the README these aren't needed unless you're running locally using a fake SQS queue. Apps won't start without "endpoint" if "non-standard" SQS is enabled which isn't a thing in "real" SQS.

