### PR TITLE
WIP - Project payment fields onto refund

### DIFF
--- a/src/main/java/uk/gov/pay/ledger/event/model/TransactionEntityFactory.java
+++ b/src/main/java/uk/gov/pay/ledger/event/model/TransactionEntityFactory.java
@@ -16,18 +16,22 @@ public class TransactionEntityFactory {
     private static final Logger LOGGER = LoggerFactory.getLogger(TransactionEntityFactory.class);
 
     @Inject
-    public TransactionEntityFactory(ObjectMapper objectMapper){
+    public TransactionEntityFactory(ObjectMapper objectMapper) {
         this.objectMapper = objectMapper;
     }
 
     public TransactionEntity create(EventDigest eventDigest) {
+        return create(eventDigest, eventDigest.getEventPayload());
+    }
+
+    public TransactionEntity create(EventDigest eventDigest, Map<String, Object> eventPayload) {
         TransactionState digestTransactionState = eventDigest
                 .getMostRecentSalientEventType()
                 .map(TransactionState::fromEventType)
                 .orElse(TransactionState.UNDEFINED);
 
-        String transactionDetail = convertToTransactionDetails(eventDigest.getEventPayload());
-        TransactionEntity entity = objectMapper.convertValue(eventDigest.getEventPayload(), TransactionEntity.class);
+        String transactionDetail = convertToTransactionDetails(eventPayload);
+        TransactionEntity entity = objectMapper.convertValue(eventPayload, TransactionEntity.class);
         entity.setTransactionDetails(transactionDetail);
         entity.setEventCount(eventDigest.getEventCount());
         entity.setState(digestTransactionState);
@@ -47,4 +51,5 @@ public class TransactionEntityFactory {
         }
         return "{}";
     }
+
 }

--- a/src/main/java/uk/gov/pay/ledger/event/service/EventService.java
+++ b/src/main/java/uk/gov/pay/ledger/event/service/EventService.java
@@ -17,7 +17,7 @@ public class EventService {
         this.eventDao = eventDao;
     }
 
-    private EventDigest getEventDigestForResource(String resourceExternalId) {
+    public EventDigest getEventDigestForResource(String resourceExternalId) {
         List<Event> events = eventDao.getEventsByResourceExternalId(resourceExternalId);
         return EventDigest.fromEventList(events);
     }

--- a/src/main/java/uk/gov/pay/ledger/event/service/EventService.java
+++ b/src/main/java/uk/gov/pay/ledger/event/service/EventService.java
@@ -17,7 +17,7 @@ public class EventService {
         this.eventDao = eventDao;
     }
 
-    public EventDigest getEventDigestForResource(String resourceExternalId) {
+    private EventDigest getEventDigestForResource(String resourceExternalId) {
         List<Event> events = eventDao.getEventsByResourceExternalId(resourceExternalId);
         return EventDigest.fromEventList(events);
     }
@@ -29,5 +29,9 @@ public class EventService {
         } catch (Exception e) {
             return new CreateEventResponse(e);
         }
+    }
+
+    public EventDigest getEventDigestForResource(Event event) {
+        return getEventDigestForResource(event.getResourceExternalId());
     }
 }

--- a/src/main/java/uk/gov/pay/ledger/queue/EventDigestHandler.java
+++ b/src/main/java/uk/gov/pay/ledger/queue/EventDigestHandler.java
@@ -36,12 +36,10 @@ public class EventDigestHandler {
     }
 
     public void processEvent(Event event) {
-        EventDigest eventDigest = eventService.getEventDigestForResource(event.getResourceExternalId());
-
         if (isATransactionEvent(event.getResourceType())) {
-            processDigestForTransactionEvent(event, eventDigest);
+            processDigestForTransactionEvent(event);
         } else if (isAPayoutEvent(event.getResourceType())) {
-            processDigestForPayout(eventDigest);
+            processDigestForPayout(event);
         } else {
             LOGGER.warn("Event digest processing for resource type [{}] is not supported. Event type [{}] and resource external id [{}]",
                     event.getResourceType(),
@@ -58,12 +56,13 @@ public class EventDigestHandler {
         return PAYMENT.equals(resourceType) || REFUND.equals(resourceType);
     }
 
-    private void processDigestForTransactionEvent(Event event, EventDigest eventDigest) {
+    private void processDigestForTransactionEvent(Event event) {
+        EventDigest eventDigest = eventService.getEventDigestForResource(event);
         transactionService.upsertTransactionFor(eventDigest);
         transactionMetadataService.upsertMetadataFor(event);
     }
 
-    private void processDigestForPayout(EventDigest eventDigest) {
-        payoutService.upsertPayoutFor(eventDigest);
+    private void processDigestForPayout(Event event) {
+        payoutService.upsertPayoutFor(eventService.getEventDigestForResource(event));
     }
 }

--- a/src/main/java/uk/gov/pay/ledger/queue/EventDigestHandler.java
+++ b/src/main/java/uk/gov/pay/ledger/queue/EventDigestHandler.java
@@ -5,15 +5,18 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.pay.ledger.event.model.Event;
 import uk.gov.pay.ledger.event.model.EventDigest;
-import uk.gov.pay.ledger.event.model.ResourceType;
+import uk.gov.pay.ledger.event.model.TransactionEntityFactory;
 import uk.gov.pay.ledger.event.service.EventService;
 import uk.gov.pay.ledger.payout.service.PayoutService;
+import uk.gov.pay.ledger.transaction.entity.TransactionEntity;
 import uk.gov.pay.ledger.transaction.service.TransactionMetadataService;
 import uk.gov.pay.ledger.transaction.service.TransactionService;
 
-import static uk.gov.pay.ledger.event.model.ResourceType.PAYMENT;
-import static uk.gov.pay.ledger.event.model.ResourceType.PAYOUT;
-import static uk.gov.pay.ledger.event.model.ResourceType.REFUND;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static java.util.stream.Collectors.toMap;
 
 public class EventDigestHandler {
 
@@ -23,46 +26,97 @@ public class EventDigestHandler {
     private final TransactionService transactionService;
     private final TransactionMetadataService transactionMetadataService;
     private final PayoutService payoutService;
+    private TransactionEntityFactory transactionEntityFactory;
 
     @Inject
     public EventDigestHandler(EventService eventService,
                               TransactionService transactionService,
                               TransactionMetadataService transactionMetadataService,
-                              PayoutService payoutService) {
+                              PayoutService payoutService,
+                              TransactionEntityFactory transactionEntityFactory) {
         this.eventService = eventService;
         this.transactionService = transactionService;
         this.transactionMetadataService = transactionMetadataService;
         this.payoutService = payoutService;
+        this.transactionEntityFactory = transactionEntityFactory;
+    }
+
+    public EventProcessor processorFor(Event event) {
+        switch (event.getResourceType()) {
+            case PAYMENT:
+                return new PaymentEventProcessor();
+            case REFUND:
+                return new RefundEventProcessor();
+            case PAYOUT:
+                return new PayoutEventProcessor();
+            default:
+                String message = String.format("Event digest processing for resource type [%s] is not supported. Event type [%s] and resource external id [%s]",
+                        event.getResourceType(),
+                        event.getEventType(),
+                        event.getResourceExternalId());
+                LOGGER.error(message);
+                throw new RuntimeException(message);
+        }
+
     }
 
     public void processEvent(Event event) {
-        if (isATransactionEvent(event.getResourceType())) {
-            processDigestForTransactionEvent(event);
-        } else if (isAPayoutEvent(event.getResourceType())) {
-            processDigestForPayout(event);
-        } else {
-            LOGGER.warn("Event digest processing for resource type [{}] is not supported. Event type [{}] and resource external id [{}]",
-                    event.getResourceType(),
-                    event.getEventType(),
-                    event.getResourceExternalId());
+        processorFor(event).process(event);
+    }
+
+    static abstract class EventProcessor {
+        public abstract void process(Event event);
+
+    }
+
+    class PaymentEventProcessor extends EventProcessor {
+        @Override
+        public void process(Event event) {
+
+            EventDigest eventDigest = eventService.getEventDigestForResource(event);
+            transactionService.upsertTransactionFor(eventDigest);
+            transactionMetadataService.upsertMetadataFor(event);
         }
     }
 
-    private boolean isAPayoutEvent(ResourceType resourceType) {
-        return PAYOUT.equals(resourceType);
+    class RefundEventProcessor extends EventProcessor {
+
+        @Override
+        public void process(Event event) {
+            EventDigest refundEventDigest = eventService.getEventDigestForResource(event);
+
+            Map<String, Object> fieldsFromPayment = getFieldsFromOriginalPayment(refundEventDigest.getParentResourceExternalId());
+
+            Map<String, Object> refundEventPayload = new HashMap<>(refundEventDigest.getEventPayload());
+            refundEventPayload.putAll(fieldsFromPayment);
+
+            TransactionEntity refund = transactionEntityFactory.create(refundEventDigest, refundEventPayload);
+
+            transactionService.upsertTransaction(refund);
+            transactionMetadataService.upsertMetadataFor(event);
+        }
+
+        private Map<String, Object> getFieldsFromOriginalPayment(String paymentExternalId) {
+            List<String> paymentsFieldsToCopyToRefunds = List.of("cardholder_name", "email", "description",
+                    "card_brand", "last_digits_card_number", "first_digits_card_number", "reference",
+                    "card_brand_label", "expiry_date", "card_type", "wallet_type");
+
+            EventDigest paymentEventDigest = eventService.getEventDigestForResource(paymentExternalId);
+
+            return paymentEventDigest == null || paymentEventDigest.getEventPayload() == null ?
+                    Map.of()
+                    : paymentEventDigest.getEventPayload()
+                    .entrySet()
+                    .stream().filter(entry -> paymentsFieldsToCopyToRefunds.contains(entry.getKey()))
+                    .collect(toMap(Map.Entry::getKey, Map.Entry::getValue));
+        }
     }
 
-    private boolean isATransactionEvent(ResourceType resourceType) {
-        return PAYMENT.equals(resourceType) || REFUND.equals(resourceType);
+    class PayoutEventProcessor extends EventProcessor {
+        @Override
+        public void process(Event event) {
+            payoutService.upsertPayoutFor(eventService.getEventDigestForResource(event));
+        }
     }
 
-    private void processDigestForTransactionEvent(Event event) {
-        EventDigest eventDigest = eventService.getEventDigestForResource(event);
-        transactionService.upsertTransactionFor(eventDigest);
-        transactionMetadataService.upsertMetadataFor(event);
-    }
-
-    private void processDigestForPayout(Event event) {
-        payoutService.upsertPayoutFor(eventService.getEventDigestForResource(event));
-    }
 }

--- a/src/main/java/uk/gov/pay/ledger/queue/EventMessageHandler.java
+++ b/src/main/java/uk/gov/pay/ledger/queue/EventMessageHandler.java
@@ -6,11 +6,8 @@ import io.sentry.Sentry;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.pay.ledger.event.model.Event;
-import uk.gov.pay.ledger.event.model.EventDigest;
 import uk.gov.pay.ledger.event.model.response.CreateEventResponse;
 import uk.gov.pay.ledger.event.service.EventService;
-import uk.gov.pay.ledger.transaction.service.TransactionMetadataService;
-import uk.gov.pay.ledger.transaction.service.TransactionService;
 
 import java.time.ZonedDateTime;
 import java.time.temporal.ChronoUnit;

--- a/src/main/java/uk/gov/pay/ledger/queue/eventprocessor/EventProcessor.java
+++ b/src/main/java/uk/gov/pay/ledger/queue/eventprocessor/EventProcessor.java
@@ -1,0 +1,7 @@
+package uk.gov.pay.ledger.queue.eventprocessor;
+
+import uk.gov.pay.ledger.event.model.Event;
+
+public abstract class EventProcessor {
+    public abstract void process(Event event);
+}

--- a/src/main/java/uk/gov/pay/ledger/queue/eventprocessor/PaymentEventProcessor.java
+++ b/src/main/java/uk/gov/pay/ledger/queue/eventprocessor/PaymentEventProcessor.java
@@ -1,0 +1,28 @@
+package uk.gov.pay.ledger.queue.eventprocessor;
+
+import uk.gov.pay.ledger.event.model.Event;
+import uk.gov.pay.ledger.event.model.EventDigest;
+import uk.gov.pay.ledger.event.service.EventService;
+import uk.gov.pay.ledger.transaction.service.TransactionMetadataService;
+import uk.gov.pay.ledger.transaction.service.TransactionService;
+
+public class PaymentEventProcessor extends EventProcessor {
+    private EventService eventService;
+    private TransactionService transactionService;
+    private TransactionMetadataService transactionMetadataService;
+
+    public PaymentEventProcessor(EventService eventService, TransactionService transactionService,
+                                 TransactionMetadataService transactionMetadataService) {
+
+        this.eventService = eventService;
+        this.transactionService = transactionService;
+        this.transactionMetadataService = transactionMetadataService;
+    }
+
+    @Override
+    public void process(Event event) {
+        EventDigest eventDigest = eventService.getEventDigestForResource(event);
+        transactionService.upsertTransactionFor(eventDigest);
+        transactionMetadataService.upsertMetadataFor(event);
+    }
+}

--- a/src/main/java/uk/gov/pay/ledger/queue/eventprocessor/PayoutEventProcessor.java
+++ b/src/main/java/uk/gov/pay/ledger/queue/eventprocessor/PayoutEventProcessor.java
@@ -1,0 +1,20 @@
+package uk.gov.pay.ledger.queue.eventprocessor;
+
+import uk.gov.pay.ledger.event.model.Event;
+import uk.gov.pay.ledger.event.service.EventService;
+import uk.gov.pay.ledger.payout.service.PayoutService;
+
+public class PayoutEventProcessor extends EventProcessor {
+    private EventService eventService;
+    private PayoutService payoutService;
+
+    public PayoutEventProcessor(EventService eventService, PayoutService payoutService) {
+        this.eventService = eventService;
+        this.payoutService = payoutService;
+    }
+
+    @Override
+    public void process(Event event) {
+        payoutService.upsertPayoutFor(eventService.getEventDigestForResource(event));
+    }
+}

--- a/src/main/java/uk/gov/pay/ledger/queue/eventprocessor/RefundEventProcessor.java
+++ b/src/main/java/uk/gov/pay/ledger/queue/eventprocessor/RefundEventProcessor.java
@@ -1,0 +1,61 @@
+package uk.gov.pay.ledger.queue.eventprocessor;
+
+import uk.gov.pay.ledger.event.model.Event;
+import uk.gov.pay.ledger.event.model.EventDigest;
+import uk.gov.pay.ledger.event.model.TransactionEntityFactory;
+import uk.gov.pay.ledger.event.service.EventService;
+import uk.gov.pay.ledger.transaction.entity.TransactionEntity;
+import uk.gov.pay.ledger.transaction.service.TransactionService;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static java.util.stream.Collectors.toMap;
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
+
+public class RefundEventProcessor extends EventProcessor {
+    private final EventService eventService;
+    private final TransactionService transactionService;
+    private final TransactionEntityFactory transactionEntityFactory;
+
+    public RefundEventProcessor(EventService eventService, TransactionService transactionService,
+                                TransactionEntityFactory transactionEntityFactory) {
+
+        this.eventService = eventService;
+        this.transactionService = transactionService;
+        this.transactionEntityFactory = transactionEntityFactory;
+    }
+
+    @Override
+    public void process(Event event) {
+        EventDigest refundEventDigest = eventService.getEventDigestForResource(event);
+
+        Map<String, Object> refundEventPayload = new HashMap<>(refundEventDigest.getEventPayload());
+
+        if (isNotBlank(refundEventDigest.getParentResourceExternalId())) {
+            Map<String, Object> fieldsFromPayment = getFieldsFromOriginalPayment(
+                    refundEventDigest.getParentResourceExternalId());
+            refundEventPayload.putAll(fieldsFromPayment);
+        }
+
+        TransactionEntity refund = transactionEntityFactory.create(refundEventDigest, refundEventPayload);
+
+        transactionService.upsertTransaction(refund);
+    }
+
+    private Map<String, Object> getFieldsFromOriginalPayment(String paymentExternalId) {
+        List<String> paymentsFieldsToCopyToRefunds = List.of("cardholder_name", "email", "description",
+                "card_brand", "last_digits_card_number", "first_digits_card_number", "reference",
+                "card_brand_label", "expiry_date", "card_type", "wallet_type");
+
+        // todo : catch 'no events found' exception ? Pacts fail currently
+        EventDigest paymentEventDigest = eventService.getEventDigestForResource(paymentExternalId);
+
+        return paymentEventDigest == null || paymentEventDigest.getEventPayload() == null ? Map.of()
+                : paymentEventDigest.getEventPayload()
+                .entrySet()
+                .stream().filter(entry -> paymentsFieldsToCopyToRefunds.contains(entry.getKey()))
+                .collect(toMap(Map.Entry::getKey, Map.Entry::getValue));
+    }
+}

--- a/src/main/java/uk/gov/pay/ledger/transaction/service/TransactionService.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/service/TransactionService.java
@@ -160,6 +160,10 @@ public class TransactionService {
 
     public void upsertTransactionFor(EventDigest eventDigest) {
         TransactionEntity transaction = transactionEntityFactory.create(eventDigest);
+        upsertTransaction(transaction);
+    }
+
+    public void upsertTransaction(TransactionEntity transaction) {
         transactionDao.upsert(transaction);
     }
 

--- a/src/test/java/uk/gov/pay/ledger/event/service/EventServiceTest.java
+++ b/src/test/java/uk/gov/pay/ledger/event/service/EventServiceTest.java
@@ -38,6 +38,8 @@ public class EventServiceTest {
 
     private ZonedDateTime latestEventTime;
     private final String resourceExternalId = "resource_external_id";
+    private Event event1;
+    private Event event2;
 
     @BeforeEach
     public void setUp() {
@@ -45,13 +47,13 @@ public class EventServiceTest {
 
         latestEventTime = ZonedDateTime.now().minusHours(1L);
         String eventDetails1 = "{ \"amount\": 1000}";
-        Event event1 = EventFixture.anEventFixture()
+        event1 = EventFixture.anEventFixture()
                 .withEventData(eventDetails1)
                 .withResourceExternalId(resourceExternalId)
                 .withEventDate(latestEventTime)
                 .toEntity();
         String eventDetails2 = "{ \"amount\": 2000, \"description\": \"a payment\"}";
-        Event event2 = EventFixture.anEventFixture()
+        event2 = EventFixture.anEventFixture()
                 .withEventData(eventDetails2)
                 .withResourceExternalId(resourceExternalId)
                 .withEventDate(ZonedDateTime.now().minusHours(2L))
@@ -61,7 +63,7 @@ public class EventServiceTest {
 
     @Test
     public void getEventDigestForResource_shouldUseFirstEventInListToPopulateEventDigestMetadata() {
-        EventDigest eventDigest = eventService.getEventDigestForResource(resourceExternalId);
+        EventDigest eventDigest = eventService.getEventDigestForResource(event1);
 
         assertThat(eventDigest.getMostRecentEventTimestamp(), is(latestEventTime));
         assertThat(eventDigest.getMostRecentSalientEventType().get(), is(SalientEventType.PAYMENT_CREATED));
@@ -69,7 +71,7 @@ public class EventServiceTest {
 
     @Test
     public void laterEventsShouldOverrideEarlierEventsInEventDetailsDigest() {
-        EventDigest eventDigest = eventService.getEventDigestForResource(resourceExternalId);
+        EventDigest eventDigest = eventService.getEventDigestForResource(event1);
 
         assertThat(eventDigest.getEventPayload().get("description"), is("a payment"));
         assertThat(eventDigest.getEventPayload().get("amount"), is(1000));
@@ -92,7 +94,7 @@ public class EventServiceTest {
                 .toEntity();
         when(mockEventDao.getEventsByResourceExternalId(resourceExternalId)).thenReturn(List.of(event2, event1));
 
-        EventDigest eventDigest = eventService.getEventDigestForResource(resourceExternalId);
+        EventDigest eventDigest = eventService.getEventDigestForResource(event1);
 
         assertThat(eventDigest.getMostRecentSalientEventType().get(), is(SalientEventType.PAYMENT_CREATED));
     }

--- a/src/test/java/uk/gov/pay/ledger/queue/EventDigestHandlerTest.java
+++ b/src/test/java/uk/gov/pay/ledger/queue/EventDigestHandlerTest.java
@@ -68,7 +68,7 @@ public class EventDigestHandlerTest {
         Event event = anEventFixture().withResourceType(PAYMENT).toEntity();
         eventDigestHandler.processEvent(event);
 
-        verify(eventService).getEventDigestForResource(event.getResourceExternalId());
+        verify(eventService).getEventDigestForResource(event);
         verify(transactionService).upsertTransactionFor(eventDigest);
         verify(transactionMetadataService).upsertMetadataFor(event);
     }
@@ -78,7 +78,7 @@ public class EventDigestHandlerTest {
         Event event = anEventFixture().withResourceType(REFUND).toEntity();
         eventDigestHandler.processEvent(event);
 
-        verify(eventService).getEventDigestForResource(event.getResourceExternalId());
+        verify(eventService).getEventDigestForResource(event);
         verify(transactionService).upsertTransactionFor(eventDigest);
         verify(transactionMetadataService).upsertMetadataFor(event);
     }
@@ -88,7 +88,7 @@ public class EventDigestHandlerTest {
         Event event = anEventFixture().withResourceType(PAYOUT).toEntity();
         eventDigestHandler.processEvent(event);
 
-        verify(eventService).getEventDigestForResource(event.getResourceExternalId());
+        verify(eventService).getEventDigestForResource(event);
         verify(payoutService).upsertPayoutFor(eventDigest);
     }
 

--- a/src/test/java/uk/gov/pay/ledger/queue/EventDigestHandlerTest.java
+++ b/src/test/java/uk/gov/pay/ledger/queue/EventDigestHandlerTest.java
@@ -5,7 +5,6 @@ import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.classic.spi.LoggingEvent;
 import ch.qos.logback.core.Appender;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.BeforeClass;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -33,7 +32,6 @@ import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 import static uk.gov.pay.ledger.event.model.ResourceType.AGREEMENT;
 import static uk.gov.pay.ledger.event.model.ResourceType.PAYMENT;
 import static uk.gov.pay.ledger.event.model.ResourceType.PAYOUT;
@@ -87,7 +85,6 @@ public class EventDigestHandlerTest {
 
         verify(eventService).getEventDigestForResource(event);
         verify(transactionService).upsertTransaction(any());
-        verify(transactionMetadataService).upsertMetadataFor(event);
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/ledger/util/fixture/QueuePaymentEventFixture.java
+++ b/src/test/java/uk/gov/pay/ledger/util/fixture/QueuePaymentEventFixture.java
@@ -135,9 +135,11 @@ public class QueuePaymentEventFixture implements QueueFixture<QueuePaymentEventF
                                 .put("address_country", "GB")
                                 .put("card_type", "DEBIT")
                                 .put("card_brand", "visa")
+                                .put("card_brand_label", "Visa")
                                 .put("gateway_transaction_id", gatewayAccountId)
                                 .put("corporate_surcharge", 5)
                                 .put("total_amount", 1005)
+                                .put("wallet_type", "Google Pay")
                                 .build());
                 break;
             case "CAPTURE_CONFIRMED":


### PR DESCRIPTION
---- DO NOT MERGE ----
- This PR works on the assumption that `reference` field is only available on payment. At present, it is available on both refunds and payments records. Aim is to move `reference` on refunds payload from connector to `gateway_transaction_id` (provided reference and gateway_transaction_id represent same info in connector refunds table). 



## WHAT 

- Move the responsibility for getting the eventdigest into the process method
- Projects payments fields (required to search for refunds or report (CSV) in refunds) onto refund transaction.
- This change will project payment fields directly on to transaction table (i.e, cardholder_name, email and so on) and additional fields on to transaction_details json blob.


