### PR TITLE
PP-6657 Refund event digest processor shared payment data

### DIFF
--- a/src/main/java/uk/gov/pay/ledger/event/model/EventDigest.java
+++ b/src/main/java/uk/gov/pay/ledger/event/model/EventDigest.java
@@ -1,6 +1,7 @@
 package uk.gov.pay.ledger.event.model;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import uk.gov.pay.ledger.exception.EmptyEventsException;
 
 import java.io.IOException;
 import java.time.ZonedDateTime;
@@ -47,7 +48,7 @@ public class EventDigest {
 
         var latestEvent = events.stream()
                 .findFirst()
-                .orElseThrow(() -> new RuntimeException("No events found"));
+                .orElseThrow(() -> new EmptyEventsException("No events found"));
 
         var latestSalientEventType = events.stream()
                 .map(e -> SalientEventType.from(e.getEventType()))

--- a/src/main/java/uk/gov/pay/ledger/exception/EmptyEventsException.java
+++ b/src/main/java/uk/gov/pay/ledger/exception/EmptyEventsException.java
@@ -1,0 +1,7 @@
+package uk.gov.pay.ledger.exception;
+
+public class EmptyEventsException extends RuntimeException {
+    public EmptyEventsException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/uk/gov/pay/ledger/queue/eventprocessor/RefundEventProcessor.java
+++ b/src/main/java/uk/gov/pay/ledger/queue/eventprocessor/RefundEventProcessor.java
@@ -4,6 +4,7 @@ import uk.gov.pay.ledger.event.model.Event;
 import uk.gov.pay.ledger.event.model.EventDigest;
 import uk.gov.pay.ledger.event.model.TransactionEntityFactory;
 import uk.gov.pay.ledger.event.service.EventService;
+import uk.gov.pay.ledger.exception.EmptyEventsException;
 import uk.gov.pay.ledger.transaction.entity.TransactionEntity;
 import uk.gov.pay.ledger.transaction.service.TransactionService;
 
@@ -21,6 +22,7 @@ public class RefundEventProcessor extends EventProcessor {
 
     public RefundEventProcessor(EventService eventService, TransactionService transactionService,
                                 TransactionEntityFactory transactionEntityFactory) {
+
         this.eventService = eventService;
         this.transactionService = transactionService;
         this.transactionEntityFactory = transactionEntityFactory;
@@ -29,6 +31,44 @@ public class RefundEventProcessor extends EventProcessor {
     @Override
     public void process(Event event) {
         EventDigest refundEventDigest = eventService.getEventDigestForResource(event);
+
+        /**
+         * Apply shared refund payment attributes to the refund digest
+         *
+         * Frontend consumers rely on searching/ filtering/ downloading attributes that belong to a payment on the
+         * refund. Previously this was done at the "view" level by joining transactions to transactions, for performance
+         * reasons this is now done here during domain object projection (as transactions are de-normalised).
+         *
+         * If there is no longer a frontend requirement to display payment information on a refund, this shared data
+         * for the digest can be removed.
+         */
+        if (isNotBlank(refundEventDigest.getParentResourceExternalId())) {
+            Map<String, Object> fieldsFromPayment = getFieldsFromOriginalPayment(refundEventDigest.getParentResourceExternalId());
+            refundEventDigest.getEventPayload().putAll(fieldsFromPayment);
+        }
+
         transactionService.upsertTransactionFor(refundEventDigest);
+    }
+
+    private Map<String, Object> getFieldsFromOriginalPayment(String paymentExternalId) {
+        EventDigest paymentEventDigest = null;
+        List<String> paymentsFieldsToCopyToRefunds = List.of("cardholder_name", "email", "description",
+                "card_brand", "last_digits_card_number", "first_digits_card_number", "reference",
+                "card_brand_label", "expiry_date", "card_type", "wallet_type");
+
+        try {
+            paymentEventDigest = eventService.getEventDigestForResource(paymentExternalId);
+        } catch (EmptyEventsException ignored) {
+            // no valid refund projection is possible without payment events, allow upstream to handle this
+        }
+
+        var paymentPayloadIsEmpty = paymentEventDigest == null || paymentEventDigest.getEventPayload() == null;
+
+        return paymentPayloadIsEmpty
+                ? Map.of()
+                : paymentEventDigest.getEventPayload()
+                    .entrySet()
+                    .stream().filter(entry -> paymentsFieldsToCopyToRefunds.contains(entry.getKey()))
+                    .collect(toMap(Map.Entry::getKey, Map.Entry::getValue));
     }
 }

--- a/src/main/java/uk/gov/pay/ledger/transaction/service/TransactionService.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/service/TransactionService.java
@@ -160,10 +160,6 @@ public class TransactionService {
 
     public void upsertTransactionFor(EventDigest eventDigest) {
         TransactionEntity transaction = transactionEntityFactory.create(eventDigest);
-        upsertTransaction(transaction);
-    }
-
-    public void upsertTransaction(TransactionEntity transaction) {
         transactionDao.upsert(transaction);
     }
 

--- a/src/test/java/uk/gov/pay/ledger/queue/QueueMessageReceiverIT.java
+++ b/src/test/java/uk/gov/pay/ledger/queue/QueueMessageReceiverIT.java
@@ -7,15 +7,21 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import uk.gov.pay.ledger.event.model.SalientEventType;
 import uk.gov.pay.ledger.event.model.ResourceType;
 import uk.gov.pay.ledger.extension.AppWithPostgresAndSqsExtension;
+import com.google.gson.Gson;
+import uk.gov.pay.ledger.transaction.dao.TransactionDao;
+import uk.gov.pay.ledger.transaction.entity.TransactionEntity;
 import uk.gov.pay.ledger.util.fixture.QueuePaymentEventFixture;
 
 import java.time.ZonedDateTime;
+import java.util.Map;
+import java.util.Optional;
 
 import static io.dropwizard.testing.ConfigOverride.config;
 import static io.restassured.RestAssured.given;
 import static io.restassured.http.ContentType.JSON;
 import static java.lang.String.format;
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static uk.gov.pay.ledger.util.fixture.QueuePaymentEventFixture.aQueuePaymentEventFixture;
 
 @ExtendWith(DropwizardExtensionsSupport.class)
@@ -25,6 +31,8 @@ public class QueueMessageReceiverIT {
     public static AppWithPostgresAndSqsExtension rule = new AppWithPostgresAndSqsExtension(
             config("queueMessageReceiverConfig.backgroundProcessingEnabled", "true")
     );
+
+    TransactionDao transactionDao = new TransactionDao(rule.getJdbi());
 
     private static final ZonedDateTime CREATED_AT = ZonedDateTime.parse("2019-06-07T08:46:01.123456Z");
 
@@ -103,6 +111,21 @@ public class QueueMessageReceiverIT {
         final String resourceExternalId = "rexid";
         final String parentResourceExternalId = "parentRexId";
         final String gatewayAccountId = "test_accountId";
+
+        aQueuePaymentEventFixture()
+                .withResourceExternalId(parentResourceExternalId)
+                .withEventDate(CREATED_AT)
+                .withEventType("PAYMENT_CREATED")
+                .withDefaultEventDataForEventType("PAYMENT_CREATED")
+                .insert(rule.getSqsClient());
+
+        aQueuePaymentEventFixture()
+                .withResourceExternalId(parentResourceExternalId)
+                .withEventDate(CREATED_AT)
+                .withEventType("PAYMENT_DETAILS_ENTERED")
+                .withDefaultEventDataForEventType("PAYMENT_DETAILS_ENTERED")
+                .insert(rule.getSqsClient());
+
         aQueuePaymentEventFixture()
                 .withResourceExternalId(parentResourceExternalId)
                 .withEventDate(CREATED_AT)
@@ -130,6 +153,20 @@ public class QueueMessageReceiverIT {
                 .statusCode(200)
                 .body("transaction_id", is(resourceExternalId))
                 .body("state.status", is("submitted"));
+
+        Optional<TransactionEntity> mayBeRefund = transactionDao.findTransactionByExternalId(resourceExternalId);
+        TransactionEntity refund = mayBeRefund.get();
+        assertThat(refund.getCardholderName(), is("J citizen"));
+        assertThat(refund.getEmail(), is("j.doe@example.org"));
+        assertThat(refund.getCardBrand(), is("visa"));
+        assertThat(refund.getDescription(), is("a description"));
+        assertThat(refund.getLastDigitsCardNumber(), is("4242"));
+        assertThat(refund.getFirstDigitsCardNumber(), is("424242"));
+        assertThat(refund.getReference(), is("aref"));
+        Map<String, String> transactionDetails = new Gson().fromJson(refund.getTransactionDetails(), Map.class);
+        assertThat(transactionDetails.get("reference"), is("aref"));
+        assertThat(transactionDetails.get("expiry_date"), is("11/21"));
+        assertThat(transactionDetails.get("card_type"), is("DEBIT"));
     }
 
     @Test


### PR DESCRIPTION
Depends on https://github.com/alphagov/pay-ledger/pull/839

Update the RefundEventProcessor to pull shared payment attributes from
the payment event digest. These key: values are then added to the refund
event digest which allows all downstream projection (upserting a
transaction) to include this data.

Verify that attributes are set correctly.

With @kbottla