### PR TITLE
PP-6657 Split out event digest processors for domain object projection

### DIFF
--- a/src/main/java/uk/gov/pay/ledger/event/model/TransactionEntityFactory.java
+++ b/src/main/java/uk/gov/pay/ledger/event/model/TransactionEntityFactory.java
@@ -16,18 +16,22 @@ public class TransactionEntityFactory {
     private static final Logger LOGGER = LoggerFactory.getLogger(TransactionEntityFactory.class);
 
     @Inject
-    public TransactionEntityFactory(ObjectMapper objectMapper){
+    public TransactionEntityFactory(ObjectMapper objectMapper) {
         this.objectMapper = objectMapper;
     }
 
     public TransactionEntity create(EventDigest eventDigest) {
+        return create(eventDigest, eventDigest.getEventPayload());
+    }
+
+    public TransactionEntity create(EventDigest eventDigest, Map<String, Object> eventPayload) {
         TransactionState digestTransactionState = eventDigest
                 .getMostRecentSalientEventType()
                 .map(TransactionState::fromEventType)
                 .orElse(TransactionState.UNDEFINED);
 
-        String transactionDetail = convertToTransactionDetails(eventDigest.getEventPayload());
-        TransactionEntity entity = objectMapper.convertValue(eventDigest.getEventPayload(), TransactionEntity.class);
+        String transactionDetail = convertToTransactionDetails(eventPayload);
+        TransactionEntity entity = objectMapper.convertValue(eventPayload, TransactionEntity.class);
         entity.setTransactionDetails(transactionDetail);
         entity.setEventCount(eventDigest.getEventCount());
         entity.setState(digestTransactionState);
@@ -47,4 +51,5 @@ public class TransactionEntityFactory {
         }
         return "{}";
     }
+
 }

--- a/src/main/java/uk/gov/pay/ledger/event/service/EventService.java
+++ b/src/main/java/uk/gov/pay/ledger/event/service/EventService.java
@@ -30,4 +30,8 @@ public class EventService {
             return new CreateEventResponse(e);
         }
     }
+
+    public EventDigest getEventDigestForResource(Event event) {
+        return getEventDigestForResource(event.getResourceExternalId());
+    }
 }

--- a/src/main/java/uk/gov/pay/ledger/queue/EventMessageHandler.java
+++ b/src/main/java/uk/gov/pay/ledger/queue/EventMessageHandler.java
@@ -6,11 +6,8 @@ import io.sentry.Sentry;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.pay.ledger.event.model.Event;
-import uk.gov.pay.ledger.event.model.EventDigest;
 import uk.gov.pay.ledger.event.model.response.CreateEventResponse;
 import uk.gov.pay.ledger.event.service.EventService;
-import uk.gov.pay.ledger.transaction.service.TransactionMetadataService;
-import uk.gov.pay.ledger.transaction.service.TransactionService;
 
 import java.time.ZonedDateTime;
 import java.time.temporal.ChronoUnit;

--- a/src/main/java/uk/gov/pay/ledger/queue/eventprocessor/EventProcessor.java
+++ b/src/main/java/uk/gov/pay/ledger/queue/eventprocessor/EventProcessor.java
@@ -1,0 +1,7 @@
+package uk.gov.pay.ledger.queue.eventprocessor;
+
+import uk.gov.pay.ledger.event.model.Event;
+
+public abstract class EventProcessor {
+    public abstract void process(Event event);
+}

--- a/src/main/java/uk/gov/pay/ledger/queue/eventprocessor/PaymentEventProcessor.java
+++ b/src/main/java/uk/gov/pay/ledger/queue/eventprocessor/PaymentEventProcessor.java
@@ -1,0 +1,28 @@
+package uk.gov.pay.ledger.queue.eventprocessor;
+
+import uk.gov.pay.ledger.event.model.Event;
+import uk.gov.pay.ledger.event.model.EventDigest;
+import uk.gov.pay.ledger.event.service.EventService;
+import uk.gov.pay.ledger.transaction.service.TransactionMetadataService;
+import uk.gov.pay.ledger.transaction.service.TransactionService;
+
+public class PaymentEventProcessor extends EventProcessor {
+    private EventService eventService;
+    private TransactionService transactionService;
+    private TransactionMetadataService transactionMetadataService;
+
+    public PaymentEventProcessor(EventService eventService, TransactionService transactionService,
+                                 TransactionMetadataService transactionMetadataService) {
+
+        this.eventService = eventService;
+        this.transactionService = transactionService;
+        this.transactionMetadataService = transactionMetadataService;
+    }
+
+    @Override
+    public void process(Event event) {
+        EventDigest eventDigest = eventService.getEventDigestForResource(event);
+        transactionService.upsertTransactionFor(eventDigest);
+        transactionMetadataService.upsertMetadataFor(event);
+    }
+}

--- a/src/main/java/uk/gov/pay/ledger/queue/eventprocessor/PayoutEventProcessor.java
+++ b/src/main/java/uk/gov/pay/ledger/queue/eventprocessor/PayoutEventProcessor.java
@@ -1,0 +1,20 @@
+package uk.gov.pay.ledger.queue.eventprocessor;
+
+import uk.gov.pay.ledger.event.model.Event;
+import uk.gov.pay.ledger.event.service.EventService;
+import uk.gov.pay.ledger.payout.service.PayoutService;
+
+public class PayoutEventProcessor extends EventProcessor {
+    private EventService eventService;
+    private PayoutService payoutService;
+
+    public PayoutEventProcessor(EventService eventService, PayoutService payoutService) {
+        this.eventService = eventService;
+        this.payoutService = payoutService;
+    }
+
+    @Override
+    public void process(Event event) {
+        payoutService.upsertPayoutFor(eventService.getEventDigestForResource(event));
+    }
+}

--- a/src/main/java/uk/gov/pay/ledger/queue/eventprocessor/RefundEventProcessor.java
+++ b/src/main/java/uk/gov/pay/ledger/queue/eventprocessor/RefundEventProcessor.java
@@ -1,0 +1,34 @@
+package uk.gov.pay.ledger.queue.eventprocessor;
+
+import uk.gov.pay.ledger.event.model.Event;
+import uk.gov.pay.ledger.event.model.EventDigest;
+import uk.gov.pay.ledger.event.model.TransactionEntityFactory;
+import uk.gov.pay.ledger.event.service.EventService;
+import uk.gov.pay.ledger.transaction.entity.TransactionEntity;
+import uk.gov.pay.ledger.transaction.service.TransactionService;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static java.util.stream.Collectors.toMap;
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
+
+public class RefundEventProcessor extends EventProcessor {
+    private final EventService eventService;
+    private final TransactionService transactionService;
+    private final TransactionEntityFactory transactionEntityFactory;
+
+    public RefundEventProcessor(EventService eventService, TransactionService transactionService,
+                                TransactionEntityFactory transactionEntityFactory) {
+        this.eventService = eventService;
+        this.transactionService = transactionService;
+        this.transactionEntityFactory = transactionEntityFactory;
+    }
+
+    @Override
+    public void process(Event event) {
+        EventDigest refundEventDigest = eventService.getEventDigestForResource(event);
+        transactionService.upsertTransactionFor(refundEventDigest);
+    }
+}

--- a/src/main/java/uk/gov/pay/ledger/transaction/service/TransactionService.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/service/TransactionService.java
@@ -160,6 +160,10 @@ public class TransactionService {
 
     public void upsertTransactionFor(EventDigest eventDigest) {
         TransactionEntity transaction = transactionEntityFactory.create(eventDigest);
+        upsertTransaction(transaction);
+    }
+
+    public void upsertTransaction(TransactionEntity transaction) {
         transactionDao.upsert(transaction);
     }
 

--- a/src/test/java/uk/gov/pay/ledger/event/service/EventServiceTest.java
+++ b/src/test/java/uk/gov/pay/ledger/event/service/EventServiceTest.java
@@ -38,6 +38,8 @@ public class EventServiceTest {
 
     private ZonedDateTime latestEventTime;
     private final String resourceExternalId = "resource_external_id";
+    private Event event1;
+    private Event event2;
 
     @BeforeEach
     public void setUp() {
@@ -45,13 +47,13 @@ public class EventServiceTest {
 
         latestEventTime = ZonedDateTime.now().minusHours(1L);
         String eventDetails1 = "{ \"amount\": 1000}";
-        Event event1 = EventFixture.anEventFixture()
+        event1 = EventFixture.anEventFixture()
                 .withEventData(eventDetails1)
                 .withResourceExternalId(resourceExternalId)
                 .withEventDate(latestEventTime)
                 .toEntity();
         String eventDetails2 = "{ \"amount\": 2000, \"description\": \"a payment\"}";
-        Event event2 = EventFixture.anEventFixture()
+        event2 = EventFixture.anEventFixture()
                 .withEventData(eventDetails2)
                 .withResourceExternalId(resourceExternalId)
                 .withEventDate(ZonedDateTime.now().minusHours(2L))
@@ -61,7 +63,7 @@ public class EventServiceTest {
 
     @Test
     public void getEventDigestForResource_shouldUseFirstEventInListToPopulateEventDigestMetadata() {
-        EventDigest eventDigest = eventService.getEventDigestForResource(resourceExternalId);
+        EventDigest eventDigest = eventService.getEventDigestForResource(event1);
 
         assertThat(eventDigest.getMostRecentEventTimestamp(), is(latestEventTime));
         assertThat(eventDigest.getMostRecentSalientEventType().get(), is(SalientEventType.PAYMENT_CREATED));
@@ -69,7 +71,7 @@ public class EventServiceTest {
 
     @Test
     public void laterEventsShouldOverrideEarlierEventsInEventDetailsDigest() {
-        EventDigest eventDigest = eventService.getEventDigestForResource(resourceExternalId);
+        EventDigest eventDigest = eventService.getEventDigestForResource(event1);
 
         assertThat(eventDigest.getEventPayload().get("description"), is("a payment"));
         assertThat(eventDigest.getEventPayload().get("amount"), is(1000));
@@ -92,7 +94,7 @@ public class EventServiceTest {
                 .toEntity();
         when(mockEventDao.getEventsByResourceExternalId(resourceExternalId)).thenReturn(List.of(event2, event1));
 
-        EventDigest eventDigest = eventService.getEventDigestForResource(resourceExternalId);
+        EventDigest eventDigest = eventService.getEventDigestForResource(event1);
 
         assertThat(eventDigest.getMostRecentSalientEventType().get(), is(SalientEventType.PAYMENT_CREATED));
     }

--- a/src/test/java/uk/gov/pay/ledger/queue/EventDigestHandlerTest.java
+++ b/src/test/java/uk/gov/pay/ledger/queue/EventDigestHandlerTest.java
@@ -4,17 +4,18 @@ import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.classic.spi.LoggingEvent;
 import ch.qos.logback.core.Appender;
-import org.junit.BeforeClass;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.slf4j.LoggerFactory;
 import uk.gov.pay.ledger.event.model.Event;
 import uk.gov.pay.ledger.event.model.EventDigest;
+import uk.gov.pay.ledger.event.model.TransactionEntityFactory;
 import uk.gov.pay.ledger.event.service.EventService;
 import uk.gov.pay.ledger.payout.service.PayoutService;
 import uk.gov.pay.ledger.transaction.service.TransactionMetadataService;
@@ -25,11 +26,12 @@ import java.util.List;
 import static java.lang.String.format;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 import static uk.gov.pay.ledger.event.model.ResourceType.AGREEMENT;
 import static uk.gov.pay.ledger.event.model.ResourceType.PAYMENT;
 import static uk.gov.pay.ledger.event.model.ResourceType.PAYOUT;
@@ -47,19 +49,22 @@ public class EventDigestHandlerTest {
     private TransactionMetadataService transactionMetadataService;
     @Mock
     private PayoutService payoutService;
+    private TransactionEntityFactory transactionEntityFactory;
     @Captor
     private ArgumentCaptor<LoggingEvent> loggingEventArgumentCaptor;
     @Mock
     private Appender<ILoggingEvent> mockAppender;
 
-    @InjectMocks
     private EventDigestHandler eventDigestHandler;
     private EventDigest eventDigest;
 
-    @BeforeClass
+    @BeforeEach
     public void setUp() {
+        transactionEntityFactory = new TransactionEntityFactory(new ObjectMapper());
+        eventDigestHandler =  new EventDigestHandler(eventService, transactionService,
+                transactionMetadataService, payoutService, transactionEntityFactory);
         eventDigest = EventDigest.fromEventList(List.of(anEventFixture().toEntity()));
-        when(eventService.getEventDigestForResource(any()))
+        lenient().when(eventService.getEventDigestForResource(any(Event.class)))
                 .thenReturn(eventDigest);
     }
 
@@ -68,7 +73,7 @@ public class EventDigestHandlerTest {
         Event event = anEventFixture().withResourceType(PAYMENT).toEntity();
         eventDigestHandler.processEvent(event);
 
-        verify(eventService).getEventDigestForResource(event.getResourceExternalId());
+        verify(eventService).getEventDigestForResource(event);
         verify(transactionService).upsertTransactionFor(eventDigest);
         verify(transactionMetadataService).upsertMetadataFor(event);
     }
@@ -78,9 +83,8 @@ public class EventDigestHandlerTest {
         Event event = anEventFixture().withResourceType(REFUND).toEntity();
         eventDigestHandler.processEvent(event);
 
-        verify(eventService).getEventDigestForResource(event.getResourceExternalId());
-        verify(transactionService).upsertTransactionFor(eventDigest);
-        verify(transactionMetadataService).upsertMetadataFor(event);
+        verify(eventService).getEventDigestForResource(event);
+        verify(transactionService).upsertTransactionFor(any());
     }
 
     @Test
@@ -88,17 +92,18 @@ public class EventDigestHandlerTest {
         Event event = anEventFixture().withResourceType(PAYOUT).toEntity();
         eventDigestHandler.processEvent(event);
 
-        verify(eventService).getEventDigestForResource(event.getResourceExternalId());
+        verify(eventService).getEventDigestForResource(event);
         verify(payoutService).upsertPayoutFor(eventDigest);
     }
 
     @Test
-    public void shouldLogWarningIfResourceTypeIsNotPayout() {
+    public void shouldLogErrorAndThrowExceptionIfResourceTypeIsNotSupported() {
         Logger root = (Logger) LoggerFactory.getLogger(EventDigestHandler.class);
         root.addAppender(mockAppender);
 
         Event event = anEventFixture().withResourceType(AGREEMENT).toEntity();
-        eventDigestHandler.processEvent(event);
+
+        assertThrows(RuntimeException.class, () -> eventDigestHandler.processEvent(event));
 
         verify(transactionService, never()).upsertTransactionFor(any());
         verify(transactionMetadataService, never()).upsertMetadataFor(any());

--- a/src/test/java/uk/gov/pay/ledger/queue/QueueMessageReceiverIT.java
+++ b/src/test/java/uk/gov/pay/ledger/queue/QueueMessageReceiverIT.java
@@ -1,12 +1,10 @@
 package uk.gov.pay.ledger.queue;
 
-import io.dropwizard.testing.junit5.DropwizardExtensionsSupport;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.junit.jupiter.api.extension.RegisterExtension;
-import uk.gov.pay.ledger.event.model.ResourceType;
+import org.junit.ClassRule;
+import org.junit.Test;
 import uk.gov.pay.ledger.event.model.SalientEventType;
-import uk.gov.pay.ledger.extension.AppWithPostgresAndSqsExtension;
+import uk.gov.pay.ledger.event.model.ResourceType;
+import uk.gov.pay.ledger.rule.AppWithPostgresAndSqsRule;
 import uk.gov.pay.ledger.util.fixture.QueuePaymentEventFixture;
 
 import java.time.ZonedDateTime;
@@ -20,10 +18,8 @@ import static uk.gov.pay.ledger.util.fixture.QueuePaymentEventFixture.aQueuePaym
 
 public class QueueMessageReceiverIT {
 
-    @RegisterExtension
-    public static AppWithPostgresAndSqsExtension rule = new AppWithPostgresAndSqsExtension(
-            config("queueMessageReceiverConfig.backgroundProcessingEnabled", "true")
-    );
+    @ClassRule
+    public static AppWithPostgresAndSqsRule rule = new AppWithPostgresAndSqsRule(config("queueMessageReceiverConfig.backgroundProcessingEnabled", "true"));
 
     private static final ZonedDateTime CREATED_AT = ZonedDateTime.parse("2019-06-07T08:46:01.123456Z");
 

--- a/src/test/java/uk/gov/pay/ledger/queue/QueueMessageReceiverIT.java
+++ b/src/test/java/uk/gov/pay/ledger/queue/QueueMessageReceiverIT.java
@@ -1,10 +1,12 @@
 package uk.gov.pay.ledger.queue;
 
-import org.junit.ClassRule;
-import org.junit.Test;
+import io.dropwizard.testing.junit5.DropwizardExtensionsSupport;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import uk.gov.pay.ledger.event.model.SalientEventType;
 import uk.gov.pay.ledger.event.model.ResourceType;
-import uk.gov.pay.ledger.rule.AppWithPostgresAndSqsRule;
+import uk.gov.pay.ledger.extension.AppWithPostgresAndSqsExtension;
 import uk.gov.pay.ledger.util.fixture.QueuePaymentEventFixture;
 
 import java.time.ZonedDateTime;
@@ -16,10 +18,13 @@ import static java.lang.String.format;
 import static org.hamcrest.CoreMatchers.is;
 import static uk.gov.pay.ledger.util.fixture.QueuePaymentEventFixture.aQueuePaymentEventFixture;
 
+@ExtendWith(DropwizardExtensionsSupport.class)
 public class QueueMessageReceiverIT {
 
-    @ClassRule
-    public static AppWithPostgresAndSqsRule rule = new AppWithPostgresAndSqsRule(config("queueMessageReceiverConfig.backgroundProcessingEnabled", "true"));
+    @RegisterExtension
+    public static AppWithPostgresAndSqsExtension rule = new AppWithPostgresAndSqsExtension(
+            config("queueMessageReceiverConfig.backgroundProcessingEnabled", "true")
+    );
 
     private static final ZonedDateTime CREATED_AT = ZonedDateTime.parse("2019-06-07T08:46:01.123456Z");
 


### PR DESCRIPTION
* Move event digest collection up to the processor level
* Model anything that can be projected as an event processor, this
should collect an event digest and project a domain object

with @kbottla
with @heathd