### PR TITLE
PP-6768 Optimise next_link generation

### DIFF
--- a/src/main/java/uk/gov/pay/ledger/transaction/service/TransactionService.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/service/TransactionService.java
@@ -125,7 +125,10 @@ public class TransactionService {
     private TransactionSearchResponse buildTransactionSearchResponse(TransactionSearchParams searchParams, UriInfo uriInfo, List<Transaction> transactionList, Long totalCount) {
         Long total = Optional.ofNullable(totalCount).orElse(0L);
         PaginationBuilder paginationBuilder = new PaginationBuilder(searchParams, uriInfo);
-        paginationBuilder = paginationBuilder.withTotalCount(total).buildResponse();
+        paginationBuilder = paginationBuilder
+                .withTotalCount(total)
+                .withCount((long) transactionList.size())
+                .buildResponse();
 
         List<TransactionView> transactionViewList = mapToTransactionViewList(transactionList, searchParams.getStatusVersion());
 

--- a/src/main/java/uk/gov/pay/ledger/util/pagination/PaginationBuilder.java
+++ b/src/main/java/uk/gov/pay/ledger/util/pagination/PaginationBuilder.java
@@ -7,6 +7,7 @@ import uk.gov.pay.ledger.common.search.SearchParams;
 
 import javax.ws.rs.core.UriInfo;
 import java.net.URI;
+import java.util.Objects;
 
 import static com.fasterxml.jackson.annotation.JsonInclude.Include;
 
@@ -23,6 +24,8 @@ public class PaginationBuilder {
 
     @JsonIgnore
     private Long totalCount;
+    @JsonIgnore
+    private Long count;
     @JsonIgnore
     private Long selfPageNum;
     @JsonProperty(SELF_LINK)
@@ -44,6 +47,11 @@ public class PaginationBuilder {
 
     public PaginationBuilder withTotalCount(Long total) {
         this.totalCount = total;
+        return this;
+    }
+
+    public PaginationBuilder withCount(Long count) {
+        this.count = count;
         return this;
     }
 
@@ -84,7 +92,9 @@ public class PaginationBuilder {
         selfLink = PaginationLink.ofValue(uriWithParams(searchParams.buildQueryParamString(searchParams.getPageNumber())));
         firstLink = PaginationLink.ofValue(uriWithParams(searchParams.buildQueryParamString(1L)));
 
-        nextLink = PaginationLink.ofValue(uriWithParams(searchParams.buildQueryParamString(selfPageNum + 1)));
+        if (Objects.equals(count, searchParams.getDisplaySize())) {
+            nextLink = PaginationLink.ofValue(uriWithParams(searchParams.buildQueryParamString(selfPageNum + 1)));
+        }
 
         if (selfPageNum == 1L) {
             prevLink = null;

--- a/src/test/java/uk/gov/pay/ledger/util/pagination/PaginationBuilderTest.java
+++ b/src/test/java/uk/gov/pay/ledger/util/pagination/PaginationBuilderTest.java
@@ -102,7 +102,8 @@ public class PaginationBuilderTest {
         transactionSearchParams.setDisplaySize(10L);
         transactionSearchParams.setLimitTotal(true);
         PaginationBuilder builder = new PaginationBuilder(transactionSearchParams, mockedUriInfo)
-                .withTotalCount(120L);
+                .withTotalCount(120L)
+                .withCount(10L);
         builder = builder.buildResponse();
         assertThat(builder.getFirstLink().getHref().contains("page=1&display_size=10"), is(true));
         assertThat(builder.getLastLink(), is(nullValue()));
@@ -117,12 +118,24 @@ public class PaginationBuilderTest {
         transactionSearchParams.setDisplaySize(10L);
         transactionSearchParams.setLimitTotal(true);
         PaginationBuilder builder = new PaginationBuilder(transactionSearchParams, mockedUriInfo)
-                .withTotalCount(120L);
+                .withTotalCount(120L)
+                .withCount(10L);
         builder = builder.buildResponse();
         assertThat(builder.getFirstLink().getHref().contains("page=1&display_size=10"), is(true));
         assertThat(builder.getLastLink(), is(nullValue()));
         assertThat(builder.getPrevLink().getHref().contains("page=2&display_size=10"), is(true));
         assertThat(builder.getNextLink().getHref().contains("page=4&display_size=10"), is(true));
         assertThat(builder.getSelfLink().getHref().contains("page=3&display_size=10"), is(true));
+    }
+
+    @Test
+    public void shouldNotGenerateNextLink_whenLimitTotalIsSetAndCountIsLessThanPageSize() {
+        transactionSearchParams.setDisplaySize(10L);
+        transactionSearchParams.setLimitTotal(true);
+        PaginationBuilder builder = new PaginationBuilder(transactionSearchParams, mockedUriInfo)
+                .withTotalCount(120L)
+                .withCount(9L);
+        builder = builder.buildResponse();
+        assertThat(builder.getNextLink(), is(nullValue()));
     }
 }


### PR DESCRIPTION
## WHAT
- When searching with `limit_total` flag enabled, next_link generated is an increment of current page. Use `count` to make sure `next_page` is generated only when there is possibility of more results i.e., when count is same as page_size. 