### PR TITLE
PP-7696 Temporarily disable database source enum test

### DIFF
--- a/src/test/java/uk/gov/pay/ledger/transaction/dao/TransactionDaoIT.java
+++ b/src/test/java/uk/gov/pay/ledger/transaction/dao/TransactionDaoIT.java
@@ -1,6 +1,7 @@
 package uk.gov.pay.ledger.transaction.dao;
 
 import com.google.common.collect.ImmutableMap;
+import org.junit.Ignore;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import uk.gov.pay.commons.model.Source;
@@ -391,6 +392,7 @@ public class TransactionDaoIT {
     }
 
     @Test
+    @Ignore
     public void sourceTypeInDatabase_shouldMatchValuesInEnum() {
         var sourceArray = Arrays.stream(Source.values()).map(Enum::toString).collect(Collectors.toList());
         transactionDao.getSourceTypeValues().forEach(x -> assertThat(sourceArray.contains(x), is(true)));


### PR DESCRIPTION
Temporarily disable `TransactionDaoIT.sourceTypeInDatabase_shouldMatchValuesInEnum`, which checks that the values of the `source` enum in the database match those of the `Source` enum in the Java code.

We’re adding a new `CARD_AGENT_INITIATED_MOTO` value and since our database migrations are decoupled from our code changes, we can’t update both ledger’s database and the imported enum atomically.

So we’re going to have to disable the test, migrate the database, update the Java enum, then re-enable the test.