### PR TITLE
PP-7833 Search transactions by metadata_value

### DIFF
--- a/src/main/java/uk/gov/pay/ledger/transaction/search/common/TransactionSearchParams.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/search/common/TransactionSearchParams.java
@@ -227,6 +227,9 @@ public class TransactionSearchParams extends SearchParams {
         if (isNotBlank(toSettledDate)) {
             filters.add(" po.paid_out_date < :" + TO_SETTLED_DATE_FIELD);
         }
+        if (isNotBlank(metadataValue)) {
+            filters.add(" lower(tm.value) = lower(:" + METADATA_VALUE + ")");
+        }
 
         return List.copyOf(filters);
     }

--- a/src/main/java/uk/gov/pay/ledger/transactionmetadata/dao/TransactionMetadataDao.java
+++ b/src/main/java/uk/gov/pay/ledger/transactionmetadata/dao/TransactionMetadataDao.java
@@ -19,13 +19,13 @@ public class TransactionMetadataDao {
             "  AND transaction_details??'external_metadata'" +
             " :searchExtraFields ";
 
-    private static final String FIND_METADATA_KEYS_FOR_TX_SEARCH_INCLUDING_METADATA_VALUE = "SELECT distinct mk.key from metadata_key mk, transaction_metadata tm " +
-            " WHERE tm.metadata_key_id = mk.id" +
-            "  AND tm.transaction_id in " +
-            "        (SELECT tm2.transaction_id " +
-            "           FROM transaction t, transaction_metadata tm2 " +
-            "          WHERE tm2.transaction_id = t.id " +
-            "          AND lower(tm2.value) = :metadata_value" +
+    private static final String FIND_METADATA_KEYS_FOR_TX_SEARCH_INCLUDING_METADATA_VALUE = "SELECT distinct mk.key from metadata_key mk, transaction_metadata tm2 " +
+            " WHERE tm2.metadata_key_id = mk.id" +
+            "  AND tm2.transaction_id in " +
+            "        (SELECT tm.transaction_id " +
+            "           FROM transaction t, transaction_metadata tm " +
+            "          WHERE tm.transaction_id = t.id " +
+            "          AND lower(tm.value) = lower(:metadata_value)" +
             "          :searchExtraFields)";
 
     private static final String INSERT_STRING = "INSERT INTO transaction_metadata(transaction_id, metadata_key_id) " +

--- a/src/test/java/uk/gov/pay/ledger/transaction/dao/TransactionDaoIT.java
+++ b/src/test/java/uk/gov/pay/ledger/transaction/dao/TransactionDaoIT.java
@@ -1,8 +1,6 @@
 package uk.gov.pay.ledger.transaction.dao;
 
 import com.google.common.collect.ImmutableMap;
-import org.junit.Ignore;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import uk.gov.pay.commons.model.Source;

--- a/src/test/java/uk/gov/pay/ledger/transactionmetadata/dao/TransactionMetadataDaoIT.java
+++ b/src/test/java/uk/gov/pay/ledger/transactionmetadata/dao/TransactionMetadataDaoIT.java
@@ -131,7 +131,7 @@ public class TransactionMetadataDaoIT {
         aTransactionMetadataFixture().withTransactionId(transaction1.getId())
                 .withMetadataKey("test-key-2").withValue("value3").insert(rule.getJdbi());
         aTransactionMetadataFixture().withTransactionId(transaction2.getId())
-                .withMetadataKey("test-key-n").withValue("value1").insert(rule.getJdbi());
+                .withMetadataKey("test-key-n").withValue("VALUE1").insert(rule.getJdbi());
         aTransactionMetadataFixture().withTransactionId(transactionToBeExcluded.getId())
                 .withMetadataKey("test-key-3").withValue("value3").insert(rule.getJdbi());
 

--- a/src/test/java/uk/gov/pay/ledger/util/fixture/MetadataKeyFixture.java
+++ b/src/test/java/uk/gov/pay/ledger/util/fixture/MetadataKeyFixture.java
@@ -1,0 +1,22 @@
+package uk.gov.pay.ledger.util.fixture;
+
+import org.jdbi.v3.core.Jdbi;
+
+public class MetadataKeyFixture {
+
+    public static void insertMedataKeyIfNotExists(Jdbi jdbi, String metadataKey) {
+        jdbi.withHandle(h ->
+                h.execute(
+                        "INSERT INTO metadata_key(key) " +
+                                "SELECT ? " +
+                                "WHERE NOT EXISTS ( " +
+                                "    SELECT 1 " +
+                                "    FROM metadata_key " +
+                                "    WHERE key = ? )"
+                        ,
+                        metadataKey,
+                        metadataKey
+                )
+        );
+    }
+}


### PR DESCRIPTION
- Added functionality to search transacions by metadata_value
- transaction_metadata is joined with transaction (when searching by metadata_value). This can return multiple rows for a transaction as metadata `value` is not unique. To avoid duplicates `distinct` clause is added to the queries when searching by metadata_value.
- Based on query plan for two options, joining transaction_metadata and getting distinct result is performant as indexes `transaction_metadata_lower_value_idx & transaction_pkey` are used first and the results are filtered by other search criteria
- Where as using IN clause could first use indexes on transaction table and could slow the query

## Plans based on performance env data

#### Inner join transaction_metadata and distinct
```
explain analyse select
	distinct t.*,
	po.paid_out_date as paid_out_date
from
	transaction t
inner join transaction_metadata tm on
	t.id = tm.transaction_id
left outer join payout po on
	t.gateway_payout_id = po.gateway_payout_id
where
    t.gateway_account_id = '38'
	and lower(t.reference) like lower('%75100000001872%')
	and lower(tm.value) = lower('b9125c088e28e89363ba3d69310b633c')
order by
	t.created_date desc offset 0 limit 500

QUERY PLAN                                                                                                                                                                                                                                                     |
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
Limit  (cost=24.98..25.06 rows=1 width=1333) (actual time=0.049..0.050 rows=1 loops=1)                                                                                                                                                                         |
  ->  Unique  (cost=24.98..25.06 rows=1 width=1333) (actual time=0.048..0.048 rows=1 loops=1)                                                                                                                                                                  |
        ->  Sort  (cost=24.98..24.98 rows=1 width=1333) (actual time=0.048..0.048 rows=1 loops=1)                                                                                                                                                              |
              Sort Key: t.created_date DESC, t.id, t.external_id, t.amount, t.reference, t.description, t.state, t.email, t.cardholder_name, t.transaction_details, t.event_count, t.card_brand, t.last_digits_card_number, t.first_digits_card_number, t.net_a|
              Sort Method: quicksort  Memory: 27kB                                                                                                                                                                                                             |
              ->  Nested Loop Left Join  (cost=1.01..24.97 rows=1 width=1333) (actual time=0.031..0.033 rows=1 loops=1)                                                                                                                                        |
                    ->  Nested Loop  (cost=0.86..18.24 rows=1 width=1325) (actual time=0.029..0.030 rows=1 loops=1)                                                                                                                                            |
                          ->  Index Scan using transaction_metadata_lower_value_idx on transaction_metadata tm  (cost=0.43..8.45 rows=1 width=8) (actual time=0.016..0.016 rows=1 loops=1)                                                                     |
                                Index Cond: (lower((value)::text) = 'b9125c088e28e89363ba3d69310b633c'::text)                                                                                                                                                  |
                          ->  Index Scan using transaction_pkey on transaction t  (cost=0.43..8.46 rows=1 width=1325) (actual time=0.011..0.011 rows=1 loops=1)                                                                                                |
                                Index Cond: (id = tm.transaction_id)                                                                                                                                                                                           |
                                Filter: (((gateway_account_id)::text = '38'::text) AND (lower((reference)::text) ~~ '%75100000001872%'::text))                                                                                                                 |
                    ->  Index Scan using gateway_payout_id_unique on payout po  (cost=0.14..3.43 rows=1 width=126) (actual time=0.001..0.001 rows=0 loops=1)                                                                                                   |
                          Index Cond: ((t.gateway_payout_id)::text = (gateway_payout_id)::text)                                                                                                                                                                |
Planning Time: 0.518 ms                                                                                                                                                                                                                                        |
Execution Time: 0.106 ms
```

### IN clause to find transactions

```
explain analyse select
	t.*,
	po.paid_out_date as paid_out_date
from
	transaction t
left outer join payout po on
	t.gateway_payout_id = po.gateway_payout_id
where
	t.gateway_account_id = '38'
	and lower(t.reference) like lower('%751000000018%')
	and t.id in (
	select
		transaction_id
	from
		transaction_metadata tm, transaction t
	where
		lower(tm.value)= lower('b9125c088e28e89363ba3d69310b633c')
		and t.gateway_account_id = '38'
		and lower(t.reference) like lower('%751000000018%')
		and lower(tm.value) = lower('b9125c088e28e89363ba3d69310b633c')
	order by
		t.created_date desc offset 0
	limit 500)

QUERY PLAN                                                                                                                                                                                      |
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
Nested Loop Left Join  (cost=5657.54..5674.08 rows=1 width=1333) (actual time=9.585..9.585 rows=1 loops=1)                                                                                      |
  ->  Nested Loop  (cost=5657.40..5673.90 rows=1 width=1325) (actual time=9.580..9.581 rows=1 loops=1)                                                                                          |
        ->  HashAggregate  (cost=5656.96..5656.98 rows=2 width=8) (actual time=9.554..9.554 rows=1 loops=1)                                                                                     |
              Group Key: tm.transaction_id                                                                                                                                                      |
              ->  Limit  (cost=5656.80..5656.82 rows=11 width=16) (actual time=9.550..9.551 rows=1 loops=1)                                                                                     |
                    ->  Sort  (cost=5656.80..5656.82 rows=11 width=16) (actual time=9.549..9.549 rows=1 loops=1)                                                                                |
                          Sort Key: t_1.created_date DESC                                                                                                                                       |
                          Sort Method: quicksort  Memory: 25kB                                                                                                                                  |
                          ->  Nested Loop  (cost=3396.70..5656.60 rows=11 width=16) (actual time=9.540..9.543 rows=1 loops=1)                                                                   |
                                ->  Index Scan using transaction_metadata_lower_value_idx on transaction_metadata tm  (cost=0.43..8.45 rows=1 width=8) (actual time=0.020..0.022 rows=1 loops=1)|
                                      Index Cond: (lower((value)::text) = 'b9125c088e28e89363ba3d69310b633c'::text)                                                                             |
                                ->  Bitmap Heap Scan on transaction t_1  (cost=3396.27..5648.05 rows=11 width=8) (actual time=9.517..9.518 rows=1 loops=1)                                      |
                                      Recheck Cond: (lower((reference)::text) ~~ '%75100000001872%'::text)                                                                                      |
                                      Filter: ((gateway_account_id)::text = '38'::text)                                                                                                         |
                                      Heap Blocks: exact=1                                                                                                                                      |
                                      ->  Bitmap Index Scan on transaction_reference_gin_idx  (cost=0.00..3396.27 rows=569 width=0) (actual time=9.504..9.504 rows=1 loops=1)                   |
                                            Index Cond: (lower((reference)::text) ~~ '%75100000001872%'::text)                                                                                  |
        ->  Index Scan using transaction_pkey on transaction t  (cost=0.43..8.46 rows=1 width=1325) (actual time=0.022..0.022 rows=1 loops=1)                                                   |
              Index Cond: (id = tm.transaction_id)                                                                                                                                              |
              Filter: (((gateway_account_id)::text = '38'::text) AND (lower((reference)::text) ~~ '%%'::text))                                                                                  |
  ->  Index Scan using gateway_payout_id_unique on payout po  (cost=0.14..0.16 rows=1 width=126) (actual time=0.001..0.001 rows=0 loops=1)                                                      |
        Index Cond: ((t.gateway_payout_id)::text = (gateway_payout_id)::text)                                                                                                                   |
Planning Time: 0.487 ms                                                                                                                                                                         |
Execution Time: 9.648 ms
```