### PR TITLE
PP-6913 Remove binding to ledger_db in ledger manifest

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -12,7 +12,6 @@ applications:
     disk_quota: ((disk_quota))
     services:
       - ledger-secret-service
-      - ledger-db
       - sqs
     env:
       ENV_MAP_BP_USE_APP_PROFILE_DIR: true


### PR DESCRIPTION
We're now using vpc peered RDS instances and no longer need to bind to a
brokered RDS instance. Remove the `ledger_db` service binding from the
manifest so ledger will start.

## WHAT ##
We missed one, this will fix ledger which isn't currently above to deploy https://cd.gds-reliability.engineering/teams/pay-deploy/pipelines/deploy/jobs/deploy-ledger-staging/builds/90#L5f5a0fc1:18