### PR TITLE
PP-7832 refactor TransactionMetadataService to use EventDigest for upsert

### DIFF
--- a/src/main/java/uk/gov/pay/ledger/queue/eventprocessor/PaymentEventProcessor.java
+++ b/src/main/java/uk/gov/pay/ledger/queue/eventprocessor/PaymentEventProcessor.java
@@ -37,7 +37,7 @@ public class PaymentEventProcessor extends EventProcessor {
         EventDigest paymentEventDigest = EventDigest.fromEventList(events);
 
         transactionService.upsertTransactionFor(paymentEventDigest);
-        transactionMetadataService.upsertMetadataFor(event);
+        transactionMetadataService.upsertMetadataFor(paymentEventDigest);
 
         /**
          * If the payment has associated refunds, we want to update the payment details that we also store on refunds to

--- a/src/test/java/uk/gov/pay/ledger/queue/EventDigestHandlerTest.java
+++ b/src/test/java/uk/gov/pay/ledger/queue/EventDigestHandlerTest.java
@@ -79,7 +79,7 @@ public class EventDigestHandlerTest {
         eventDigestHandler.processEvent(event);
 
         verify(transactionService).upsertTransactionFor(any(EventDigest.class));
-        verify(transactionMetadataService).upsertMetadataFor(event);
+        verify(transactionMetadataService).upsertMetadataFor(any(EventDigest.class));
     }
 
     @Test
@@ -110,7 +110,7 @@ public class EventDigestHandlerTest {
         assertThrows(RuntimeException.class, () -> eventDigestHandler.processEvent(event));
 
         verify(transactionService, never()).upsertTransactionFor(any());
-        verify(transactionMetadataService, never()).upsertMetadataFor(any());
+        verify(transactionMetadataService, never()).upsertMetadataFor(any(EventDigest.class));
         verify(payoutService, never()).upsertPayoutFor(any());
 
         verify(mockAppender, times(1)).doAppend(loggingEventArgumentCaptor.capture());

--- a/src/test/java/uk/gov/pay/ledger/queue/eventprocessor/PaymentEventProcessorTest.java
+++ b/src/test/java/uk/gov/pay/ledger/queue/eventprocessor/PaymentEventProcessorTest.java
@@ -64,7 +64,7 @@ class PaymentEventProcessorTest {
         paymentEventProcessor.process(event);
 
         verify(transactionService).upsertTransactionFor(any(EventDigest.class));
-        verify(transactionMetadataService).upsertMetadataFor(event);
+        verify(transactionMetadataService).upsertMetadataFor(any(EventDigest.class));
         verify(refundEventProcessor).reprojectRefundTransaction(eq(refundTransaction1.getExternalId()), any(EventDigest.class));
         verify(refundEventProcessor).reprojectRefundTransaction(eq(refundTransaction2.getExternalId()), any(EventDigest.class));
     }
@@ -86,7 +86,7 @@ class PaymentEventProcessorTest {
 
         paymentEventProcessor.process(event);
         verify(transactionService).upsertTransactionFor(any(EventDigest.class));
-        verify(transactionMetadataService).upsertMetadataFor(event);
+        verify(transactionMetadataService).upsertMetadataFor(any(EventDigest.class));
         verify(transactionService, never()).getChildTransactions(any());
         verify(refundEventProcessor, never()).reprojectRefundTransaction(any(), any());
     }
@@ -108,7 +108,7 @@ class PaymentEventProcessorTest {
 
         paymentEventProcessor.process(event);
         verify(transactionService).upsertTransactionFor(any(EventDigest.class));
-        verify(transactionMetadataService).upsertMetadataFor(event);
+        verify(transactionMetadataService).upsertMetadataFor(any(EventDigest.class));
         verify(transactionService, never()).getChildTransactions(any());
         verify(refundEventProcessor, never()).reprojectRefundTransaction(any(), any());
     }

--- a/src/test/java/uk/gov/pay/ledger/transaction/service/TransactionMetadataServiceTest.java
+++ b/src/test/java/uk/gov/pay/ledger/transaction/service/TransactionMetadataServiceTest.java
@@ -1,11 +1,13 @@
 package uk.gov.pay.ledger.transaction.service;
 
+import com.google.gson.GsonBuilder;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.pay.commons.model.Source;
 import uk.gov.pay.ledger.event.model.Event;
+import uk.gov.pay.ledger.event.model.EventDigest;
 import uk.gov.pay.ledger.event.model.ResourceType;
 import uk.gov.pay.ledger.event.model.SalientEventType;
 import uk.gov.pay.ledger.metadatakey.dao.MetadataKeyDao;
@@ -14,13 +16,19 @@ import uk.gov.pay.ledger.transaction.entity.TransactionEntity;
 import uk.gov.pay.ledger.transaction.state.TransactionState;
 import uk.gov.pay.ledger.transactionmetadata.dao.TransactionMetadataDao;
 
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static uk.gov.pay.ledger.event.model.ResourceType.PAYMENT;
+import static uk.gov.pay.ledger.util.fixture.EventFixture.anEventFixture;
 import static uk.gov.pay.ledger.util.fixture.QueuePaymentEventFixture.aQueuePaymentEventFixture;
 import static uk.gov.pay.ledger.util.fixture.TransactionFixture.aTransactionFixture;
 
@@ -53,8 +61,9 @@ public class TransactionMetadataServiceTest {
                 .withMetadata("meta2", "data2")
                 .withDefaultEventDataForEventType(SalientEventType.PAYMENT_CREATED.name())
                 .toEntity();
+        EventDigest eventDigest = EventDigest.fromEventList(List.of(paymentCreatedEvent));
 
-        service.upsertMetadataFor(paymentCreatedEvent);
+        service.upsertMetadataFor(eventDigest);
 
         verify(mockMetadataKeyDao).insertIfNotExist("meta1");
         verify(mockMetadataKeyDao).insertIfNotExist("meta2");
@@ -76,9 +85,36 @@ public class TransactionMetadataServiceTest {
                 .withDefaultEventDataForEventType(SalientEventType.CAPTURE_SUBMITTED.name())
                 .toEntity();
 
-        service.upsertMetadataFor(paymentCreatedEvent);
+        EventDigest eventDigest = EventDigest.fromEventList(List.of(paymentCreatedEvent));
+
+        service.upsertMetadataFor(eventDigest);
 
         verify(mockMetadataKeyDao, never()).insertIfNotExist(anyString());
         verify(mockTransactionMetadataDao, never()).upsert(anyLong(), anyString(), anyString());
+    }
+
+    @Test
+    public void shouldUpsertValue() {
+        String externalId = "transaction-id";
+        TransactionEntity transaction = aTransactionFixture().withState(TransactionState.STARTED).toEntity();
+        service = new TransactionMetadataService(mockMetadataKeyDao, mockTransactionMetadataDao, mockTransactionDao);
+
+        Event event = anEventFixture().withResourceType(PAYMENT)
+                .withResourceExternalId(externalId)
+                .withEventType("ADMIN_MANUALLY_DID_AN_UPDATE")
+                .withEventData(new GsonBuilder().create()
+                        .toJson(Map.of("external_metadata", Map.of("key1", true))))
+                .toEntity();
+
+        Event previousEvent = anEventFixture().withResourceType(PAYMENT)
+                .withEventType("USER_APPROVED_FOR_CAPTURE")
+                .toEntity();
+        EventDigest paymentEventDigest = EventDigest.fromEventList(List.of(event, previousEvent));
+
+        when(mockTransactionDao.findTransactionByExternalId(externalId)).thenReturn(Optional.of(transaction));
+
+        service.upsertMetadataFor(paymentEventDigest);
+
+        verify(mockTransactionMetadataDao).upsert(any(), eq("key1"), eq("true"));
     }
 }


### PR DESCRIPTION
## WHAT

- refactor TransactionMetadataService to use EventDigest instead of Event for upserting transaction_metadata
- add/refactor relevant tests