### PR TITLE
PP-7832 Fix getting metadata values

### DIFF
--- a/src/main/java/uk/gov/pay/ledger/transaction/service/TransactionMetadataService.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/service/TransactionMetadataService.java
@@ -48,7 +48,7 @@ public class TransactionMetadataService {
                     .ifPresent(transactionEntity -> {
                         eventDataNode.get("external_metadata").fields().forEachRemaining(metadata -> {
                             metadataKeyDao.insertIfNotExist(metadata.getKey());
-                            String value = metadata.getValue().textValue();
+                            String value = metadata.getValue().asText();
                             transactionMetadataDao
                                     .upsert(transactionEntity.getId(), metadata.getKey(), value);
                         });

--- a/src/main/java/uk/gov/pay/ledger/transactionmetadata/dao/TransactionMetadataDao.java
+++ b/src/main/java/uk/gov/pay/ledger/transactionmetadata/dao/TransactionMetadataDao.java
@@ -28,19 +28,12 @@ public class TransactionMetadataDao {
             "          AND lower(tm.value) = lower(:metadata_value)" +
             "          :searchExtraFields)";
 
-    private static final String INSERT_STRING = "INSERT INTO transaction_metadata(transaction_id, metadata_key_id) " +
-            "SELECT :transactionId, (select id from metadata_key where key = :key) " +
-            "WHERE NOT EXISTS ( " +
-            "    SELECT 1 " +
-            "    FROM transaction_metadata " +
-            "    WHERE metadata_key_id in (select id from metadata_key where key = :key ) " +
-            "      and transaction_id = :transactionId)";
-
     private static final String UPSERT_STRING = "INSERT INTO transaction_metadata(transaction_id, metadata_key_id, value) " +
             "VALUES(:transactionId, (select id from metadata_key where key = :key ), :value) " +
-            "ON CONFLICT ON CONSTRAINT  transaction_id_and_metadata_key_id_key DO UPDATE SET "+
-            "value = EXCLUDED.value WHERE transaction_metadata.transaction_id = EXCLUDED.transaction_id AND " +
-            "transaction_metadata.metadata_key_id = EXCLUDED.metadata_key_id";
+            "ON CONFLICT ON CONSTRAINT transaction_id_and_metadata_key_id_key " +
+            "DO UPDATE SET value = EXCLUDED.value " +
+            "WHERE transaction_metadata.transaction_id = EXCLUDED.transaction_id " +
+            "AND transaction_metadata.metadata_key_id = EXCLUDED.metadata_key_id";
 
     private final Jdbi jdbi;
 

--- a/src/test/java/uk/gov/pay/ledger/transaction/service/TransactionMetadataServiceTest.java
+++ b/src/test/java/uk/gov/pay/ledger/transaction/service/TransactionMetadataServiceTest.java
@@ -50,7 +50,8 @@ public class TransactionMetadataServiceTest {
                 .withResourceType(ResourceType.PAYMENT)
                 .withSource(Source.CARD_API)
                 .withMetadata("meta1", "data1")
-                .withMetadata("meta2", "data2")
+                .withMetadata("meta2", 2)
+                .withMetadata("meta3", true)
                 .withDefaultEventDataForEventType(SalientEventType.PAYMENT_CREATED.name())
                 .toEntity();
 
@@ -59,7 +60,8 @@ public class TransactionMetadataServiceTest {
         verify(mockMetadataKeyDao).insertIfNotExist("meta1");
         verify(mockMetadataKeyDao).insertIfNotExist("meta2");
         verify(mockTransactionMetadataDao).upsert(transaction.getId(), "meta1", "data1");
-        verify(mockTransactionMetadataDao).upsert(transaction.getId(), "meta2", "data2");
+        verify(mockTransactionMetadataDao).upsert(transaction.getId(), "meta2", "2");
+        verify(mockTransactionMetadataDao).upsert(transaction.getId(), "meta3", "true");
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/ledger/util/fixture/QueuePaymentEventFixture.java
+++ b/src/test/java/uk/gov/pay/ledger/util/fixture/QueuePaymentEventFixture.java
@@ -91,14 +91,9 @@ public class QueuePaymentEventFixture implements QueueFixture<QueuePaymentEventF
     public QueuePaymentEventFixture withDefaultEventDataForEventType(String eventType) {
         switch (eventType) {
             case "PAYMENT_CREATED":
-                var externalMetadata = new JsonObject();
-                if (!metadata.isEmpty()) {
-                    metadata.forEach((key, value) ->
-                            externalMetadata.addProperty(key, String.valueOf(value)));
-                } else if (includeMetada) {
-                    externalMetadata.addProperty("key", "value");
+                if (metadata.isEmpty() && includeMetada) {
+                    metadata.put("key", "value");
                 }
-
                 eventData = gsonBuilder.create()
                         .toJson(ImmutableMap.builder()
                                 .put("amount", 1000)
@@ -111,7 +106,7 @@ public class QueuePaymentEventFixture implements QueueFixture<QueuePaymentEventF
                                 .put("delayed_capture", false)
                                 .put("moto", false)
                                 .put("live", true)
-                                .put("external_metadata", externalMetadata)
+                                .put("external_metadata", metadata)
                                 .put("email", "j.doe@example.org")
                                 .put("cardholder_name", "J citizen")
                                 .put("address_line1", "12 Rouge Avenue")
@@ -151,7 +146,7 @@ public class QueuePaymentEventFixture implements QueueFixture<QueuePaymentEventF
                 eventData = gsonBuilder.create().toJson(Map.of("capture_submitted_date", eventDate.toString()));
                 break;
             case "PAYMENT_NOTIFICATION_CREATED":
-                externalMetadata = new JsonObject();
+                var externalMetadata = new JsonObject();
                 externalMetadata.addProperty("telephone_number", "+447700900796");
                 externalMetadata.addProperty("processor_id", "processorId");
                 externalMetadata.addProperty("authorised_date", "2018-02-21T16:05:33Z");


### PR DESCRIPTION
Use JsonNode::asText rather than JsonNode::textValue to get string value to insert into the `transaction_metadata` table. Previously, boolean and number values were not being inserted.