### PR TITLE
PP-6758 CSV consumer uses flat refunds

### DIFF
--- a/src/main/java/uk/gov/pay/ledger/transaction/dao/TransactionDao.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/dao/TransactionDao.java
@@ -71,7 +71,7 @@ public class TransactionDao {
             "ORDER BY t.created_date DESC OFFSET :offset LIMIT :limit";
 
     private static final String SEARCH_TRANSACTIONS_CURSOR =
-            SEARCH_TRANSACTIONS_WITH_PARENT_BASE +
+            "SELECT * FROM transaction t " +
             ":searchExtraFields " +
             ":cursorFields " +
             "ORDER BY t.created_date DESC, t.id DESC LIMIT :limit";
@@ -295,7 +295,7 @@ public class TransactionDao {
             query.bind("startingAfterId", startingAfterId);
             query.bind("limit", cursorPageSize);
 
-            return query.map(new TransactionWithParentMapper()).list();
+            return query.map(new TransactionMapper()).list();
         });
     }
 

--- a/src/main/java/uk/gov/pay/ledger/transaction/model/CsvTransactionFactory.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/model/CsvTransactionFactory.java
@@ -24,6 +24,7 @@ import java.util.Optional;
 
 import static java.math.BigDecimal.valueOf;
 import static org.apache.commons.lang3.StringUtils.isBlank;
+import static org.apache.commons.lang3.StringUtils.lowerCase;
 import static org.apache.commons.lang3.StringUtils.replaceChars;
 import static org.apache.commons.text.WordUtils.capitalizeFully;
 import static uk.gov.pay.ledger.util.JsonParser.safeGetAsLong;
@@ -84,19 +85,19 @@ public class CsvTransactionFactory {
                         getPaymentTransactionAttributes(transactionEntity, transactionDetails)
                 );
 
+                result.put(FIELD_GOVUK_PAYMENT_ID, transactionEntity.getExternalId());
                 result.put(FIELD_AMOUNT, penceToCurrency(transactionEntity.getAmount()));
                 result.put(FIELD_TOTAL_AMOUNT, penceToCurrency(totalAmount));
                 result.put(FIELD_NET, penceToCurrency(netAmount));
                 result.put(FIELD_FEE, penceToCurrency(transactionEntity.getFee()));
                 result.put(FIELD_STATE, PaymentState.getDisplayName(transactionEntity.getState()));
+                result.put(FIELD_MOTO, transactionEntity.isMoto());
             }
             if (TransactionType.REFUND.toString().equals(transactionEntity.getTransactionType())) {
-                if (transactionEntity.getParentTransactionEntity() != null) {
-                    result.putAll(
-                            getPaymentTransactionAttributes(transactionEntity, transactionDetails.get("payment_details"))
-                    );
-                }
-
+                result.putAll(
+                        getPaymentTransactionAttributes(transactionEntity, transactionDetails.get("payment_details"))
+                );
+                result.put(FIELD_GOVUK_PAYMENT_ID, transactionEntity.getParentExternalId());
                 result.put(FIELD_AMOUNT, penceToCurrency(transactionEntity.getAmount() * -1));
                 result.put(FIELD_NET, penceToCurrency(netAmount * -1));
                 result.put(FIELD_TOTAL_AMOUNT, penceToCurrency(totalAmount * -1));
@@ -104,6 +105,7 @@ public class CsvTransactionFactory {
                 result.put(FIELD_STATE, RefundState.getDisplayName(transactionEntity.getState()));
             }
 
+            result.put(FIELD_PROVIDER_ID, sanitiseAgainstSpreadsheetFormulaInjection(transactionEntity.getGatewayTransactionId()));
             result.put(FIELD_DATE_CREATED, dateCreated);
             result.put(FIELD_TIME_CREATED, timeCreated);
             result.put(FIELD_CORPORATE_CARD_SURCHARGE, penceToCurrency(
@@ -130,7 +132,8 @@ public class CsvTransactionFactory {
         return result;
     }
 
-    private Map<String, Object> getPaymentTransactionAttributes(TransactionEntity transactionEntity, JsonNode details) throws IOException {
+    private Map<String, Object> getPaymentTransactionAttributes(TransactionEntity transactionEntity, JsonNode details) {
+
         Map<String, Object> result = new HashMap<>();
 
         result.put(FIELD_REFERENCE, sanitiseAgainstSpreadsheetFormulaInjection(transactionEntity.getReference()));
@@ -138,17 +141,15 @@ public class CsvTransactionFactory {
         result.put(FIELD_EMAIL, sanitiseAgainstSpreadsheetFormulaInjection(transactionEntity.getEmail()));
         result.put(FIELD_CARDHOLDER_NAME, sanitiseAgainstSpreadsheetFormulaInjection(transactionEntity.getCardholderName()));
         result.put(FIELD_CARD_NUMBER, transactionEntity.getLastDigitsCardNumber());
-        result.put(FIELD_GOVUK_PAYMENT_ID, transactionEntity.getExternalId());
 
-        result.put(FIELD_CARD_BRAND, safeGetAsString(details, "card_brand_label"));
-        result.put(FIELD_CARD_EXPIRY_DATE, safeGetAsString(details, "expiry_date"));
-        result.put(FIELD_PROVIDER_ID, sanitiseAgainstSpreadsheetFormulaInjection(transactionEntity.getGatewayTransactionId()));
-        result.put(FIELD_CARD_TYPE, StringUtils.lowerCase(safeGetAsString(details, "card_type")));
-        result.put(FIELD_MOTO, transactionEntity.isMoto());
-
-        result.put(FIELD_WALLET_TYPE, capitalizeFully(
-                replaceChars(safeGetAsString(details, "wallet"), '_', ' '))
-        );
+        if (details != null) {
+            result.put(FIELD_CARD_BRAND, safeGetAsString(details, "card_brand_label"));
+            result.put(FIELD_CARD_EXPIRY_DATE, safeGetAsString(details, "expiry_date"));
+            result.put(FIELD_CARD_TYPE, lowerCase(safeGetAsString(details, "card_type")));
+            result.put(FIELD_WALLET_TYPE, capitalizeFully(
+                    replaceChars(safeGetAsString(details, "wallet"), '_', ' '))
+            );
+        }
 
         return result;
     }

--- a/src/test/java/uk/gov/pay/ledger/util/fixture/TransactionFixture.java
+++ b/src/test/java/uk/gov/pay/ledger/util/fixture/TransactionFixture.java
@@ -120,6 +120,10 @@ public class TransactionFixture implements DbFixture<TransactionFixture, Transac
         return id;
     }
 
+    public String getCardExpiryDate() {
+        return cardExpiryDate;
+    }
+
     public TransactionFixture withId(Long id) {
         this.id = id;
         return this;
@@ -221,12 +225,18 @@ public class TransactionFixture implements DbFixture<TransactionFixture, Transac
         return cardBrand;
     }
 
+    public String getCardBrandLabel() {
+        return cardBrandLabel;
+    }
+
     public TransactionFixture withCardBrand(String cardBrand) {
         this.cardBrand = cardBrand;
         return this;
     }
 
-    public boolean isMoto() { return moto;}
+    public boolean isMoto() {
+        return moto;
+    }
 
     public TransactionFixture withMoto(boolean moto) {
         this.moto = moto;
@@ -378,6 +388,10 @@ public class TransactionFixture implements DbFixture<TransactionFixture, Transac
     @NotNull
     private JsonObject getTransactionDetail() {
         JsonObject transactionDetails = new JsonObject();
+        JsonObject refundPaymentDetails = new JsonObject();
+
+        String defaultCardType = String.valueOf(CREDIT);
+        String defaultWalletType = "APPLE_PAY";
 
         transactionDetails.addProperty("language", language);
         transactionDetails.addProperty("return_url", returnUrl);
@@ -387,8 +401,17 @@ public class TransactionFixture implements DbFixture<TransactionFixture, Transac
         transactionDetails.addProperty("corporate_surcharge", corporateCardSurcharge);
         transactionDetails.addProperty("refunded_by", refundedById);
         transactionDetails.addProperty("user_email", refundedByUserEmail);
-        transactionDetails.addProperty("card_type", String.valueOf(CREDIT));
-        transactionDetails.addProperty("wallet", "APPLE_PAY");
+        transactionDetails.addProperty("card_type", defaultCardType);
+        transactionDetails.addProperty("wallet", defaultWalletType);
+
+        if ("REFUND".equals(transactionType)) {
+            refundPaymentDetails.addProperty("card_brand_label", cardBrandLabel);
+            refundPaymentDetails.addProperty("expiry_date", cardExpiryDate);
+            refundPaymentDetails.addProperty("card_type", defaultCardType);
+            refundPaymentDetails.addProperty("wallet", defaultWalletType);
+            transactionDetails.add("payment_details", refundPaymentDetails);
+        }
+
         Optional.ofNullable(cardBrandLabel)
                 .ifPresent(cardBrandLabel -> transactionDetails.addProperty("card_brand_label", cardBrandLabel));
         Optional.ofNullable(externalMetadata)
@@ -591,6 +614,15 @@ public class TransactionFixture implements DbFixture<TransactionFixture, Transac
 
     public TransactionFixture withRefundedByUserEmail(String refundedByUserEmail) {
         this.refundedByUserEmail = refundedByUserEmail;
+        return this;
+    }
+
+    public TransactionFixture withDefaultPaymentDetails() {
+        // default values are already assigned for cardBrand, cardholderName, reference, description, email
+
+        this.firstDigitsCardNumber = "123456";
+        this.lastDigitsCardNumber = "1234";
+        this.cardBrandLabel = "Visa";
         return this;
     }
 }


### PR DESCRIPTION
## WHAT
- Refunds stored within transaction table are now projected with payment details required (to search / for CSV data). These appear at top level (fields like reference, email, description and so on) on a table row and a few payment fields in `payment_details` (card_brand_label, wallet_type and so on) json nested within ``transaction_details` json blob.

- We can now search for refunds by payment values (like reference, email ...) directly and map payment specific fields onto refunds with payment fields available on refunds.

**Changes**
- Removes self join on transaction table for CSV query and directly map results to entities using `TransactionMapper`.
- Project refunds records in CSV with payment details available on refund records.
- Provider ID is set from payment/refund transactions as available. Currently payment provider ID is set on refunds
- Moto flag is now only available for payment records. Similar to provider id, it was taken from the payment and assigned to refund records currently.