### PR TITLE
PP-6669 add settlement summary to refund

### DIFF
--- a/src/main/java/uk/gov/pay/ledger/transaction/model/Payment.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/model/Payment.java
@@ -8,8 +8,8 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
 import uk.gov.pay.commons.api.json.ApiResponseDateTimeSerializer;
 import uk.gov.pay.commons.model.Source;
+import uk.gov.pay.ledger.transaction.search.model.PaymentSettlementSummary;
 import uk.gov.pay.ledger.transaction.search.model.RefundSummary;
-import uk.gov.pay.ledger.transaction.search.model.SettlementSummary;
 import uk.gov.pay.ledger.transaction.state.TransactionState;
 
 import java.time.ZonedDateTime;
@@ -40,7 +40,7 @@ public class Payment extends Transaction {
     private Long netAmount;
     private Long totalAmount;
     private RefundSummary refundSummary;
-    private SettlementSummary settlementSummary;
+    private PaymentSettlementSummary settlementSummary;
     private Boolean live;
     private Source source;
     private String walletType;
@@ -164,7 +164,7 @@ public class Payment extends Transaction {
         return totalAmount;
     }
 
-    public SettlementSummary getSettlementSummary() {
+    public PaymentSettlementSummary getSettlementSummary() {
         return settlementSummary;
     }
 
@@ -202,7 +202,7 @@ public class Payment extends Transaction {
         private Long totalAmount;
         private Long amount;
         private RefundSummary refundSummary;
-        private SettlementSummary settlementSummary;
+        private PaymentSettlementSummary settlementSummary;
         private Boolean live;
         private Source source;
         private String walletType;
@@ -318,8 +318,8 @@ public class Payment extends Transaction {
             return this;
         }
 
-        public Builder withSettlementSummary(SettlementSummary settlementSummary) {
-            this.settlementSummary = settlementSummary;
+        public Builder withSettlementSummary(PaymentSettlementSummary paymentSettlementSummary) {
+            this.settlementSummary = paymentSettlementSummary;
             return this;
         }
 

--- a/src/main/java/uk/gov/pay/ledger/transaction/model/Refund.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/model/Refund.java
@@ -1,5 +1,6 @@
 package uk.gov.pay.ledger.transaction.model;
 
+import uk.gov.pay.ledger.transaction.search.model.SettlementSummary;
 import uk.gov.pay.ledger.transaction.state.TransactionState;
 
 import java.time.ZonedDateTime;
@@ -13,6 +14,7 @@ public class Refund extends Transaction {
     private final String parentExternalId;
     private final String gatewayTransactionId;
     private final Payment paymentDetails;
+    private final SettlementSummary settlementSummary;
 
     public Refund(Builder builder) {
         super(builder.id, builder.gatewayAccountId, builder.amount, builder.externalId, builder.gatewayPayoutId);
@@ -24,6 +26,7 @@ public class Refund extends Transaction {
         this.parentExternalId = builder.parentExternalId;
         this.gatewayTransactionId = builder.gatewayTransactionId;
         this.paymentDetails = builder.paymentDetails;
+        this.settlementSummary = builder.settlementSummary;
     }
 
     public TransactionState getState() {
@@ -63,6 +66,10 @@ public class Refund extends Transaction {
         return paymentDetails;
     }
 
+    public SettlementSummary getSettlementSummary() {
+        return settlementSummary;
+    }
+
     public static class Builder {
         private TransactionState state;
         private ZonedDateTime createdDate;
@@ -77,6 +84,7 @@ public class Refund extends Transaction {
         private Payment paymentDetails;
         private String gatewayPayoutId;
         private String gatewayTransactionId;
+        private SettlementSummary settlementSummary;
 
         public Builder() {
         }
@@ -147,6 +155,11 @@ public class Refund extends Transaction {
 
         public Builder withPaymentDetails(Payment paymentDetails) {
             this.paymentDetails = paymentDetails;
+            return this;
+        }
+
+        public Builder withSettlementSummary(SettlementSummary refundSettlementSummary) {
+            this.settlementSummary = refundSettlementSummary;
             return this;
         }
     }

--- a/src/main/java/uk/gov/pay/ledger/transaction/model/TransactionFactory.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/model/TransactionFactory.java
@@ -7,8 +7,9 @@ import com.google.inject.Inject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.pay.ledger.transaction.entity.TransactionEntity;
-import uk.gov.pay.ledger.transaction.search.model.RefundSummary;
 import uk.gov.pay.ledger.transaction.search.model.SettlementSummary;
+import uk.gov.pay.ledger.transaction.search.model.RefundSummary;
+import uk.gov.pay.ledger.transaction.search.model.PaymentSettlementSummary;
 
 import java.io.IOException;
 import java.util.Map;
@@ -64,7 +65,7 @@ public class TransactionFactory {
             }
 
             RefundSummary refundSummary = RefundSummary.from(entity);
-            SettlementSummary settlementSummary = new SettlementSummary(
+            PaymentSettlementSummary paymentSettlementSummary = new PaymentSettlementSummary(
                     safeGetAsDate(transactionDetails, "capture_submitted_date"),
                     safeGetAsDate(transactionDetails, "captured_date"),
                     entity.getPayoutEntity().map(payoutEntity -> payoutEntity.getPaidOutDate()).orElse(null)
@@ -92,7 +93,7 @@ public class TransactionFactory {
                     .withNetAmount(entity.getNetAmount())
                     .withRefundSummary(refundSummary)
                     .withTotalAmount(entity.getTotalAmount())
-                    .withSettlementSummary(settlementSummary)
+                    .withSettlementSummary(paymentSettlementSummary)
                     .withMoto(entity.isMoto())
                     .withLive(entity.isLive())
                     .withSource(entity.getSource())
@@ -125,6 +126,10 @@ public class TransactionFactory {
                     .withWalletType(safeGetAsString(refundPaymentDetails, "wallet"))
                     .build();
 
+            SettlementSummary refundSettlementSummary = new SettlementSummary(
+                    entity.getPayoutEntity().map(payoutEntity -> payoutEntity.getPaidOutDate()).orElse(null)
+            );
+
             return new Refund.Builder()
                     .withGatewayAccountId(entity.getGatewayAccountId())
                     .withAmount(entity.getAmount())
@@ -138,6 +143,7 @@ public class TransactionFactory {
                     .withParentExternalId(entity.getParentExternalId())
                     .withGatewayPayoutId(entity.getGatewayPayoutId())
                     .withPaymentDetails(paymentDetails)
+                    .withSettlementSummary(refundSettlementSummary)
                     .build();
 
         } catch (IOException e) {

--- a/src/main/java/uk/gov/pay/ledger/transaction/search/model/PaymentSettlementSummary.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/search/model/PaymentSettlementSummary.java
@@ -1,0 +1,66 @@
+package uk.gov.pay.ledger.transaction.search.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Objects;
+import java.util.Optional;
+
+import static uk.gov.pay.commons.model.ApiResponseDateTimeFormatter.ISO_INSTANT_MILLISECOND_PRECISION;
+
+public class PaymentSettlementSummary extends SettlementSummary {
+    private ZonedDateTime settlementSubmittedTime;
+    private ZonedDateTime capturedDate;
+
+    public PaymentSettlementSummary(ZonedDateTime settlementSubmittedTime, ZonedDateTime capturedDate, ZonedDateTime settledDate) {
+        super(settledDate);
+        this.settlementSubmittedTime = settlementSubmittedTime;
+        this.capturedDate = capturedDate;
+    }
+
+    @JsonProperty("capture_submit_time")
+    public Optional<String> getSettlementSubmittedTime() {
+        return Optional.ofNullable(settlementSubmittedTime)
+                .map(ISO_INSTANT_MILLISECOND_PRECISION::format);
+    }
+
+    @JsonProperty("captured_date")
+    public Optional<String> getCapturedDate() {
+        return Optional.ofNullable(capturedDate)
+                .map(t -> t.format(DateTimeFormatter.ISO_LOCAL_DATE));
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        PaymentSettlementSummary that = (PaymentSettlementSummary) o;
+
+        if (!Objects.equals(settlementSubmittedTime, that.settlementSubmittedTime))
+            return false;
+
+        if(!Objects.equals(settledDate, that.settledDate))
+            return false;
+
+        return Objects.equals(capturedDate, that.capturedDate);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = settlementSubmittedTime != null ? settlementSubmittedTime.hashCode() : 0;
+        result = 31 * result + (capturedDate != null ? capturedDate.hashCode() : 0);
+        result = 31 * result + (settledDate != null ? settledDate.hashCode() : 0);
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "PaymentSettlementSummary{" +
+                ", settlementSubmittedTime=" + settlementSubmittedTime +
+                ", capturedDate=" + capturedDate +
+                ", settledDate=" + settledDate +
+                '}';
+    }
+}

--- a/src/main/java/uk/gov/pay/ledger/transaction/search/model/SettlementSummary.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/search/model/SettlementSummary.java
@@ -8,29 +8,12 @@ import java.time.format.DateTimeFormatter;
 import java.util.Objects;
 import java.util.Optional;
 
-import static uk.gov.pay.commons.model.ApiResponseDateTimeFormatter.ISO_INSTANT_MILLISECOND_PRECISION;
-
 public class SettlementSummary {
-    private ZonedDateTime settlementSubmittedTime;
-    private ZonedDateTime capturedDate;
-    private ZonedDateTime settledDate;
 
-    public SettlementSummary(ZonedDateTime settlementSubmittedTime, ZonedDateTime capturedDate, ZonedDateTime settledDate) {
-        this.settlementSubmittedTime = settlementSubmittedTime;
-        this.capturedDate = capturedDate;
+    protected ZonedDateTime settledDate;
+
+    public SettlementSummary(ZonedDateTime settledDate) {
         this.settledDate = settledDate;
-    }
-
-    @JsonProperty("capture_submit_time")
-    public Optional<String> getSettlementSubmittedTime() {
-        return Optional.ofNullable(settlementSubmittedTime)
-                .map(ISO_INSTANT_MILLISECOND_PRECISION::format);
-    }
-
-    @JsonProperty("captured_date")
-    public Optional<String> getCapturedDate() {
-        return Optional.ofNullable(capturedDate)
-                .map(t -> t.format(DateTimeFormatter.ISO_LOCAL_DATE));
     }
 
     @JsonProperty("settled_date")
@@ -47,28 +30,18 @@ public class SettlementSummary {
 
         SettlementSummary that = (SettlementSummary) o;
 
-        if (!Objects.equals(settlementSubmittedTime, that.settlementSubmittedTime))
-            return false;
-
-        if(!Objects.equals(settledDate, that.settledDate))
-            return false;
-
-        return Objects.equals(capturedDate, that.capturedDate);
+        return Objects.equals(settledDate, that.settledDate);
     }
 
     @Override
     public int hashCode() {
-        int result = settlementSubmittedTime != null ? settlementSubmittedTime.hashCode() : 0;
-        result = 31 * result + (capturedDate != null ? capturedDate.hashCode() : 0);
-        result = 31 * result + (settledDate != null ? settledDate.hashCode() : 0);
-        return result;
+        return  31 * (settledDate != null ? settledDate.hashCode() : 0);
     }
 
     @Override
     public String toString() {
         return "SettlementSummary{" +
-                ", settlementSubmittedTime=" + settlementSubmittedTime +
-                ", capturedDate=" + capturedDate +
+                ", settledDate=" + settledDate +
                 '}';
     }
 }

--- a/src/main/java/uk/gov/pay/ledger/transaction/search/model/TransactionView.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/search/model/TransactionView.java
@@ -151,7 +151,8 @@ public class TransactionView {
                 .withRefundedBy(refund.getRefundedBy())
                 .withRefundedByUserEmail(refund.getRefundedByUserEmail())
                 .withTransactionType(refund.getTransactionType())
-                .withGatewayPayoutId(refund.getGatewayPayoutId());
+                .withGatewayPayoutId(refund.getGatewayPayoutId())
+                .withSettlementSummary(refund.getSettlementSummary());
         if (refund.getPaymentDetails() != null) {
             refundBuilder = refundBuilder
                     .withPaymentDetails(from(refund.getPaymentDetails(), statusVersion));

--- a/src/test/java/uk/gov/pay/ledger/transaction/model/TransactionFactoryTest.java
+++ b/src/test/java/uk/gov/pay/ledger/transaction/model/TransactionFactoryTest.java
@@ -254,6 +254,20 @@ public class TransactionFactoryTest {
         assertThat(refundEntity.getPaymentDetails().getWalletType(), is("APPLE_PAY"));
     }
 
+    @Test
+    public void createsRefundWithSettlementSummaryFromTransactionEntity() {
+        var payoutObject = aPayoutEntity()
+                .withPaidOutDate(paidOutDate)
+                .build();
+        var refund = new TransactionEntity.Builder()
+                .withTransactionType(TransactionType.REFUND.name())
+                .withTransactionDetails(fullTransactionDetails.toString())
+                .withPayoutEntity(payoutObject)
+                .build();
+        assertThat(refund.getPayoutEntity().isPresent(), is(true));
+        assertThat(refund.getPayoutEntity().get().getPaidOutDate(), is(notNullValue()));
+    }
+
     private void assertCorrectPaymentTransactionWithFullData(Payment payment) {
         assertThat(payment.getGatewayAccountId(), is(gatewayAccountId));
         assertThat(payment.getAmount(), is(amount));

--- a/src/test/java/uk/gov/pay/ledger/transaction/resource/TransactionResourceIT.java
+++ b/src/test/java/uk/gov/pay/ledger/transaction/resource/TransactionResourceIT.java
@@ -15,12 +15,17 @@ import uk.gov.pay.ledger.util.fixture.TransactionFixture;
 
 import javax.ws.rs.core.Response;
 import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
 
 import static io.restassured.RestAssured.given;
 import static io.restassured.http.ContentType.JSON;
+import static org.apache.commons.lang3.RandomStringUtils.randomAlphanumeric;
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.Matchers.hasKey;
 import static uk.gov.pay.commons.model.ApiResponseDateTimeFormatter.ISO_INSTANT_MILLISECOND_PRECISION;
 import static uk.gov.pay.ledger.util.DatabaseTestHelper.aDatabaseTestHelper;
+import static uk.gov.pay.ledger.util.fixture.PayoutFixture.PayoutFixtureBuilder.aPayoutFixture;
 import static uk.gov.pay.ledger.util.fixture.TransactionFixture.aTransactionFixture;
 
 public class TransactionResourceIT {
@@ -136,7 +141,7 @@ public class TransactionResourceIT {
         var now = ZonedDateTime.parse("2019-07-31T14:52:07.073Z");
         var refundedBy = "some_user_id";
         var refundedByUserEmail = "test@example.com";
-        var gatewayPayoutId = "payout-id";
+        var gatewayPayoutId = "payout-id" + randomAlphanumeric(10);
 
         transactionFixture = aTransactionFixture()
                 .withTransactionType("REFUND")
@@ -145,10 +150,19 @@ public class TransactionResourceIT {
                 .withRefundedById(refundedBy)
                 .withRefundedByUserEmail(refundedByUserEmail)
                 .withGatewayTransactionId("gateway-transaction-id")
+                .withCaptureSubmittedDate(now)
+                .withCapturedDate(now)
                 .withDefaultPaymentDetails()
                 .withDefaultTransactionDetails()
                 .withGatewayPayoutId(gatewayPayoutId);
         transactionFixture.insert(rule.getJdbi());
+
+        aPayoutFixture()
+                .withGatewayAccountId(transactionFixture.getGatewayAccountId())
+                .withGatewayPayoutId(gatewayPayoutId)
+                .withPaidOutDate(now)
+                .build()
+                .insert(rule.getJdbi());
 
         given().port(port)
                 .contentType(JSON)
@@ -173,7 +187,10 @@ public class TransactionResourceIT {
                 .body("payment_details.card_details.last_digits_card_number", is(transactionFixture.getLastDigitsCardNumber()))
                 .body("payment_details.card_details.first_digits_card_number", is(transactionFixture.getFirstDigitsCardNumber()))
                 .body("payment_details.card_details.expiry_date", is(transactionFixture.getCardExpiryDate()))
-                .body("payment_details.card_details.card_type", is("credit"));
+                .body("payment_details.card_details.card_type", is("credit"))
+                .body("$", not(hasKey("captured_submit_time")))
+                .body("$", not(hasKey("captured_date")))
+                .body("settlement_summary.settled_date", is(now.format(DateTimeFormatter.ofPattern("yyyy-MM-dd"))));
     }
 
     @Test


### PR DESCRIPTION
## WHAT
- add settlement summary to refund transaction type
- refactor SettlementSummary to have one common field between the different types of transactions
- add PaymentSettlementSummary that extends SettlementSummary
- add relevant tests