### PR TITLE
PP-7241 Add `paas` environment prefix

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -36,7 +36,7 @@ applications:
 
       ADMIN_PORT: '10701'
       DISABLE_INTERNAL_HTTPS: ((disable_internal_https))
-      ENVIRONMENT: ((space))
+      ENVIRONMENT: paas-((space))
       JAVA_OPTS: -Xms512m -Xmx1G
       JBP_CONFIG_JAVA_MAIN: '{ arguments: "server /home/vcap/app/config/config.yaml" }'
       JBP_CONFIG_OPEN_JDK_JRE: '{ jre: { version: 11.+ } }'


### PR DESCRIPTION
The `ENVIRONMENT` variable is used to distinguish our various
environments in Sentry (and is added to our structured logging under the
environment key).

This change will only impact apps deployed on PaaS and should allow us
to separate issues more obviously in Sentry.

## WHAT ##
Strictly speaking existing infra and paas apps have different `environment` tags in Sentry because paas environments do not have the `n` suffix, but this makes it much clearer.