### PR TITLE
PP-7859 Insert transaction_metadata for metadata pact state

### DIFF
--- a/src/test/java/uk/gov/pay/ledger/pact/ContractTest.java
+++ b/src/test/java/uk/gov/pay/ledger/pact/ContractTest.java
@@ -165,7 +165,7 @@ public abstract class ContractTest {
                 .withAmount(100L)
                 .withExternalMetadata(metadata)
                 .withDefaultTransactionDetails()
-                .insert(app.getJdbi());
+                .insertTransactionAndTransactionMetadata(app.getJdbi());
     }
 
     @State("a transaction with a gateway transaction id exists")


### PR DESCRIPTION
## WHAT
- For pact state `a transaction with metadata exists`, insert transaction_metadata & metadata rows as well so this state can be used by pact (search by metadata)