### PR TITLE
PP-6768 Add DAO method to count total with limit

### DIFF
--- a/src/main/java/uk/gov/pay/ledger/transaction/dao/TransactionDao.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/dao/TransactionDao.java
@@ -49,6 +49,12 @@ public class TransactionDao {
             "FROM transaction t " +
             ":searchExtraFields ";
 
+    private static final String COUNT_TRANSACTIONS_WITH_LIMIT = "select count(id) from (SELECT t.id " +
+            "FROM transaction t " +
+            " :searchExtraFields " +
+            " OFFSET 0 LIMIT :limit" +
+            ") txs";
+
     private static final String UPSERT_STRING =
             "INSERT INTO transaction(" +
                     "external_id," +
@@ -214,6 +220,18 @@ public class TransactionDao {
         return jdbi.withHandle(handle -> {
             Query query = handle.createQuery(createSearchTemplate(searchParams.getFilterTemplates(), COUNT_TRANSACTIONS));
             searchParams.getQueryMap().forEach(bindSearchParameter(query));
+            return query
+                    .mapTo(Long.class)
+                    .one();
+        });
+    }
+
+    public Long getTotalWithLimitForSearch(TransactionSearchParams searchParams) {
+        return jdbi.withHandle(handle -> {
+            Query query = handle.createQuery(createSearchTemplate(searchParams.getFilterTemplates(), COUNT_TRANSACTIONS_WITH_LIMIT));
+            searchParams.getQueryMap().forEach(bindSearchParameter(query));
+            query.bind("limit", searchParams.getLimitTotalSize());
+
             return query
                     .mapTo(Long.class)
                     .one();

--- a/src/main/java/uk/gov/pay/ledger/transaction/search/common/TransactionSearchParams.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/search/common/TransactionSearchParams.java
@@ -37,6 +37,7 @@ public class TransactionSearchParams extends SearchParams {
     private static final String GATEWAY_PAYOUT_ID = "gateway_payout_id";
     private static final long DEFAULT_PAGE_NUMBER = 1L;
     private static final long DEFAULT_MAX_DISPLAY_SIZE = 500L;
+    private static final Long DEFAULT_LIMIT_TOTAL_SIZE = 10000L;
 
     private long maxDisplaySize = DEFAULT_MAX_DISPLAY_SIZE;
 
@@ -80,6 +81,10 @@ public class TransactionSearchParams extends SearchParams {
     @DefaultValue("500")
     @QueryParam("display_size")
     private Long displaySize = DEFAULT_MAX_DISPLAY_SIZE;
+    @DefaultValue("10000")
+    @QueryParam("limit_total_size")
+    private Long limitTotalSize = DEFAULT_LIMIT_TOTAL_SIZE;
+
     private Map<String, Object> queryMap;
     @QueryParam("gateway_transaction_id")
     private String gatewayTransactionId;
@@ -151,6 +156,10 @@ public class TransactionSearchParams extends SearchParams {
 
     public void setDisplaySize(Long displaySize) {
         this.displaySize = displaySize;
+    }
+
+    public void setLimitTotalSize(Long limitTotalSize) {
+        this.limitTotalSize = limitTotalSize;
     }
 
     public void overrideMaxDisplaySize(Long maxDisplaySize) {
@@ -299,6 +308,13 @@ public class TransactionSearchParams extends SearchParams {
         } else {
             return this.displaySize;
         }
+    }
+
+    public Long getLimitTotalSize() {
+        if (limitTotalSize < displaySize) {
+            return DEFAULT_LIMIT_TOTAL_SIZE;
+        }
+        return this.limitTotalSize;
     }
 
     public String getFromDate() {

--- a/src/test/java/uk/gov/pay/ledger/transaction/search/common/TransactionSearchParamsTest.java
+++ b/src/test/java/uk/gov/pay/ledger/transaction/search/common/TransactionSearchParamsTest.java
@@ -147,4 +147,12 @@ public class TransactionSearchParamsTest {
         transactionSearchParams.setToDate("2018-09-22T10:14:16.067Z");
         assertThat(transactionSearchParams.buildQueryParamString(1L), containsString("to_date=2018-09-22T10:14:16.067Z"));
     }
+
+    @Test
+    public void getLimitTotalSizeShouldReturnDefaultValueIfBelowDisplaySize() {
+        transactionSearchParams.setDisplaySize(100L);
+        transactionSearchParams.setLimitTotalSize(10L);
+
+        assertThat(transactionSearchParams.getLimitTotalSize(), is(10000L));
+    }
 }


### PR DESCRIPTION
## WHAT
- Added DAO method to use to count results up to configured limit instead of counting all rows for search
- Ensures the limit applied isn't below display_size, so total in the results won't be less than the actual number of search results.