### PR TITLE
PP-6758 Pact states: Add payment details to refunds payload

### DIFF
--- a/src/main/java/uk/gov/pay/ledger/transaction/dao/TransactionDao.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/dao/TransactionDao.java
@@ -278,7 +278,7 @@ public class TransactionDao {
     public List<TransactionEntity> cursorTransactionSearch(TransactionSearchParams searchParams, ZonedDateTime startingAfterCreatedDate, Long startingAfterId) {
         Long cursorPageSize = searchParams.getDisplaySize();
         String cursorTemplate = "";
-        String searchTemplate = createSearchTemplate(searchParams.getFilterTemplatesWithParentTransactionSearch(), SEARCH_TRANSACTIONS_CURSOR);
+        String searchTemplate = createSearchTemplate(searchParams.getFilterTemplates(), SEARCH_TRANSACTIONS_CURSOR);
 
         if (startingAfterCreatedDate != null && startingAfterId != null) {
             cursorTemplate = searchParams.getQueryMap().isEmpty() ? "WHERE " : "AND ";

--- a/src/test/java/uk/gov/pay/ledger/pact/ContractTest.java
+++ b/src/test/java/uk/gov/pay/ledger/pact/ContractTest.java
@@ -388,8 +388,7 @@ public abstract class ContractTest {
                 .withReference(reference)
                 .withDescription(description)
                 .withCreatedDate(ZonedDateTime.parse(createdDate))
-                .withCardBrand(null)
-                .withEmail(null)
+                .withDefaultPaymentDetails()
                 .withDefaultTransactionDetails()
                 .insert(app.getJdbi());
     }
@@ -455,7 +454,7 @@ public abstract class ContractTest {
                 .withCardBrandLabel("Visa")
                 .withGatewayTransactionId("gateway-transaction-id")
                 .withCardholderName("J Doe")
-                .withEmail("gds-payments-team-smoke@digital.cabinet-office.gov.uk")
+                .withEmail("test@example.org")
                 .withCreatedDate(ZonedDateTime.parse(createdDate))
                 .withCaptureSubmittedDate(ZonedDateTime.parse(createdDate).plusMinutes(2L))
                 .withCapturedDate(ZonedDateTime.parse(createdDate).plusHours(1L))

--- a/src/test/java/uk/gov/pay/ledger/transaction/dao/TransactionDaoSearchIT.java
+++ b/src/test/java/uk/gov/pay/ledger/transaction/dao/TransactionDaoSearchIT.java
@@ -872,6 +872,11 @@ public class TransactionDaoSearchIT {
 
         transactionFixture = aTransactionFixture()
                 .withGatewayAccountId("1")
+                .withReference("ref1")
+                .withCardholderName("test 1")
+                .withLastDigitsCardNumber("1234")
+                .withCardBrand("visa")
+                .withEmail("test@example.org")
                 .withCreatedDate(now(ZoneOffset.UTC).minusDays(1))
                 .insert(rule.getJdbi());
 
@@ -881,10 +886,14 @@ public class TransactionDaoSearchIT {
                 .insert(rule.getJdbi());
 
         searchParams.setAccountIds(List.of("1"));
+        searchParams.setReference("ref");
+        searchParams.setCardHolderName("test");
+        searchParams.setEmail("test@example.org");
+        searchParams.setCardBrands(new CommaDelimitedSetParameter("visa"));
 
         List<TransactionEntity> transactionList = transactionDao.cursorTransactionSearch(searchParams, null, null);
 
-        assertThat(transactionList.size(), is(2));
+        assertThat(transactionList.size(), is(1));
     }
 
     @Test


### PR DESCRIPTION
## WHAT 
 - Adds payments details expected by consumer (selfservice) for new `payment_details` json on refund transaction
- Also fixed csv search query to use filter template on transaction as parent transaction filter template is no longer applicable. 
   - Updated DAO test to apply filters on fields
