### PR TITLE
PP-7832 add unique constraint on transaction_metadata table

### DIFF
--- a/src/main/resources/migrations/00057_make_transaction_id_and_metadata_key_id_unique_combo.sql
+++ b/src/main/resources/migrations/00057_make_transaction_id_and_metadata_key_id_unique_combo.sql
@@ -1,0 +1,5 @@
+--liquibase formatted sql
+
+--changeset uk.gov.pay:add_unique_constraint_on_transaction_id_and_metadata_key_id
+
+ALTER TABLE transaction_metadata ADD CONSTRAINT transaction_id_and_metadata_key_id_key UNIQUE (transaction_id, metadata_key_id);


### PR DESCRIPTION
## WHAT
- to be able to create an upsert sql command on transaction_metadata table we need to use `ON CONFLICT`. `ON CONFLICT` will be only triggered if transaction_id and metadata_key_id are a unique combination.