### PR TITLE
PP-7253 Add ignore no pacts to verify annotation

### DIFF
--- a/src/test/java/uk/gov/pay/ledger/pact/ConnectorContractTest.java
+++ b/src/test/java/uk/gov/pay/ledger/pact/ConnectorContractTest.java
@@ -1,5 +1,6 @@
 package uk.gov.pay.ledger.pact;
 
+import au.com.dius.pact.provider.junit.IgnoreNoPactsToVerify;
 import au.com.dius.pact.provider.junit.PactRunner;
 import au.com.dius.pact.provider.junit.Provider;
 import au.com.dius.pact.provider.junit.loader.PactBroker;
@@ -11,5 +12,6 @@ import org.junit.runner.RunWith;
 @PactBroker(scheme = "https", host = "${PACT_BROKER_HOST:pact-broker-test.cloudapps.digital}", tags = {"${PACT_CONSUMER_TAG}", "test"},
         authentication = @PactBrokerAuth(username = "${PACT_BROKER_USERNAME}", password = "${PACT_BROKER_PASSWORD}"),
         consumers = {"connector"})
+@IgnoreNoPactsToVerify
 public class ConnectorContractTest extends ContractTest {
 }


### PR DESCRIPTION
This will mean master builds will continue to pass even though there
is currently no verification for connector -> ledger pacts