### PR TITLE
PP-6989 Map `cancel by external service failed` salient event to transaction state

### DIFF
--- a/src/main/java/uk/gov/pay/ledger/transaction/state/TransactionState.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/state/TransactionState.java
@@ -103,6 +103,7 @@ public enum TransactionState {
                     Map.entry(SalientEventType.CANCEL_BY_EXPIRATION_FAILED, FAILED_EXPIRED),
                     Map.entry(SalientEventType.CANCELLED_BY_EXPIRATION, FAILED_EXPIRED),
                     Map.entry(SalientEventType.CANCEL_BY_EXTERNAL_SERVICE_SUBMITTED, CANCELLED),
+                    Map.entry(SalientEventType.CANCEL_BY_EXTERNAL_SERVICE_FAILED, CANCELLED),
                     Map.entry(SalientEventType.CANCELLED_BY_EXTERNAL_SERVICE, CANCELLED),
                     Map.entry(SalientEventType.CANCEL_BY_USER_SUBMITTED, FAILED_CANCELLED),
                     Map.entry(SalientEventType.CANCEL_BY_USER_FAILED, FAILED_CANCELLED),

--- a/src/test/java/uk/gov/pay/ledger/report/resource/PerformanceReportResourceIT.java
+++ b/src/test/java/uk/gov/pay/ledger/report/resource/PerformanceReportResourceIT.java
@@ -25,6 +25,7 @@ import static uk.gov.pay.ledger.util.fixture.TransactionFixture.aTransactionFixt
 
 public class PerformanceReportResourceIT {
 
+    @RegisterExtension
     public static AppWithPostgresAndSqsExtension rule = new AppWithPostgresAndSqsExtension();
 
     private Integer port = rule.getAppRule().getLocalPort();


### PR DESCRIPTION
## WHAT
- Maps salient event `CANCEL_BY_EXTERNAL_SERVICE_FAILED` to transaction state `CANCELLED`