### PR TITLE
PP-7253 Remove IgnoreNoPactsToVerify notification

### DIFF
--- a/src/test/java/uk/gov/pay/ledger/pact/ConnectorContractTest.java
+++ b/src/test/java/uk/gov/pay/ledger/pact/ConnectorContractTest.java
@@ -1,6 +1,5 @@
 package uk.gov.pay.ledger.pact;
 
-import au.com.dius.pact.provider.junit.IgnoreNoPactsToVerify;
 import au.com.dius.pact.provider.junit.PactRunner;
 import au.com.dius.pact.provider.junit.Provider;
 import au.com.dius.pact.provider.junit.loader.PactBroker;
@@ -12,6 +11,5 @@ import org.junit.runner.RunWith;
 @PactBroker(scheme = "https", host = "${PACT_BROKER_HOST:pact-broker-test.cloudapps.digital}", tags = {"${PACT_CONSUMER_TAG}", "test"},
         authentication = @PactBrokerAuth(username = "${PACT_BROKER_USERNAME}", password = "${PACT_BROKER_PASSWORD}"),
         consumers = {"connector"})
-@IgnoreNoPactsToVerify
 public class ConnectorContractTest extends ContractTest {
 }


### PR DESCRIPTION
We now have pacts published for connector as a consumer with ledger as a provider, so this annotation can be removed.