### PR TITLE
PP-6768 Add new query param `limit_total`

### DIFF
--- a/src/main/java/uk/gov/pay/ledger/common/search/SearchParams.java
+++ b/src/main/java/uk/gov/pay/ledger/common/search/SearchParams.java
@@ -10,6 +10,10 @@ public abstract class SearchParams {
 
     public abstract Long getDisplaySize();
 
+    public boolean limitTotal() {
+        return false;
+    }
+
     protected boolean isSet(CommaDelimitedSetParameter commaDelimitedSetParameter) {
         return commaDelimitedSetParameter != null && commaDelimitedSetParameter.isNotEmpty();
     }

--- a/src/main/java/uk/gov/pay/ledger/transaction/search/common/TransactionSearchParams.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/search/common/TransactionSearchParams.java
@@ -47,7 +47,6 @@ public class TransactionSearchParams extends SearchParams {
     @DefaultValue("false")
     @QueryParam("exact_reference_match")
     private boolean exactReferenceMatch;
-    @DefaultValue("false")
     private List<String> accountIds;
     @QueryParam("email")
     private String email;
@@ -75,12 +74,15 @@ public class TransactionSearchParams extends SearchParams {
     private TransactionType transactionType;
     @QueryParam("gateway_payout_id")
     private String gatewayPayoutId;
-    @DefaultValue("true")
     private Long pageNumber = 1L;
 
     @DefaultValue("500")
     @QueryParam("display_size")
     private Long displaySize = DEFAULT_MAX_DISPLAY_SIZE;
+
+    @DefaultValue("false")
+    @QueryParam("limit_total")
+    private boolean limitTotal;
     @DefaultValue("10000")
     @QueryParam("limit_total_size")
     private Long limitTotalSize = DEFAULT_LIMIT_TOTAL_SIZE;
@@ -160,6 +162,10 @@ public class TransactionSearchParams extends SearchParams {
 
     public void setLimitTotalSize(Long limitTotalSize) {
         this.limitTotalSize = limitTotalSize;
+    }
+
+    public void setLimitTotal(boolean limitTotal) {
+        this.limitTotal = limitTotal;
     }
 
     public void overrideMaxDisplaySize(Long maxDisplaySize) {
@@ -308,6 +314,11 @@ public class TransactionSearchParams extends SearchParams {
         } else {
             return this.displaySize;
         }
+    }
+
+    @Override
+    public boolean limitTotal() {
+        return limitTotal;
     }
 
     public Long getLimitTotalSize() {

--- a/src/main/java/uk/gov/pay/ledger/transaction/service/TransactionService.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/service/TransactionService.java
@@ -98,15 +98,20 @@ public class TransactionService {
                 .map(transactionFactory::createTransactionEntity)
                 .collect(Collectors.toList());
 
+        Long total;
 
-        Long total = transactionDao.getTotalForSearch(searchParams);
+        if (searchParams.limitTotal()) {
+            total = transactionDao.getTotalWithLimitForSearch(searchParams);
+        } else {
+            total = transactionDao.getTotalForSearch(searchParams);
 
-        long size = searchParams.getDisplaySize();
-        if (total > 0 && searchParams.getDisplaySize() > 0) {
-            long lastPage = (total + size - 1) / size;
-            if (searchParams.getPageNumber() > lastPage || searchParams.getPageNumber() < 1) {
-                throw new WebApplicationException("the requested page not found",
-                        Response.Status.NOT_FOUND);
+            long size = searchParams.getDisplaySize();
+            if (total > 0 && searchParams.getDisplaySize() > 0) {
+                long lastPage = (total + size - 1) / size;
+                if (searchParams.getPageNumber() > lastPage || searchParams.getPageNumber() < 1) {
+                    throw new WebApplicationException("the requested page not found",
+                            Response.Status.NOT_FOUND);
+                }
             }
         }
 

--- a/src/main/java/uk/gov/pay/ledger/util/pagination/PaginationBuilder.java
+++ b/src/main/java/uk/gov/pay/ledger/util/pagination/PaginationBuilder.java
@@ -48,9 +48,14 @@ public class PaginationBuilder {
     }
 
     public PaginationBuilder buildResponse() {
-        Long pageSize = searchParams.getDisplaySize();
-        long lastPage = totalCount > 0 ? (totalCount + pageSize - 1) / pageSize : 1;
-        buildLinks(lastPage);
+
+        if (searchParams.limitTotal()) {
+            buildLinksForLimitTotal();
+        } else {
+            Long pageSize = searchParams.getDisplaySize();
+            long lastPage = totalCount > 0 ? (totalCount + pageSize - 1) / pageSize : 1;
+            buildLinks(lastPage);
+        }
 
         return this;
     }
@@ -73,6 +78,19 @@ public class PaginationBuilder {
 
     public PaginationLink getNextLink() {
         return nextLink;
+    }
+
+    private void buildLinksForLimitTotal() {
+        selfLink = PaginationLink.ofValue(uriWithParams(searchParams.buildQueryParamString(searchParams.getPageNumber())));
+        firstLink = PaginationLink.ofValue(uriWithParams(searchParams.buildQueryParamString(1L)));
+
+        nextLink = PaginationLink.ofValue(uriWithParams(searchParams.buildQueryParamString(selfPageNum + 1)));
+
+        if (selfPageNum == 1L) {
+            prevLink = null;
+        } else {
+            prevLink = PaginationLink.ofValue(uriWithParams(searchParams.buildQueryParamString(selfPageNum - 1)));
+        }
     }
 
     private void buildLinks(long lastPage) {

--- a/src/test/java/uk/gov/pay/ledger/util/pagination/PaginationBuilderTest.java
+++ b/src/test/java/uk/gov/pay/ledger/util/pagination/PaginationBuilderTest.java
@@ -95,4 +95,34 @@ public class PaginationBuilderTest {
         assertThat(builder.getNextLink().getHref().contains("page=4&display_size=10"), is(true));
         assertThat(builder.getSelfLink().getHref().contains("page=3&display_size=10"), is(true));
     }
+
+    @Test
+    public void shouldBuildLinksCorrectly_whenLimitTotalParamIsSetAndFirstPageIsAccessed() {
+        transactionSearchParams.setPageNumber(1L);
+        transactionSearchParams.setDisplaySize(10L);
+        transactionSearchParams.setLimitTotal(true);
+        PaginationBuilder builder = new PaginationBuilder(transactionSearchParams, mockedUriInfo)
+                .withTotalCount(120L);
+        builder = builder.buildResponse();
+        assertThat(builder.getFirstLink().getHref().contains("page=1&display_size=10"), is(true));
+        assertThat(builder.getLastLink(), is(nullValue()));
+        assertThat(builder.getPrevLink(), is(nullValue()));
+        assertThat(builder.getNextLink().getHref().contains("page=2&display_size=10"), is(true));
+        assertThat(builder.getSelfLink().getHref().contains("page=1&display_size=10"), is(true));
+    }
+
+    @Test
+    public void shouldShowAllLinksCorrectly_whenLimitTotalParamIsSetAndMultiplePagesExists() {
+        transactionSearchParams.setPageNumber(3L);
+        transactionSearchParams.setDisplaySize(10L);
+        transactionSearchParams.setLimitTotal(true);
+        PaginationBuilder builder = new PaginationBuilder(transactionSearchParams, mockedUriInfo)
+                .withTotalCount(120L);
+        builder = builder.buildResponse();
+        assertThat(builder.getFirstLink().getHref().contains("page=1&display_size=10"), is(true));
+        assertThat(builder.getLastLink(), is(nullValue()));
+        assertThat(builder.getPrevLink().getHref().contains("page=2&display_size=10"), is(true));
+        assertThat(builder.getNextLink().getHref().contains("page=4&display_size=10"), is(true));
+        assertThat(builder.getSelfLink().getHref().contains("page=3&display_size=10"), is(true));
+    }
 }


### PR DESCRIPTION
## WHAT 
- Added new query param `limit_total`. When param is set, counting total for search results is limited to `limit_tota_size` value or defaults.   When `total` is less than `limit_tota_size`, then `total` is accurate, otherwise it should be interpreted as ' > x rows' (where x is `limit_tota_size` set of default)
- Different set of pagination links are generated when `limit_total` is set. last_page is not available as accurate `total` is unknown.