### PR TITLE
PP-7277 add pact test for cancelled by user event

### DIFF
--- a/src/test/java/uk/gov/pay/ledger/pact/CancelledByUserEventQueueContractTest.java
+++ b/src/test/java/uk/gov/pay/ledger/pact/CancelledByUserEventQueueContractTest.java
@@ -1,0 +1,85 @@
+package uk.gov.pay.ledger.pact;
+
+import au.com.dius.pact.consumer.MessagePactBuilder;
+import au.com.dius.pact.consumer.MessagePactProviderRule;
+import au.com.dius.pact.consumer.Pact;
+import au.com.dius.pact.consumer.PactVerification;
+import au.com.dius.pact.model.v3.messaging.MessagePact;
+import com.google.gson.Gson;
+import org.junit.Rule;
+import org.junit.Test;
+import uk.gov.pay.ledger.event.model.SalientEventType;
+import uk.gov.pay.ledger.rule.AppWithPostgresAndSqsRule;
+import uk.gov.pay.ledger.rule.SqsTestDocker;
+import uk.gov.pay.ledger.transaction.dao.TransactionDao;
+import uk.gov.pay.ledger.transaction.entity.TransactionEntity;
+import uk.gov.pay.ledger.util.fixture.QueuePaymentEventFixture;
+
+import java.time.ZonedDateTime;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+
+import static io.dropwizard.testing.ConfigOverride.config;
+import static org.awaitility.Awaitility.await;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class CancelledByUserEventQueueContractTest {
+    Gson gson = new Gson();
+
+    @Rule
+    public MessagePactProviderRule mockProvider = new MessagePactProviderRule(this);
+
+    @Rule
+    public AppWithPostgresAndSqsRule appRule = new AppWithPostgresAndSqsRule(
+            config("queueMessageReceiverConfig.backgroundProcessingEnabled", "true")
+    );
+
+    private byte[] currentMessage;
+    private String externalId = "externalId";
+    private ZonedDateTime eventDate = ZonedDateTime.parse("2018-03-12T16:25:01.123456Z");
+    private String gatewayAccountId = "gateway_account_id";
+    private String gatewayTransactionId = "validGatewayTransactionId";
+
+    @Pact(provider = "connector", consumer = "ledger")
+    public MessagePact createCancelledByUserEventPact(MessagePactBuilder builder) {
+        QueuePaymentEventFixture canceledByUserEventFixture = QueuePaymentEventFixture.aQueuePaymentEventFixture()
+                .withResourceExternalId(externalId)
+                .withEventDate(eventDate)
+                .withGatewayAccountId(gatewayAccountId)
+                .withEventType(SalientEventType.CANCELLED_BY_USER.toString())
+                .withDefaultEventDataForEventType(SalientEventType.CANCELLED_BY_USER.toString());
+
+        Map<String, String> metadata = new HashMap<>();
+        metadata.put("contentType", "application/json");
+
+        return builder
+                .expectsToReceive("a cancelled by user message")
+                .withContent(canceledByUserEventFixture.getAsPact())
+                .toPact();
+    }
+
+    @Test
+    @PactVerification({"connector"})
+    public void test() {
+        appRule.getSqsClient().sendMessage(SqsTestDocker.getQueueUrl("event-queue"), new String(currentMessage));
+
+        TransactionDao transactionDao = new TransactionDao(appRule.getJdbi());
+
+        await().atMost(1, TimeUnit.SECONDS).until(
+                () -> transactionDao.findTransactionByExternalId(externalId).isPresent()
+        );
+
+        Optional<TransactionEntity> transaction = transactionDao.findTransactionByExternalId(externalId);
+        assertThat(transaction.isPresent(), is(true));
+        assertThat(transaction.get().getExternalId(), is(externalId));
+        Map<String, String> transactionDetails = gson.fromJson(transaction.get().getTransactionDetails(), Map.class);
+        assertThat(transactionDetails.get("gateway_transaction_id"), is(gatewayTransactionId));
+    }
+
+    public void setMessage(byte[] messageContents) {
+        currentMessage = messageContents;
+    }
+}

--- a/src/test/java/uk/gov/pay/ledger/pact/ConsumerContractTestSuite.java
+++ b/src/test/java/uk/gov/pay/ledger/pact/ConsumerContractTestSuite.java
@@ -23,6 +23,7 @@ public class ConsumerContractTestSuite {
         consumerToJUnitTest.put("connector", new JUnit4TestAdapter(PayoutCreatedEventQueueContractTest.class));
         consumerToJUnitTest.put("connector", new JUnit4TestAdapter(PaymentIncludedInPayoutEventQueueContractTest.class));
         consumerToJUnitTest.put("connector", new JUnit4TestAdapter(RefundIncludedInPayoutEventQueueContractTest.class));
+        consumerToJUnitTest.put("connector", new JUnit4TestAdapter(CancelledByUserEventQueueContractTest.class));
         return CreateTestSuite.create(consumerToJUnitTest.build());
     }
 

--- a/src/test/java/uk/gov/pay/ledger/util/fixture/QueuePaymentEventFixture.java
+++ b/src/test/java/uk/gov/pay/ledger/util/fixture/QueuePaymentEventFixture.java
@@ -175,6 +175,9 @@ public class QueuePaymentEventFixture implements QueueFixture<QueuePaymentEventF
                             .put("gateway_transaction_id", "providerId")
                             .build());
                 break;
+            case "CANCELLED_BY_USER":
+                eventData = gsonBuilder.create().toJson(Map.of("gateway_transaction_id", "validGatewayTransactionId"));
+                break;
             default:
                 eventData = gsonBuilder.create().toJson(Map.of("event_data", "event_data"));
         }


### PR DESCRIPTION
## WHAT
- the structure of the CANCELLED_BY_USER event has changed and now it contains event data (gateway transaction id). This change adds a consumer pact test for the refactored event.