### PR TITLE
PP-6766 Remove parent transaction

### DIFF
--- a/src/main/java/uk/gov/pay/ledger/transaction/model/Refund.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/model/Refund.java
@@ -3,7 +3,6 @@ package uk.gov.pay.ledger.transaction.model;
 import uk.gov.pay.ledger.transaction.state.TransactionState;
 
 import java.time.ZonedDateTime;
-import java.util.Optional;
 
 public class Refund extends Transaction {
     private final TransactionState state;
@@ -14,7 +13,6 @@ public class Refund extends Transaction {
     private final String parentExternalId;
     private final String gatewayTransactionId;
     private final Payment paymentDetails;
-    private final Optional<Transaction> parentTransaction;
 
     public Refund(Builder builder) {
         super(builder.id, builder.gatewayAccountId, builder.amount, builder.externalId, builder.gatewayPayoutId);
@@ -24,7 +22,6 @@ public class Refund extends Transaction {
         this.refundedBy = builder.refundedBy;
         this.refundedByUserEmail = builder.refundedByUserEmail;
         this.parentExternalId = builder.parentExternalId;
-        this.parentTransaction = builder.parentTransaction;
         this.gatewayTransactionId = builder.gatewayTransactionId;
         this.paymentDetails = builder.paymentDetails;
     }
@@ -47,10 +44,6 @@ public class Refund extends Transaction {
 
     public String getParentExternalId() {
         return parentExternalId;
-    }
-
-    public Optional<Transaction> getParentTransaction() {
-        return parentTransaction;
     }
 
     public String getGatewayTransactionId() {
@@ -82,7 +75,6 @@ public class Refund extends Transaction {
         private String externalId;
         private String parentExternalId;
         private Payment paymentDetails;
-        private Optional<Transaction> parentTransaction;
         private String gatewayPayoutId;
         private String gatewayTransactionId;
 
@@ -140,11 +132,6 @@ public class Refund extends Transaction {
 
         public Builder withParentExternalId(String parentExternalId) {
             this.parentExternalId = parentExternalId;
-            return this;
-        }
-
-        public Builder withParentTransaction(Optional<Transaction> transaction) {
-            this.parentTransaction = transaction;
             return this;
         }
 

--- a/src/main/java/uk/gov/pay/ledger/transaction/model/TransactionFactory.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/model/TransactionFactory.java
@@ -109,9 +109,6 @@ public class TransactionFactory {
         try {
             JsonNode transactionDetails = objectMapper.readTree(Optional.ofNullable(entity.getTransactionDetails()).orElse("{}"));
 
-            Optional<Transaction> parentTransaction = Optional.ofNullable(entity.getParentTransactionEntity())
-                    .map(this::createTransactionEntity);
-
             JsonNode refundPaymentDetails = transactionDetails.get("payment_details");
 
             CardType cardType = CardType.fromString(safeGetAsString(refundPaymentDetails, "card_type"));
@@ -138,7 +135,6 @@ public class TransactionFactory {
                     .withRefundedBy(safeGetAsString(transactionDetails, "refunded_by"))
                     .withRefundedByUserEmail(safeGetAsString(transactionDetails, "user_email"))
                     .withParentExternalId(entity.getParentExternalId())
-                    .withParentTransaction(parentTransaction)
                     .withGatewayPayoutId(entity.getGatewayPayoutId())
                     .withPaymentDetails(paymentDetails)
                     .build();

--- a/src/main/java/uk/gov/pay/ledger/transaction/search/common/TransactionSearchParams.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/search/common/TransactionSearchParams.java
@@ -47,8 +47,6 @@ public class TransactionSearchParams extends SearchParams {
     @QueryParam("exact_reference_match")
     private boolean exactReferenceMatch;
     @DefaultValue("false")
-    @QueryParam("with_parent_transaction")
-    private boolean withParentTransaction;
     private List<String> accountIds;
     @QueryParam("email")
     private String email;
@@ -140,10 +138,6 @@ public class TransactionSearchParams extends SearchParams {
 
     public void setStatusVersion(int statusVersion) {
         this.statusVersion = statusVersion;
-    }
-
-    public void setWithParentTransaction(boolean withParentTransaction) {
-        this.withParentTransaction = withParentTransaction;
     }
 
     public void setGatewayPayoutId(String gatewayPayoutId) {
@@ -356,10 +350,6 @@ public class TransactionSearchParams extends SearchParams {
 
     public int getStatusVersion() {
         return statusVersion;
-    }
-
-    public boolean getWithParentTransaction() {
-        return withParentTransaction;
     }
 
     @Override

--- a/src/main/java/uk/gov/pay/ledger/transaction/search/common/TransactionSearchParamsValidator.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/search/common/TransactionSearchParamsValidator.java
@@ -15,10 +15,6 @@ public class TransactionSearchParamsValidator {
 
     public static void validateSearchParams(TransactionSearchParams searchParams, CommaDelimitedSetParameter gatewayAccountIds) {
         validateDates(searchParams);
-
-        if (searchParams.getWithParentTransaction() && isEmpty(gatewayAccountIds)) {
-            throw new ValidationException("gateway_account_id is mandatory to search with parent transaction");
-        }
     }
 
     public static void validateSearchParamsForCsv(TransactionSearchParams searchParams, CommaDelimitedSetParameter gatewayAccountIds) {

--- a/src/main/java/uk/gov/pay/ledger/transaction/search/model/TransactionView.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/search/model/TransactionView.java
@@ -53,7 +53,6 @@ public class TransactionView {
     private String refundedBy;
     private String refundedByUserEmail;
     private TransactionType transactionType;
-    private TransactionView parentTransaction;
     private Boolean moto;
     private Boolean live;
     private Source source;
@@ -88,7 +87,6 @@ public class TransactionView {
         this.refundedBy = builder.refundedBy;
         this.refundedByUserEmail = builder.refundedByUserEmail;
         this.transactionType = builder.transactionType;
-        this.parentTransaction = builder.parentTransaction;
         this.moto = builder.moto;
         this.live = builder.live;
         this.source = builder.source;
@@ -153,7 +151,6 @@ public class TransactionView {
                 .withRefundedBy(refund.getRefundedBy())
                 .withRefundedByUserEmail(refund.getRefundedByUserEmail())
                 .withTransactionType(refund.getTransactionType())
-                .withParentTransaction(refund.getParentTransaction().map(parentTransaction -> from(parentTransaction, statusVersion)).orElse(null))
                 .withGatewayPayoutId(refund.getGatewayPayoutId());
         if (refund.getPaymentDetails() != null) {
             refundBuilder = refundBuilder
@@ -285,10 +282,6 @@ public class TransactionView {
         return transactionType;
     }
 
-    public TransactionView getParentTransaction() {
-        return parentTransaction;
-    }
-
     public Boolean getLive() {
         return live;
     }
@@ -310,7 +303,6 @@ public class TransactionView {
     }
 
     public static class Builder {
-        private TransactionView parentTransaction;
         private Long id;
         private String gatewayAccountId;
         private Long amount;
@@ -479,11 +471,6 @@ public class TransactionView {
 
         public Builder withTransactionType(TransactionType transactionType) {
             this.transactionType = transactionType;
-            return this;
-        }
-
-        public Builder withParentTransaction(TransactionView parentTransaction) {
-            this.parentTransaction = parentTransaction;
             return this;
         }
 

--- a/src/main/java/uk/gov/pay/ledger/transaction/service/TransactionService.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/service/TransactionService.java
@@ -19,8 +19,8 @@ import uk.gov.pay.ledger.transaction.model.TransactionSearchResponse;
 import uk.gov.pay.ledger.transaction.model.TransactionType;
 import uk.gov.pay.ledger.transaction.model.TransactionsForTransactionResponse;
 import uk.gov.pay.ledger.transaction.search.common.TransactionSearchParams;
-import uk.gov.pay.ledger.util.pagination.PaginationBuilder;
 import uk.gov.pay.ledger.transaction.search.model.TransactionView;
+import uk.gov.pay.ledger.util.pagination.PaginationBuilder;
 
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Response;
@@ -93,14 +93,6 @@ public class TransactionService {
             searchParams.setAccountIds(gatewayAccountIds);
         }
 
-        if (searchParams.getWithParentTransaction()) {
-            return searchTransactionsAndParent(searchParams, uriInfo);
-        } else {
-            return searchTransactionsWithoutParent(searchParams, uriInfo);
-        }
-    }
-
-    private TransactionSearchResponse searchTransactionsWithoutParent(TransactionSearchParams searchParams, UriInfo uriInfo) {
         List<Transaction> transactionList = transactionDao.searchTransactions(searchParams)
                 .stream()
                 .map(transactionFactory::createTransactionEntity)
@@ -117,17 +109,6 @@ public class TransactionService {
                         Response.Status.NOT_FOUND);
             }
         }
-
-        return buildTransactionSearchResponse(searchParams, uriInfo, transactionList, total);
-    }
-
-    private TransactionSearchResponse searchTransactionsAndParent(TransactionSearchParams searchParams, UriInfo uriInfo) {
-        List<Transaction> transactionList = transactionDao.searchTransactionsAndParent(searchParams)
-                .stream()
-                .map(transactionFactory::createTransactionEntity)
-                .collect(Collectors.toList());
-
-        Long total = transactionDao.getTotalForSearchTransactionAndParent(searchParams);
 
         return buildTransactionSearchResponse(searchParams, uriInfo, transactionList, total);
     }

--- a/src/test/java/uk/gov/pay/ledger/transaction/model/TransactionFactoryTest.java
+++ b/src/test/java/uk/gov/pay/ledger/transaction/model/TransactionFactoryTest.java
@@ -197,8 +197,6 @@ public class TransactionFactoryTest {
         assertThat(refundEntity.getState(), is(state));
         assertThat(refundEntity.getCreatedDate(), is(createdDate));
         assertThat(refundEntity.getEventCount(), is(eventCount));
-
-        assertCorrectPaymentTransactionWithFullData((Payment) refundEntity.getParentTransaction().get());
     }
 
     @Test
@@ -249,8 +247,6 @@ public class TransactionFactoryTest {
         assertThat(refundEntity.getPaymentDetails().getCardDetails().getExpiryDate(), is("10/27"));
         assertThat(refundEntity.getPaymentDetails().getCardDetails().getCardType(), is(CardType.CREDIT));
         assertThat(refundEntity.getPaymentDetails().getWalletType(), is("APPLE_PAY"));
-
-        assertCorrectPaymentTransactionWithFullData((Payment) refundEntity.getParentTransaction().get());
     }
 
     private void assertCorrectPaymentTransactionWithFullData(Payment payment) {

--- a/src/test/java/uk/gov/pay/ledger/transaction/resource/TransactionResourceIT.java
+++ b/src/test/java/uk/gov/pay/ledger/transaction/resource/TransactionResourceIT.java
@@ -145,6 +145,7 @@ public class TransactionResourceIT {
                 .withRefundedById(refundedBy)
                 .withRefundedByUserEmail(refundedByUserEmail)
                 .withGatewayTransactionId("gateway-transaction-id")
+                .withDefaultPaymentDetails()
                 .withDefaultTransactionDetails()
                 .withGatewayPayoutId(gatewayPayoutId);
         transactionFixture.insert(rule.getJdbi());
@@ -162,7 +163,17 @@ public class TransactionResourceIT {
                 .body("created_date", is(now.toString()))
                 .body("refunded_by", is(refundedBy))
                 .body("refunded_by_user_email", is(refundedByUserEmail))
-                .body("gateway_payout_id", is(gatewayPayoutId));
+                .body("gateway_payout_id", is(gatewayPayoutId))
+                .body("payment_details.description", is(transactionFixture.getDescription()))
+                .body("payment_details.reference", is(transactionFixture.getReference()))
+                .body("payment_details.email", is(transactionFixture.getEmail()))
+                .body("payment_details.transaction_type", is("PAYMENT"))
+                .body("payment_details.card_details.cardholder_name", is(transactionFixture.getCardholderName()))
+                .body("payment_details.card_details.card_brand", is(transactionFixture.getCardBrandLabel()))
+                .body("payment_details.card_details.last_digits_card_number", is(transactionFixture.getLastDigitsCardNumber()))
+                .body("payment_details.card_details.first_digits_card_number", is(transactionFixture.getFirstDigitsCardNumber()))
+                .body("payment_details.card_details.expiry_date", is(transactionFixture.getCardExpiryDate()))
+                .body("payment_details.card_details.card_type", is("credit"));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/ledger/transaction/search/common/TransactionSearchParamsValidatorTest.java
+++ b/src/test/java/uk/gov/pay/ledger/transaction/search/common/TransactionSearchParamsValidatorTest.java
@@ -45,26 +45,6 @@ public class TransactionSearchParamsValidatorTest {
     }
 
     @Test
-    public void shouldNotThrowException_whenGatewayAccountIdAvailableAndWithParentTransactionIsTrue() {
-        searchParams.setWithParentTransaction(true);
-        TransactionSearchParamsValidator.validateSearchParams(searchParams, new CommaDelimitedSetParameter("account-id"));
-    }
-
-    @Test
-    public void shouldNotThrowException_whenGatewayAccountIdsAvailableAndWithParentTransactionIsTrue() {
-        searchParams.setWithParentTransaction(true);
-        ValidationException validationException = assertThrows(ValidationException.class,
-                () -> TransactionSearchParamsValidator.validateSearchParams(searchParams, new CommaDelimitedSetParameter("")));
-        assertThat(validationException.getMessage(), is("gateway_account_id is mandatory to search with parent transaction"));
-    }
-
-    @Test
-    public void shouldNotThrowException_whenGatewayAccountIdIsNotAvailableAndWithParentTransactionIsTrue() {
-        searchParams.setWithParentTransaction(true);
-        TransactionSearchParamsValidator.validateSearchParams(searchParams, new CommaDelimitedSetParameter("1,2"));
-    }
-
-    @Test
     public void validateSearchParamsForCsvShouldNotThrowExceptionForValidParams() {
         searchParams.setFromDate("2019-05-01T10:15:30Z");
         searchParams.setToDate("2019-05-01T10:15:30Z");

--- a/src/test/java/uk/gov/pay/ledger/transaction/service/TransactionServiceTest.java
+++ b/src/test/java/uk/gov/pay/ledger/transaction/service/TransactionServiceTest.java
@@ -160,7 +160,7 @@ public class TransactionServiceTest {
     }
 
     @Test
-    public void searchTransactionsWithoutParent_shouldThrowNotFoundException_forInvalidPaginationParams() {
+    public void searchTransactions_shouldThrowNotFoundException_forInvalidPaginationParams() {
         List<TransactionEntity> transactionViewList = TransactionFixture.aTransactionList(gatewayAccountId, 10);
         when(mockTransactionDao.searchTransactions(any(TransactionSearchParams.class))).thenReturn(transactionViewList);
         when(mockTransactionDao.getTotalForSearch(any(TransactionSearchParams.class))).thenReturn(10L);
@@ -173,25 +173,6 @@ public class TransactionServiceTest {
 
         verify(mockTransactionDao).searchTransactions(searchParams);
         verify(mockTransactionDao).getTotalForSearch(searchParams);
-    }
-
-    @Test
-    public void shouldListTransactionsWithCorrectQueryParamsAndPaginationLinks_whenParentTransactionIsTrue() {
-        List<TransactionEntity> transactionViewList = TransactionFixture
-                .aTransactionList(gatewayAccountId, 100);
-
-        when(mockTransactionDao.searchTransactionsAndParent(any(TransactionSearchParams.class))).thenReturn(transactionViewList);
-        when(mockTransactionDao.getTotalForSearchTransactionAndParent(any(TransactionSearchParams.class))).thenReturn(100L);
-
-        setAllSearchParams();
-        searchParams.setWithParentTransaction(true);
-
-        TransactionSearchResponse transactionSearchResponse = transactionService.searchTransactions(List.of(gatewayAccountId), searchParams, mockUriInfo);
-
-        verify(mockTransactionDao).searchTransactionsAndParent(searchParams);
-        verify(mockTransactionDao).getTotalForSearchTransactionAndParent(searchParams);
-
-        assertCorrectPaginationQueryParams(transactionSearchResponse);
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/ledger/util/fixture/TransactionFixture.java
+++ b/src/test/java/uk/gov/pay/ledger/util/fixture/TransactionFixture.java
@@ -69,7 +69,6 @@ public class TransactionFixture implements DbFixture<TransactionFixture, Transac
     private boolean live;
     private boolean moto;
     private String refundedByUserEmail;
-    private TransactionEntity parentTransactionEntity;
     private String source;
     private String gatewayPayoutId;
 
@@ -296,11 +295,6 @@ public class TransactionFixture implements DbFixture<TransactionFixture, Transac
         return this;
     }
 
-    public TransactionFixture withParentTransactionEntity(TransactionEntity parentTransactionEntity) {
-        this.parentTransactionEntity = parentTransactionEntity;
-        return this;
-    }
-
     public TransactionFixture withLive(boolean live) {
         this.live = live;
         return this;
@@ -468,7 +462,6 @@ public class TransactionFixture implements DbFixture<TransactionFixture, Transac
                 .withLive(live)
                 .withMoto(moto)
                 .withGatewayTransactionId(gatewayTransactionId)
-                .withParentTransactionEntity(parentTransactionEntity)
                 .withGatewayPayoutId(gatewayPayoutId);
         Source.from(source).ifPresent(builder::withSource);
         return builder.build();


### PR DESCRIPTION
## WHAT
- Removes `with_parent_transaction` flag from search transaction endpoint as it is no longer needed.
- Updated service, models and related tests to remove parent transaction object