### PR TITLE
PP-7609 - Rename externalId so that it is 26 characters

### DIFF
--- a/src/test/java/uk/gov/pay/ledger/pact/Gateway3dsExemptionResultObtainedEventQueueContractTest.java
+++ b/src/test/java/uk/gov/pay/ledger/pact/Gateway3dsExemptionResultObtainedEventQueueContractTest.java
@@ -36,7 +36,7 @@ public class Gateway3dsExemptionResultObtainedEventQueueContractTest {
     );
 
     private byte[] currentMessage;
-    private String externalId = "gateway3dsExemptionResultObtained_externalId";
+    private String externalId = "exemptionResult_externalId";
     private ZonedDateTime eventDate = ZonedDateTime.parse("2018-03-12T16:25:01.123456Z");
 
     @Pact(provider = "connector", consumer = "ledger")


### PR DESCRIPTION
Description:
- This PR renames the externalId in Gateway3dsExemptionResultObtainedEventQueueContractTest to exemptionResult_externalId so that it is 26 characters. The previous version was 44 characters which caused a PSQLException when the Pact test was run