### PR TITLE
PP-7696 Add CARD_AGENT_INITIATED_MOTO to source database enum

### DIFF
--- a/src/main/resources/migrations/00054_add_CARD_AGENT_INITIATED_MOTO_source.sql
+++ b/src/main/resources/migrations/00054_add_CARD_AGENT_INITIATED_MOTO_source.sql
@@ -1,0 +1,4 @@
+--liquibase formatted sql
+
+--changeset uk.gov.pay:add_CARD_AGENT_INITIATED_MOTO_source runInTransaction:false
+ALTER TYPE source ADD VALUE 'CARD_AGENT_INITIATED_MOTO' BEFORE 'CARD_EXTERNAL_TELEPHONE';


### PR DESCRIPTION
Add `CARD_AGENT_INITIATED_MOTO` to the `source` enum in the database, inserting it before `CARD_EXTERNAL_TELEPHONE`.