### PR TITLE
PP-7833 Metadata keys for search transactions by metadata value

### DIFF
--- a/src/main/java/uk/gov/pay/ledger/metadatakey/dao/MetadataKeyDao.java
+++ b/src/main/java/uk/gov/pay/ledger/metadatakey/dao/MetadataKeyDao.java
@@ -1,9 +1,7 @@
 package uk.gov.pay.ledger.metadatakey.dao;
 
-
 import org.jdbi.v3.sqlobject.customizer.Bind;
 import org.jdbi.v3.sqlobject.statement.GetGeneratedKeys;
-import org.jdbi.v3.sqlobject.statement.SqlQuery;
 import org.jdbi.v3.sqlobject.statement.SqlUpdate;
 
 import java.util.Optional;

--- a/src/main/java/uk/gov/pay/ledger/transaction/search/common/TransactionSearchParams.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/search/common/TransactionSearchParams.java
@@ -7,9 +7,7 @@ import uk.gov.pay.ledger.util.CommaDelimitedSetParameter;
 
 import javax.ws.rs.DefaultValue;
 import javax.ws.rs.QueryParam;
-import java.time.LocalDate;
 import java.time.ZonedDateTime;
-import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -18,7 +16,6 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
-import static java.time.ZoneOffset.UTC;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import static uk.gov.pay.commons.validation.DateTimeUtils.fromLocalDateOnlyString;
 
@@ -44,8 +41,7 @@ public class TransactionSearchParams extends SearchParams {
     private static final long DEFAULT_PAGE_NUMBER = 1L;
     private static final long DEFAULT_MAX_DISPLAY_SIZE = 500L;
     private static final Long DEFAULT_LIMIT_TOTAL_SIZE = 10000L;
-
-    private static final DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+    private static final String METADATA_VALUE = "metadata_value";
 
     private long maxDisplaySize = DEFAULT_MAX_DISPLAY_SIZE;
 
@@ -86,6 +82,8 @@ public class TransactionSearchParams extends SearchParams {
     private String fromSettledDate;
     @QueryParam("to_settled_date")
     private String toSettledDate;
+    @QueryParam("metadata_value")
+    private String metadataValue;
     private Long pageNumber = 1L;
 
     @DefaultValue("500")
@@ -169,6 +167,10 @@ public class TransactionSearchParams extends SearchParams {
 
     public void setToSettledDate(String toSettledDate) {
         this.toSettledDate = toSettledDate;
+    }
+
+    public void setMetadataValue(String metadataValue) {
+        this.metadataValue = metadataValue;
     }
 
     @QueryParam("page")
@@ -320,6 +322,9 @@ public class TransactionSearchParams extends SearchParams {
             if (isNotBlank(toSettledDate)) {
                 queryMap.put(TO_SETTLED_DATE_FIELD, parseToSettledDate());
             }
+            if (isNotBlank(metadataValue)) {
+                queryMap.put(METADATA_VALUE, metadataValue);
+            }
         }
         return queryMap;
     }
@@ -384,6 +389,10 @@ public class TransactionSearchParams extends SearchParams {
         return toSettledDate;
     }
 
+    public String getMetadataValue() {
+        return metadataValue;
+    }
+
     @Override
     public String buildQueryParamString(Long forPage) {
         List<String> queries = new ArrayList<>();
@@ -436,6 +445,9 @@ public class TransactionSearchParams extends SearchParams {
         }
         if (isNotBlank(toSettledDate)) {
             queries.add(TO_SETTLED_DATE_FIELD + "=" + toSettledDate);
+        }
+        if (isNotBlank(metadataValue)) {
+            queries.add(METADATA_VALUE + "=" + metadataValue);
         }
         queries.add("page=" + forPage);
         queries.add("display_size=" + getDisplaySize());

--- a/src/test/java/uk/gov/pay/ledger/metadatakey/dao/MetadataKeyDaoIT.java
+++ b/src/test/java/uk/gov/pay/ledger/metadatakey/dao/MetadataKeyDaoIT.java
@@ -1,9 +1,7 @@
 package uk.gov.pay.ledger.metadatakey.dao;
 
-import io.dropwizard.testing.junit5.DropwizardExtensionsSupport;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import uk.gov.pay.ledger.extension.AppWithPostgresAndSqsExtension;
 import uk.gov.pay.ledger.util.DatabaseTestHelper;
@@ -15,7 +13,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static uk.gov.pay.ledger.util.DatabaseTestHelper.aDatabaseTestHelper;
 
-public class TransactionMetadataKeyDaoIT {
+public class MetadataKeyDaoIT {
 
     @RegisterExtension
     public static AppWithPostgresAndSqsExtension rule = new AppWithPostgresAndSqsExtension();

--- a/src/test/java/uk/gov/pay/ledger/transactionmetadata/dao/TransactionMetadataDaoIT.java
+++ b/src/test/java/uk/gov/pay/ledger/transactionmetadata/dao/TransactionMetadataDaoIT.java
@@ -1,11 +1,9 @@
 package uk.gov.pay.ledger.transactionmetadata.dao;
 
 import com.google.common.collect.ImmutableMap;
-import io.dropwizard.testing.junit5.DropwizardExtensionsSupport;
 import org.hamcrest.MatcherAssert;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import uk.gov.pay.ledger.extension.AppWithPostgresAndSqsExtension;
 import uk.gov.pay.ledger.metadatakey.dao.MetadataKeyDao;
@@ -19,12 +17,14 @@ import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Map;
 
+import static org.apache.commons.lang3.RandomStringUtils.randomAlphanumeric;
 import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static uk.gov.pay.ledger.util.DatabaseTestHelper.aDatabaseTestHelper;
 import static uk.gov.pay.ledger.util.fixture.TransactionFixture.aTransactionFixture;
+import static uk.gov.pay.ledger.util.fixture.TransactionMetadataFixture.aTransactionMetadataFixture;
 
 public class TransactionMetadataDaoIT {
 
@@ -76,37 +76,14 @@ public class TransactionMetadataDaoIT {
 
     @Test
     public void shouldReturnCorrectMetadataKeysForTransactionSearch() {
-        TransactionEntity transaction1 = aTransactionFixture()
-                .withState(TransactionState.CREATED)
-                .withTransactionType("PAYMENT")
-                .withExternalMetadata(ImmutableMap.of("test-key-1", "value1"))
-                .withDefaultCardDetails()
-                .withFirstDigitsCardNumber("123456")
-                .withLastDigitsCardNumber("1234")
-                .withDefaultTransactionDetails()
-                .insert(rule.getJdbi())
-                .toEntity();
-
-        TransactionEntity transaction2 = aTransactionFixture()
-                .withState(TransactionState.SUBMITTED)
-                .withReference(transaction1.getReference())
-                .withGatewayAccountId(transaction1.getGatewayAccountId())
-                .withExternalMetadata(ImmutableMap.of("test-key-2", "value1"))
-                .withDefaultCardDetails()
-                .withFirstDigitsCardNumber("123456")
-                .withLastDigitsCardNumber("1234")
-                .withDefaultTransactionDetails()
-                .insert(rule.getJdbi())
-                .toEntity();
-
-        TransactionEntity transactionToBeExcluded = aTransactionFixture()
-                .withState(TransactionState.SUBMITTED)
-                .withCreatedDate(ZonedDateTime.now().plusDays(3))
-                .withGatewayAccountId(transaction1.getGatewayAccountId())
-                .withExternalMetadata(ImmutableMap.of("test-key-3", "value1"))
-                .withDefaultTransactionDetails()
-                .insert(rule.getJdbi())
-                .toEntity();
+        String gatewayAccountId = randomAlphanumeric(15);
+        String reference = randomAlphanumeric(15);
+        TransactionEntity transaction1 = insertTransaction(gatewayAccountId, reference,
+                ImmutableMap.of("test-key-1", "value1"));
+        TransactionEntity transaction2 = insertTransaction(gatewayAccountId, reference,
+                ImmutableMap.of("test-key-2", "value1"));
+        TransactionEntity transactionToBeExcluded = insertTransaction(gatewayAccountId, "ref123",
+                ImmutableMap.of("test-key-3", "value1"));
 
         metadataKeyDao.insertIfNotExist("test-key-1");
         metadataKeyDao.insertIfNotExist("test-key-2");
@@ -130,5 +107,70 @@ public class TransactionMetadataDaoIT {
 
         assertThat(transactionEntityList, hasItem("test-key-1"));
         assertThat(transactionEntityList, hasItem("test-key-2"));
+    }
+
+    @Test
+    public void shouldReturnCorrectMetadataKeysWhenTransactionsAreSearchedByMetadataValue() {
+        String gatewayAccountId = randomAlphanumeric(15);
+        String reference = randomAlphanumeric(15);
+        TransactionEntity transaction1 = insertTransaction(gatewayAccountId, reference,
+                ImmutableMap.of("test-key-1", "value1", "test-key-2", "value2"));
+        TransactionEntity transaction2 = insertTransaction(gatewayAccountId, reference,
+                ImmutableMap.of("test-key-n", "value1"));
+        TransactionEntity transactionToBeExcluded = insertTransaction(gatewayAccountId, "ref123",
+                ImmutableMap.of("test-key-3", "value3"));
+
+        metadataKeyDao.insertIfNotExist("test-key-1");
+        metadataKeyDao.insertIfNotExist("test-key-2");
+        metadataKeyDao.insertIfNotExist("test-key-3");
+        metadataKeyDao.insertIfNotExist("test-key-n");
+
+        //todo: replace with transactionMetadataDao.insertIfNotExist() when this supports inserting 'value'
+        aTransactionMetadataFixture().withTransactionId(transaction1.getId())
+                .withMetadataKey("test-key-1").withValue("value1").insert(rule.getJdbi());
+        aTransactionMetadataFixture().withTransactionId(transaction1.getId())
+                .withMetadataKey("test-key-2").withValue("value3").insert(rule.getJdbi());
+        aTransactionMetadataFixture().withTransactionId(transaction2.getId())
+                .withMetadataKey("test-key-n").withValue("value1").insert(rule.getJdbi());
+        aTransactionMetadataFixture().withTransactionId(transactionToBeExcluded.getId())
+                .withMetadataKey("test-key-3").withValue("value3").insert(rule.getJdbi());
+
+        searchParams.setAccountIds(List.of(transaction1.getGatewayAccountId()));
+        searchParams.setFromDate(ZonedDateTime.now().minusDays(10).toString());
+        searchParams.setToDate(ZonedDateTime.now().plusDays(1).toString());
+        searchParams.setFirstDigitsCardNumber(transaction1.getFirstDigitsCardNumber());
+        searchParams.setLastDigitsCardNumber(transaction1.getLastDigitsCardNumber());
+        searchParams.setCardHolderName(transaction1.getCardholderName());
+        searchParams.setReference(transaction1.getReference());
+        searchParams.setEmail(transaction1.getEmail());
+
+        searchParams.setMetadataValue("value1");
+
+        List<String> transactionEntityList =
+                transactionMetadataDao.findMetadataKeysForTransactions(searchParams);
+
+        MatcherAssert.assertThat(transactionEntityList.size(), is(3));
+
+        assertThat(transactionEntityList, hasItem("test-key-1"));
+        assertThat(transactionEntityList, hasItem("test-key-n"));
+
+        // value for this metadata key is 'value2' but key expected in the list (for CSV).
+        // This is because corresponding transaction has matching metadata value on another key 'test-key-1'.
+        assertThat(transactionEntityList, hasItem("test-key-2"));
+    }
+
+    private TransactionEntity insertTransaction(String gatewayAccountId, String reference, Map<String, Object> externalMetadata) {
+        return aTransactionFixture()
+                .withState(TransactionState.CREATED)
+                .withTransactionType("PAYMENT")
+                .withGatewayAccountId(gatewayAccountId)
+                .withReference(reference)
+                .withExternalMetadata(externalMetadata)
+                .withDefaultCardDetails()
+                .withFirstDigitsCardNumber("123456")
+                .withLastDigitsCardNumber("1234")
+                .withDefaultTransactionDetails()
+                .insert(rule.getJdbi())
+                .toEntity();
     }
 }

--- a/src/test/java/uk/gov/pay/ledger/util/fixture/TransactionMetadataFixture.java
+++ b/src/test/java/uk/gov/pay/ledger/util/fixture/TransactionMetadataFixture.java
@@ -1,0 +1,47 @@
+package uk.gov.pay.ledger.util.fixture;
+
+import org.jdbi.v3.core.Jdbi;
+
+public class TransactionMetadataFixture {
+
+    private long transactionId;
+    private String metadataKey;
+    private String value;
+
+    public static TransactionMetadataFixture aTransactionMetadataFixture() {
+        return new TransactionMetadataFixture();
+    }
+
+    public TransactionMetadataFixture insert(Jdbi jdbi) {
+        jdbi.withHandle(h ->
+                h.execute(
+                        "INSERT INTO" +
+                                "    transaction_metadata(" +
+                                "        transaction_id," +
+                                "        metadata_key_id," +
+                                "        value" +
+                                "    )" +
+                                "VALUES(?, (select id from metadata_key where key = ?), ?)",
+                        transactionId,
+                        metadataKey,
+                        value
+                )
+        );
+        return this;
+    }
+
+    public TransactionMetadataFixture withTransactionId(long transactionId) {
+        this.transactionId = transactionId;
+        return this;
+    }
+
+    public TransactionMetadataFixture withMetadataKey(String metadataKey) {
+        this.metadataKey = metadataKey;
+        return this;
+    }
+
+    public TransactionMetadataFixture withValue(String value) {
+        this.value = value;
+        return this;
+    }
+}


### PR DESCRIPTION
## WHAT 
- Changes to find metadata keys for transactions searched by metadata value.
- Currently all metadata keys are returned for matching transactions (based on search criteria). transaction table is joined with transaction_metadata to find all keys.
- When transactions are searched by metadata value, all metadata keys are returned for transactions for which atleast one metadata value matches. For this, first find transactions for metadata value and then find all keys for these transactions.

- Rename `TransactionMetadataKeyDaoIT` to `MetadataKeyDaoIT` as this dao is for operations on metadata_key table only.