### PR TITLE
BAU Revert Junit Jupiter bump to 5.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -182,13 +182,7 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
-            <version>5.7.0</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-engine</artifactId>
-            <version>${junit5.version}</version>
+            <version>5.6.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
         <testcontainers.version>1.14.3</testcontainers.version>
         <postgresql.version>42.2.16</postgresql.version>
         <pay-java-commons.version>1.0.20201001124822</pay-java-commons.version>
-        <junit5.version>5.7.0</junit5.version>
+        <junit5.version>5.6.2</junit5.version>
         <surefire.version>3.0.0-M5</surefire.version>
         <guice.version>4.2.3</guice.version>
         <rest-assured.version>4.3.1</rest-assured.version>


### PR DESCRIPTION
This reverts commit 6788e23ab4fe165b667b6d4affbeb0d49823c466.

This version bump meant that running the consumer contract tests no longer
resulted in the pacts being created in `target/pacts` or AFAIK anywhere.
This meant they could not be pushed to the pact broker and deploying to
environments failed since CI was unable to tag a version of Ledger which
the pact broker had no knowledge of.

## WHAT ##
Tested this out locally, see pacts https://pact-broker-test.cloudapps.digital/hal-browser/browser.html#/pacticipants/ledger/versions/d8b1c7d62c7a6e45ba6b761bbf80fb1701cca3f4

I haven't looked at why this Junit Jupiter version bump was stopping the pacts being created.

Now that we know ledger should have a pact we might want to remove the `do not fail if there are no pacts` flag when running ledger consumer contract tests - this meant this step was failing silently and the problem surfacing during the `can-i-deploy` check upon deployment.