### PR TITLE
PP-7211 remove temporary annotation

### DIFF
--- a/src/test/java/uk/gov/pay/ledger/pact/ContractTest.java
+++ b/src/test/java/uk/gov/pay/ledger/pact/ContractTest.java
@@ -1,6 +1,5 @@
 package uk.gov.pay.ledger.pact;
 
-import au.com.dius.pact.provider.junit.IgnoreNoPactsToVerify;
 import au.com.dius.pact.provider.junit.State;
 import au.com.dius.pact.provider.junit.target.HttpTarget;
 import au.com.dius.pact.provider.junit.target.Target;
@@ -30,7 +29,6 @@ import static uk.gov.pay.ledger.util.fixture.EventFixture.anEventFixture;
 import static uk.gov.pay.ledger.util.fixture.PayoutFixture.PayoutFixtureBuilder.aPayoutFixture;
 import static uk.gov.pay.ledger.util.fixture.TransactionFixture.aTransactionFixture;
 
-@IgnoreNoPactsToVerify
 public abstract class ContractTest {
 
     @ClassRule


### PR DESCRIPTION
## WHAT
- the annotation 'IgnoreNoPactsToVerify' was temporary while we were adding some new pact tests. Remove it.