### PR TITLE
PP-6850 Re-project refunds when payment updated

### DIFF
--- a/src/main/java/uk/gov/pay/ledger/event/model/EventDigest.java
+++ b/src/main/java/uk/gov/pay/ledger/event/model/EventDigest.java
@@ -2,8 +2,8 @@ package uk.gov.pay.ledger.event.model;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import uk.gov.pay.ledger.exception.EmptyEventsException;
+import uk.gov.pay.ledger.util.JsonParser;
 
-import java.io.IOException;
 import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Map;
@@ -86,17 +86,9 @@ public class EventDigest {
     private static Map<String, Object> buildEventPayload(List<Event> events) {
         return events.stream()
                 .map(Event::getEventData)
-                .map(EventDigest::eventDetailsJsonStringToMap)
+                .map(JsonParser::jsonStringToMap)
                 .flatMap(m -> m.entrySet().stream())
                 .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue, (later, earlier) -> later));
-    }
-
-    private static Map<String, Object> eventDetailsJsonStringToMap(String eventDetails) {
-        try {
-            return (Map<String, Object>) objectMapper.readValue(eventDetails, Map.class);
-        } catch (IOException | ClassCastException e) {
-            throw new RuntimeException("Error converting event Json to Map");
-        }
     }
 
     public ZonedDateTime getMostRecentEventTimestamp() {

--- a/src/main/java/uk/gov/pay/ledger/event/service/EventService.java
+++ b/src/main/java/uk/gov/pay/ledger/event/service/EventService.java
@@ -18,8 +18,12 @@ public class EventService {
     }
 
     public EventDigest getEventDigestForResource(String resourceExternalId) {
-        List<Event> events = eventDao.getEventsByResourceExternalId(resourceExternalId);
+        List<Event> events = getEventsForResource(resourceExternalId);
         return EventDigest.fromEventList(events);
+    }
+
+    public List<Event> getEventsForResource(String resourceExternalId) {
+        return eventDao.getEventsByResourceExternalId(resourceExternalId);
     }
 
     public CreateEventResponse createIfDoesNotExist(Event event) {

--- a/src/main/java/uk/gov/pay/ledger/queue/EventDigestHandler.java
+++ b/src/main/java/uk/gov/pay/ledger/queue/EventDigestHandler.java
@@ -18,9 +18,9 @@ public class EventDigestHandler {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(EventDigestHandler.class);
 
-    PaymentEventProcessor paymentEventProcessor;
-    PayoutEventProcessor payoutEventProcessor;
-    RefundEventProcessor refundEventProcessor;
+    private PaymentEventProcessor paymentEventProcessor;
+    private PayoutEventProcessor payoutEventProcessor;
+    private RefundEventProcessor refundEventProcessor;
 
     @Inject
     public EventDigestHandler(EventService eventService,
@@ -28,9 +28,9 @@ public class EventDigestHandler {
                               TransactionMetadataService transactionMetadataService,
                               PayoutService payoutService,
                               TransactionEntityFactory transactionEntityFactory) {
-        paymentEventProcessor = new PaymentEventProcessor(eventService, transactionService, transactionMetadataService);
-        payoutEventProcessor = new PayoutEventProcessor(eventService, payoutService);
         refundEventProcessor = new RefundEventProcessor(eventService, transactionService, transactionEntityFactory);
+        paymentEventProcessor = new PaymentEventProcessor(eventService, transactionService, transactionMetadataService, refundEventProcessor);
+        payoutEventProcessor = new PayoutEventProcessor(eventService, payoutService);
     }
 
     public EventProcessor processorFor(Event event) {

--- a/src/main/java/uk/gov/pay/ledger/queue/eventprocessor/PaymentEventProcessor.java
+++ b/src/main/java/uk/gov/pay/ledger/queue/eventprocessor/PaymentEventProcessor.java
@@ -2,27 +2,64 @@ package uk.gov.pay.ledger.queue.eventprocessor;
 
 import uk.gov.pay.ledger.event.model.Event;
 import uk.gov.pay.ledger.event.model.EventDigest;
+import uk.gov.pay.ledger.event.model.SalientEventType;
 import uk.gov.pay.ledger.event.service.EventService;
 import uk.gov.pay.ledger.transaction.service.TransactionMetadataService;
 import uk.gov.pay.ledger.transaction.service.TransactionService;
+import uk.gov.pay.ledger.transaction.state.TransactionState;
+import uk.gov.pay.ledger.util.JsonParser;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 
 public class PaymentEventProcessor extends EventProcessor {
+
     private EventService eventService;
     private TransactionService transactionService;
     private TransactionMetadataService transactionMetadataService;
+    private RefundEventProcessor refundEventProcessor;
 
-    public PaymentEventProcessor(EventService eventService, TransactionService transactionService,
-                                 TransactionMetadataService transactionMetadataService) {
+    public PaymentEventProcessor(EventService eventService,
+                                 TransactionService transactionService,
+                                 TransactionMetadataService transactionMetadataService,
+                                 RefundEventProcessor refundEventProcessor) {
 
         this.eventService = eventService;
         this.transactionService = transactionService;
         this.transactionMetadataService = transactionMetadataService;
+        this.refundEventProcessor = refundEventProcessor;
     }
 
     @Override
     public void process(Event event) {
-        EventDigest eventDigest = eventService.getEventDigestForResource(event);
-        transactionService.upsertTransactionFor(eventDigest);
+        List<Event> events = eventService.getEventsForResource(event.getResourceExternalId());
+        EventDigest paymentEventDigest = EventDigest.fromEventList(events);
+
+        transactionService.upsertTransactionFor(paymentEventDigest);
         transactionMetadataService.upsertMetadataFor(event);
+
+        /**
+         * If the payment has associated refunds, we want to update the payment details that we also store on refunds to
+         * keep these in sync with the payment.
+         * We avoid a database query to get refunds when the payment has not been in a success state, as it is not
+         * possible for refunds to exist in this case. We also avoid this query when the current event contains no data
+         * that needs to be updated on the refund.
+         */
+        Map<String, Object> eventDataMap = JsonParser.jsonStringToMap(event.getEventData());
+        boolean shouldCheckForRefundsToUpdate = !event.getEventType().equals("REFUND_AVAILABILITY_UPDATED") &&
+                !(eventDataMap == null || eventDataMap.isEmpty()) &&
+                hasSuccessEvent(events);
+
+        if (shouldCheckForRefundsToUpdate) {
+            transactionService.getChildTransactions(event.getResourceExternalId())
+                    .forEach(refundTransactionEntity -> refundEventProcessor.reprojectRefundTransaction(refundTransactionEntity.getExternalId(), paymentEventDigest));
+        }
+    }
+
+    private boolean hasSuccessEvent(List<Event> events) {
+        return events.stream().map(event -> SalientEventType.from(event.getEventType()))
+                .flatMap(Optional::stream)
+                .anyMatch(salientEventType -> TransactionState.fromEventType(salientEventType) == TransactionState.SUCCESS);
     }
 }

--- a/src/main/java/uk/gov/pay/ledger/transaction/dao/TransactionDao.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/dao/TransactionDao.java
@@ -35,6 +35,9 @@ public class TransactionDao {
             " WHERE parent_external_id = :parentExternalId" +
             "   AND gateway_account_id = :gatewayAccountId";
 
+    private static final String FIND_TRANSACTIONS_BY_PARENT_EXT_ID = "SELECT * FROM transaction " +
+            " WHERE parent_external_id = :parentExternalId";
+
     private static final String SEARCH_TRANSACTIONS = "SELECT * FROM transaction t " +
             ":searchExtraFields " +
             "ORDER BY t.created_date DESC OFFSET :offset LIMIT :limit";
@@ -201,6 +204,15 @@ public class TransactionDao {
                         .bind("gatewayAccountId", gatewayAccountId)
                         .map(new TransactionMapper())
                         .stream().collect(Collectors.toList())
+        );
+    }
+
+    public List<TransactionEntity> findTransactionByParentId(String parentExternalId) {
+        return jdbi.withHandle(handle ->
+                handle.createQuery(FIND_TRANSACTIONS_BY_PARENT_EXT_ID)
+                    .bind("parentExternalId", parentExternalId)
+                    .map(new TransactionMapper())
+                    .stream().collect(Collectors.toList())
         );
     }
 

--- a/src/main/java/uk/gov/pay/ledger/transaction/service/TransactionService.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/service/TransactionService.java
@@ -186,6 +186,10 @@ public class TransactionService {
                 .findFirst();
     }
 
+    public List<TransactionEntity> getChildTransactions(String parentExternalId) {
+        return transactionDao.findTransactionByParentId(parentExternalId);
+    }
+
     private Map<String, TransactionEntity> getTransactionsAsMap(String externalId, String gatewayAccountId) {
         return transactionDao.findTransactionByExternalOrParentIdAndGatewayAccountId(
                 externalId, gatewayAccountId)

--- a/src/main/java/uk/gov/pay/ledger/util/JsonParser.java
+++ b/src/main/java/uk/gov/pay/ledger/util/JsonParser.java
@@ -1,11 +1,15 @@
 package uk.gov.pay.ledger.util;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
+import java.io.IOException;
 import java.time.ZonedDateTime;
+import java.util.Map;
 import java.util.Optional;
 
 public class JsonParser {
+    private static final ObjectMapper objectMapper = new ObjectMapper();
 
     private JsonParser() {
     }
@@ -40,5 +44,13 @@ public class JsonParser {
             return Optional.empty();
         }
         return Optional.ofNullable(object.get(fieldName));
+    }
+
+    public static Map<String, Object> jsonStringToMap(String jsonString) {
+        try {
+            return (Map<String, Object>) objectMapper.readValue(jsonString, Map.class);
+        } catch (IOException | ClassCastException e) {
+            throw new RuntimeException("Error converting event Json to Map");
+        }
     }
 }

--- a/src/test/java/uk/gov/pay/ledger/queue/EventDigestHandlerTest.java
+++ b/src/test/java/uk/gov/pay/ledger/queue/EventDigestHandlerTest.java
@@ -29,6 +29,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -73,10 +74,11 @@ public class EventDigestHandlerTest {
     @Test
     public void shouldUpsertTransactionIfResourceTypeIsPayment() {
         Event event = anEventFixture().withResourceType(PAYMENT).toEntity();
+        when(eventService.getEventsForResource(event.getResourceExternalId())).thenReturn(List.of(anEventFixture().toEntity()));
+
         eventDigestHandler.processEvent(event);
 
-        verify(eventService).getEventDigestForResource(event);
-        verify(transactionService).upsertTransactionFor(eventDigest);
+        verify(transactionService).upsertTransactionFor(any(EventDigest.class));
         verify(transactionMetadataService).upsertMetadataFor(event);
     }
 

--- a/src/test/java/uk/gov/pay/ledger/queue/eventprocessor/PaymentEventProcessorTest.java
+++ b/src/test/java/uk/gov/pay/ledger/queue/eventprocessor/PaymentEventProcessorTest.java
@@ -1,0 +1,115 @@
+package uk.gov.pay.ledger.queue.eventprocessor;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.pay.ledger.event.model.Event;
+import uk.gov.pay.ledger.event.model.EventDigest;
+import uk.gov.pay.ledger.event.service.EventService;
+import uk.gov.pay.ledger.transaction.entity.TransactionEntity;
+import uk.gov.pay.ledger.transaction.service.TransactionMetadataService;
+import uk.gov.pay.ledger.transaction.service.TransactionService;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static uk.gov.pay.ledger.event.model.ResourceType.PAYMENT;
+import static uk.gov.pay.ledger.util.fixture.EventFixture.anEventFixture;
+import static uk.gov.pay.ledger.util.fixture.TransactionFixture.aTransactionFixture;
+
+@ExtendWith(MockitoExtension.class)
+class PaymentEventProcessorTest {
+
+    @Mock
+    private EventService eventService;
+    @Mock
+    private TransactionService transactionService;
+    @Mock
+    private TransactionMetadataService transactionMetadataService;
+    @Mock
+    private RefundEventProcessor refundEventProcessor;
+
+    private PaymentEventProcessor paymentEventProcessor;
+
+    @BeforeEach
+    void setUp() {
+        paymentEventProcessor = new PaymentEventProcessor(eventService, transactionService, transactionMetadataService, refundEventProcessor);
+    }
+
+    @Test
+    void shouldReprojectRefundTransactionsWhenPaymentHasRefunds() {
+        String paymentExternalId = "payment-external-id";
+        Event event = anEventFixture().withResourceType(PAYMENT)
+                .withResourceExternalId(paymentExternalId)
+                .withEventType("ADMIN_MANUALLY_DID_AN_UPDATE")
+                .withEventData("{\"reference\": \"payment-ref\"}")
+                .toEntity();
+
+        Event previousEvent = anEventFixture().withResourceType(PAYMENT)
+                .withEventType("USER_APPROVED_FOR_CAPTURE")
+                .toEntity();
+
+        when(eventService.getEventsForResource(event.getResourceExternalId())).thenReturn(List.of(previousEvent, event));
+
+        TransactionEntity refundTransaction1 = aTransactionFixture().withExternalId("refund-external-id-1").toEntity();
+        TransactionEntity refundTransaction2 = aTransactionFixture().withExternalId("refund-external-id-2").toEntity();
+        when(transactionService.getChildTransactions(paymentExternalId)).thenReturn(List.of(refundTransaction1, refundTransaction2));
+
+        paymentEventProcessor.process(event);
+
+        verify(transactionService).upsertTransactionFor(any(EventDigest.class));
+        verify(transactionMetadataService).upsertMetadataFor(event);
+        verify(refundEventProcessor).reprojectRefundTransaction(eq(refundTransaction1.getExternalId()), any(EventDigest.class));
+        verify(refundEventProcessor).reprojectRefundTransaction(eq(refundTransaction2.getExternalId()), any(EventDigest.class));
+    }
+
+    @Test
+    void shouldNotQueryForRefundsIfPaymentHasntBeenInSuccessState() {
+        String paymentExternalId = "payment-external-id";
+        Event event = anEventFixture().withResourceType(PAYMENT)
+                .withResourceExternalId(paymentExternalId)
+                .withEventType("ADMIN_MANUALLY_DID_AN_UPDATE")
+                .withEventData("{\"reference\": \"payment-ref\"}")
+                .toEntity();
+
+        Event previousEvent = anEventFixture().withResourceType(PAYMENT)
+                .withEventType("PAYMENT_STARTED")
+                .toEntity();
+
+        when(eventService.getEventsForResource(event.getResourceExternalId())).thenReturn(List.of(previousEvent, event));
+
+        paymentEventProcessor.process(event);
+        verify(transactionService).upsertTransactionFor(any(EventDigest.class));
+        verify(transactionMetadataService).upsertMetadataFor(event);
+        verify(transactionService, never()).getChildTransactions(any());
+        verify(refundEventProcessor, never()).reprojectRefundTransaction(any(), any());
+    }
+
+    @Test
+    void shouldNotQueryForRefundsIfNoEventData() {
+        String paymentExternalId = "payment-external-id";
+        Event event = anEventFixture().withResourceType(PAYMENT)
+                .withResourceExternalId(paymentExternalId)
+                .withEventType("ADMIN_MANUALLY_DID_AN_UPDATE")
+                .withEventData("{}")
+                .toEntity();
+
+        Event previousEvent = anEventFixture().withResourceType(PAYMENT)
+                .withEventType("USER_APPROVED_FOR_CAPTURE")
+                .toEntity();
+
+        when(eventService.getEventsForResource(event.getResourceExternalId())).thenReturn(List.of(previousEvent, event));
+
+        paymentEventProcessor.process(event);
+        verify(transactionService).upsertTransactionFor(any(EventDigest.class));
+        verify(transactionMetadataService).upsertMetadataFor(event);
+        verify(transactionService, never()).getChildTransactions(any());
+        verify(refundEventProcessor, never()).reprojectRefundTransaction(any(), any());
+    }
+}

--- a/src/test/java/uk/gov/pay/ledger/queue/eventprocessor/RefundEventProcessorTest.java
+++ b/src/test/java/uk/gov/pay/ledger/queue/eventprocessor/RefundEventProcessorTest.java
@@ -18,15 +18,12 @@ import uk.gov.pay.ledger.event.model.TransactionEntityFactory;
 import uk.gov.pay.ledger.event.service.EventService;
 import uk.gov.pay.ledger.transaction.entity.TransactionEntity;
 import uk.gov.pay.ledger.transaction.service.TransactionService;
-import uk.gov.pay.ledger.util.fixture.EventFixture;
 
 import java.util.List;
 
-import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.pay.ledger.util.fixture.EventFixture.anEventFixture;


### PR DESCRIPTION
When a payment event is received, if it has associated refund, re-calculate the TransactionEntity for the refunds and persist.

This is to ensure that any payment details that we store on the refund are kept in sync with the payment.

Avoid database lookups to get refunds when we know we won't have to do any updates to refunds for the following cases:
- The payment has no previous salient events which map to the "SUCCESS" state, as in this case there cannot be refunds for the payment.
- The event we are processing has no "event_data" associated with it, as there will be no payment details that need to be updated on the refund.
- The event has type "REFUND_AVAILABILITY_UPDATED" as these events contain "event_data" but we know that we don't need to update anything on the refund in this case.