### PR TITLE
PP-7018 Remove limit for CSV transactions

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,0 +1,75 @@
+{
+  "exclude": {
+    "files": null,
+    "lines": null
+  },
+  "generated_at": "2020-09-04T13:50:13Z",
+  "plugins_used": [
+    {
+      "name": "AWSKeyDetector"
+    },
+    {
+      "name": "ArtifactoryDetector"
+    },
+    {
+      "base64_limit": 4.5,
+      "name": "Base64HighEntropyString"
+    },
+    {
+      "name": "BasicAuthDetector"
+    },
+    {
+      "name": "CloudantDetector"
+    },
+    {
+      "hex_limit": 3,
+      "name": "HexHighEntropyString"
+    },
+    {
+      "name": "IbmCloudIamDetector"
+    },
+    {
+      "name": "IbmCosHmacDetector"
+    },
+    {
+      "name": "JwtTokenDetector"
+    },
+    {
+      "keyword_exclude": null,
+      "name": "KeywordDetector"
+    },
+    {
+      "name": "MailchimpDetector"
+    },
+    {
+      "name": "PrivateKeyDetector"
+    },
+    {
+      "name": "SlackDetector"
+    },
+    {
+      "name": "SoftlayerDetector"
+    },
+    {
+      "name": "StripeDetector"
+    },
+    {
+      "name": "TwilioKeyDetector"
+    }
+  ],
+  "results": {
+    "dev.yml": [
+      {
+        "hashed_secret": "08cd923367890009657eab812753379bdb321eeb",
+        "is_verified": true,
+        "line_number": 2,
+        "type": "Secret Keyword"
+      }
+    ]
+  },
+  "version": "0.13.1",
+  "word_list": {
+    "file": null,
+    "hash": null
+  }
+}

--- a/src/main/java/uk/gov/pay/ledger/app/config/ReportingConfig.java
+++ b/src/main/java/uk/gov/pay/ledger/app/config/ReportingConfig.java
@@ -3,19 +3,11 @@ package uk.gov.pay.ledger.app.config;
 import io.dropwizard.Configuration;
 
 import javax.validation.Valid;
-import javax.validation.constraints.NotNull;
 
 public class ReportingConfig extends Configuration {
 
     @Valid
-    private int maximumCsvRowsSize;
-
-    @Valid
     private int streamingCsvPageSize;
-
-    public int getMaximumCsvRowsSize() {
-        return maximumCsvRowsSize;
-    }
 
     public int getStreamingCsvPageSize() {
         return streamingCsvPageSize;

--- a/src/main/java/uk/gov/pay/ledger/transaction/resource/TransactionResource.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/resource/TransactionResource.java
@@ -136,7 +136,7 @@ public class TransactionResource {
                     );
                     outputStream.flush();
                 }
-            } while (!page.isEmpty() && count < configuration.getReportingConfig().getMaximumCsvRowsSize());
+            } while (!page.isEmpty());
             outputStream.close();
             long elapsed = stopwatch.stop().elapsed(TimeUnit.MILLISECONDS);
             LOGGER.info("CSV stream took:",

--- a/src/main/resources/config/config.yaml
+++ b/src/main/resources/config/config.yaml
@@ -76,5 +76,4 @@ queueMessageReceiverConfig:
   messageRetryDelayInSeconds: ${QUEUE_MESSAGE_RETRY_DELAY_IN_SECONDS:-900}
 
 reportingConfig:
-  maximumCsvRowsSize: ${REPORTING_MAX_CSV_ROWS_SIZE:-100000}
   streamingCsvPageSize: ${STREAMING_CSV_PAGE_SIZE:-5000}

--- a/src/test/resources/config/test-config.yaml
+++ b/src/test/resources/config/test-config.yaml
@@ -62,5 +62,4 @@ queueMessageReceiverConfig:
   messageRetryDelayInSeconds: ${QUEUE_MESSAGE_RETRY_DELAY_IN_SECONDS:-900}
 
 reportingConfig:
-  maximumCsvRowsSize: ${REPORTING_MAX_CSV_ROWS_SIZE:-100000}
   streamingCsvPageSize: ${STREAMING_CSV_PAGE_SIZE:-5000}


### PR DESCRIPTION
## WHAT 
- Removed limit on CSV transactions so we can enable and limit total count to 5K for selfservice searches.
  For services with lots of transactions, users will need to apply filters (in selfservice) before downloading transactions.

- Also added .secrets.baseline file which is needed for gds-pre-commit (https://github.com/alphagov/gds-pre-commit) tool