### PR TITLE
PP-6657 Project payment details to nested blob

### DIFF
--- a/src/main/java/uk/gov/pay/ledger/transaction/entity/TransactionEntity.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/entity/TransactionEntity.java
@@ -8,6 +8,7 @@ import uk.gov.pay.commons.model.Source;
 import uk.gov.pay.ledger.transaction.state.TransactionState;
 
 import java.time.ZonedDateTime;
+import java.util.Map;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
@@ -226,6 +227,16 @@ public class TransactionEntity {
 
     public String getGatewayPayoutId() {
         return gatewayPayoutId;
+    }
+
+    public void setEntityFieldsFromOriginalPayment(TransactionEntity paymentTransaction) {
+        this.cardBrand = paymentTransaction.getCardBrand();
+        this.cardholderName = paymentTransaction.getCardholderName();
+        this.reference = paymentTransaction.getReference();
+        this.firstDigitsCardNumber = paymentTransaction.getFirstDigitsCardNumber();
+        this.lastDigitsCardNumber = paymentTransaction.getLastDigitsCardNumber();
+        this.description = paymentTransaction.getDescription();
+        this.email = paymentTransaction.email;
     }
 
     public static class Builder {

--- a/src/main/java/uk/gov/pay/ledger/transaction/service/TransactionService.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/service/TransactionService.java
@@ -163,6 +163,10 @@ public class TransactionService {
         transactionDao.upsert(transaction);
     }
 
+    public void upsertTransaction(TransactionEntity transaction) {
+        transactionDao.upsert(transaction);
+    }
+
     public TransactionEventResponse findTransactionEvents(String externalId, String gatewayAccountId,
                                                           boolean includeAllEvents, int statusVersion) {
         Map<String, TransactionEntity> transactionEntityMap = getTransactionsAsMap(externalId, gatewayAccountId);
@@ -180,8 +184,7 @@ public class TransactionService {
         }
     }
 
-    public Optional<TransactionView> findByGatewayTransactionId(String gatewayTransactionId, String paymentProvider
-                                                                ) {
+    public Optional<TransactionView> findByGatewayTransactionId(String gatewayTransactionId, String paymentProvider) {
         TransactionSearchParams searchParams = new TransactionSearchParams();
         searchParams.setGatewayTransactionId(gatewayTransactionId);
         searchParams.setTransactionType(PAYMENT);

--- a/src/test/java/uk/gov/pay/ledger/queue/EventDigestHandlerTest.java
+++ b/src/test/java/uk/gov/pay/ledger/queue/EventDigestHandlerTest.java
@@ -18,6 +18,7 @@ import uk.gov.pay.ledger.event.model.EventDigest;
 import uk.gov.pay.ledger.event.model.TransactionEntityFactory;
 import uk.gov.pay.ledger.event.service.EventService;
 import uk.gov.pay.ledger.payout.service.PayoutService;
+import uk.gov.pay.ledger.transaction.entity.TransactionEntity;
 import uk.gov.pay.ledger.transaction.service.TransactionMetadataService;
 import uk.gov.pay.ledger.transaction.service.TransactionService;
 
@@ -85,7 +86,7 @@ public class EventDigestHandlerTest {
         eventDigestHandler.processEvent(event);
 
         verify(eventService).getEventDigestForResource(event);
-        verify(transactionService).upsertTransactionFor(any(EventDigest.class));
+        verify(transactionService).upsertTransaction(any(TransactionEntity.class));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/ledger/queue/QueueMessageReceiverIT.java
+++ b/src/test/java/uk/gov/pay/ledger/queue/QueueMessageReceiverIT.java
@@ -163,10 +163,12 @@ public class QueueMessageReceiverIT {
         assertThat(refund.getLastDigitsCardNumber(), is("4242"));
         assertThat(refund.getFirstDigitsCardNumber(), is("424242"));
         assertThat(refund.getReference(), is("aref"));
-        Map<String, String> transactionDetails = new Gson().fromJson(refund.getTransactionDetails(), Map.class);
-        assertThat(transactionDetails.get("reference"), is("aref"));
-        assertThat(transactionDetails.get("expiry_date"), is("11/21"));
-        assertThat(transactionDetails.get("card_type"), is("DEBIT"));
+        Map<String, Object> transactionDetails = new Gson().fromJson(refund.getTransactionDetails(), Map.class);
+        Map<String,String> paymentDetails = (Map<String, String>) transactionDetails.get("payment_details");
+
+        assertThat(paymentDetails.get("card_brand_label"), is("Visa"));
+        assertThat(paymentDetails.get("expiry_date"), is("11/21"));
+        assertThat(paymentDetails.get("card_type"), is("DEBIT"));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/ledger/util/fixture/QueuePaymentEventFixture.java
+++ b/src/test/java/uk/gov/pay/ledger/util/fixture/QueuePaymentEventFixture.java
@@ -135,6 +135,7 @@ public class QueuePaymentEventFixture implements QueueFixture<QueuePaymentEventF
                                 .put("address_country", "GB")
                                 .put("card_type", "DEBIT")
                                 .put("card_brand", "visa")
+                                .put("card_brand_label", "Visa")
                                 .put("gateway_transaction_id", gatewayAccountId)
                                 .put("corporate_surcharge", 5)
                                 .put("total_amount", 1005)


### PR DESCRIPTION
## WHAT
- Project payment specific information as a nested object `payment_details` on `transaction_details` json blob
- Sets top level column directly instead of using objectMapper to set fields on refund transaction entity