### PR TITLE
PP-7906 Accept reproject_domain_object field on events

### DIFF
--- a/src/main/java/uk/gov/pay/ledger/event/dao/mapper/EventMapper.java
+++ b/src/main/java/uk/gov/pay/ledger/event/dao/mapper/EventMapper.java
@@ -21,7 +21,8 @@ public class EventMapper implements RowMapper<Event> {
                 resultSet.getString("parent_resource_external_id"),
                 ZonedDateTime.ofInstant(resultSet.getTimestamp("event_date").toInstant(), ZoneOffset.UTC),
                 resultSet.getString("event_type"),
-                resultSet.getString("event_data")
+                resultSet.getString("event_data"),
+                false
         );
     }
 }

--- a/src/main/java/uk/gov/pay/ledger/event/model/Event.java
+++ b/src/main/java/uk/gov/pay/ledger/event/model/Event.java
@@ -22,11 +22,20 @@ public class Event {
     private ZonedDateTime eventDate;
     private String eventType;
     private String eventData;
+    private boolean reprojectDomainObject;
 
-    public Event() { }
+    public Event() {
+    }
 
-    public Event(Long id, String sqsMessageId, ResourceType resourceType, String resourceExternalId,
-                 String parentResourceExternalId, ZonedDateTime eventDate, String eventType, String eventData) {
+    public Event(Long id,
+                 String sqsMessageId,
+                 ResourceType resourceType,
+                 String resourceExternalId,
+                 String parentResourceExternalId,
+                 ZonedDateTime eventDate,
+                 String eventType,
+                 String eventData,
+                 boolean reprojectDomainObject) {
         this.id = id;
         this.sqsMessageId = sqsMessageId;
         this.resourceType = resourceType;
@@ -35,11 +44,19 @@ public class Event {
         this.eventDate = eventDate;
         this.eventType = eventType;
         this.eventData = eventData;
+        this.reprojectDomainObject = reprojectDomainObject;
     }
 
-    public Event(String queueMessageId, ResourceType resourceType, String resourceExternalId, String parentResourceExternalId, ZonedDateTime eventDate,
-                 String eventType, String eventData) {
-        this(null, queueMessageId, resourceType, resourceExternalId, parentResourceExternalId, eventDate, eventType, eventData);
+    public Event(String queueMessageId,
+                 ResourceType resourceType,
+                 String resourceExternalId,
+                 String parentResourceExternalId,
+                 ZonedDateTime eventDate,
+                 String eventType,
+                 String eventData,
+                 boolean reprojectDomainObject) {
+        this(null, queueMessageId, resourceType, resourceExternalId, parentResourceExternalId, eventDate, eventType,
+                eventData, reprojectDomainObject);
     }
 
     public Long getId() {
@@ -72,6 +89,10 @@ public class Event {
 
     public String getEventData() {
         return eventData;
+    }
+
+    public boolean isReprojectDomainObject() {
+        return reprojectDomainObject;
     }
 
     @Override

--- a/src/main/java/uk/gov/pay/ledger/event/model/response/CreateEventResponse.java
+++ b/src/main/java/uk/gov/pay/ledger/event/model/response/CreateEventResponse.java
@@ -24,6 +24,15 @@ public class CreateEventResponse {
         this.state = CreateEventState.ERROR;
     }
 
+    private CreateEventResponse(CreateEventState state) {
+        this.isSuccessful = true;
+        this.state = state;
+    }
+
+    public static CreateEventResponse ignoredEventResponse() {
+        return new CreateEventResponse(CreateEventState.IGNORED);
+    }
+
     public boolean isSuccessful() {
         return isSuccessful;
     }

--- a/src/main/java/uk/gov/pay/ledger/queue/EventMessage.java
+++ b/src/main/java/uk/gov/pay/ledger/queue/EventMessage.java
@@ -31,7 +31,8 @@ public class EventMessage {
                 eventDto.getParentExternalId(),
                 eventDto.getEventDate(),
                 eventDto.getEventType(),
-                eventDto.getEventData()
+                eventDto.getEventData(),
+                eventDto.isReprojectDomainObject()
         );
     }
 

--- a/src/main/java/uk/gov/pay/ledger/queue/EventMessageDto.java
+++ b/src/main/java/uk/gov/pay/ledger/queue/EventMessageDto.java
@@ -31,6 +31,9 @@ public class EventMessageDto {
     @JsonProperty("event_details")
     private JsonNode eventData;
 
+    @JsonProperty("reproject_domain_object")
+    private boolean reprojectDomainObject;
+
     public ResourceType getResourceType() {
         return resourceType;
     }
@@ -53,5 +56,9 @@ public class EventMessageDto {
 
     public String getParentExternalId() {
         return parentExternalId;
+    }
+
+    public boolean isReprojectDomainObject() {
+        return reprojectDomainObject;
     }
 }

--- a/src/test/java/uk/gov/pay/ledger/queue/EventQueueTest.java
+++ b/src/test/java/uk/gov/pay/ledger/queue/EventQueueTest.java
@@ -19,12 +19,13 @@ import java.util.List;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
-public class EventQueueTest {
+class EventQueueTest {
 
     @Mock
     private LedgerConfig ledgerConfig;
@@ -35,13 +36,14 @@ public class EventQueueTest {
     private EventQueue eventQueue;
 
     @BeforeEach
-    public void setUp() throws QueueException {
+    void setUp() throws QueueException {
         String validJsonMessage = "{" +
                 "\"id\": \"my-id\"," +
                 "\"timestamp\": \"2018-03-12T16:25:01.123456Z\"," +
                 "\"resource_external_id\": \"3uwuyr38rry\"," +
                 "\"event_type\":\"PAYMENT_CREATED\"," +
                 "\"resource_type\": \"payment\"," +
+                "\"reproject_domain_object\": \"true\"," +
                 "\"event_details\": {" +
                 "\"example_event_details_field\": \"and its value\"" +
                 "}" +
@@ -63,7 +65,7 @@ public class EventQueueTest {
     }
 
     @Test
-    public void retrieveEvents() throws QueueException {
+    void retrieveEvents() throws QueueException {
         List<EventMessage> eventsList = eventQueue.retrieveEvents();
 
         assertNotNull(eventsList);
@@ -73,5 +75,6 @@ public class EventQueueTest {
         assertEquals("PAYMENT_CREATED", eventsList.get(0).getEvent().getEventType());
         assertEquals(ResourceType.PAYMENT, eventsList.get(0).getEvent().getResourceType());
         assertEquals("{\"example_event_details_field\":\"and its value\"}", eventsList.get(0).getEvent().getEventData());
+        assertTrue(eventsList.get(0).getEvent().isReprojectDomainObject());
     }
 }

--- a/src/test/java/uk/gov/pay/ledger/util/fixture/EventFixture.java
+++ b/src/test/java/uk/gov/pay/ledger/util/fixture/EventFixture.java
@@ -19,6 +19,7 @@ public class EventFixture implements DbFixture<EventFixture, Event> {
     private ZonedDateTime eventDate = ZonedDateTime.now(ZoneOffset.UTC);
     private String eventType = "PAYMENT_CREATED";
     private String eventData = "{\"event_data\": \"event data\"}";
+    private boolean reprojectDomainObject;
 
     private EventFixture() {
     }
@@ -67,6 +68,11 @@ public class EventFixture implements DbFixture<EventFixture, Event> {
         return this;
     }
 
+    public EventFixture withIsReprojectDomainObject(boolean reprojectDomainObject) {
+        this.reprojectDomainObject = reprojectDomainObject;
+        return this;
+    }
+
     @Override
     public EventFixture insert(Jdbi jdbi) {
         jdbi.withHandle(h ->
@@ -98,7 +104,7 @@ public class EventFixture implements DbFixture<EventFixture, Event> {
 
     @Override
     public Event toEntity() {
-        return new Event(id, sqsMessageId, resourceType, resourceExternalId, parentResourceExternalId, eventDate, eventType, eventData);
+        return new Event(id, sqsMessageId, resourceType, resourceExternalId, parentResourceExternalId, eventDate, eventType, eventData, reprojectDomainObject);
     }
 
     public Long getId() {

--- a/src/test/java/uk/gov/pay/ledger/util/fixture/QueuePaymentEventFixture.java
+++ b/src/test/java/uk/gov/pay/ledger/util/fixture/QueuePaymentEventFixture.java
@@ -29,6 +29,7 @@ public class QueuePaymentEventFixture implements QueueFixture<QueuePaymentEventF
     private Source source;
     private Map<String, Object> metadata = new HashMap<>();
     private boolean includeMetada = true;
+    private boolean reprojectDomainObject;
     private GsonBuilder gsonBuilder = new GsonBuilder();
 
     private QueuePaymentEventFixture() {
@@ -85,6 +86,11 @@ public class QueuePaymentEventFixture implements QueueFixture<QueuePaymentEventF
 
     public QueuePaymentEventFixture includeMetadata(boolean includeMetada) {
         this.includeMetada = includeMetada;
+        return this;
+    }
+
+    public QueuePaymentEventFixture withIsReprojectDomainObject(boolean reprojectDomainObject) {
+        this.reprojectDomainObject = reprojectDomainObject;
         return this;
     }
 
@@ -187,7 +193,7 @@ public class QueuePaymentEventFixture implements QueueFixture<QueuePaymentEventF
 
     @Override
     public Event toEntity() {
-        return new Event(0L, sqsMessageId, resourceType, resourceExternalId, parentResourceExternalId, eventDate, eventType, eventData);
+        return new Event(0L, sqsMessageId, resourceType, resourceExternalId, parentResourceExternalId, eventDate, eventType, eventData, reprojectDomainObject);
     }
 
     public String getSqsMessageId() {

--- a/src/test/java/uk/gov/pay/ledger/util/fixture/QueuePayoutEventFixture.java
+++ b/src/test/java/uk/gov/pay/ledger/util/fixture/QueuePayoutEventFixture.java
@@ -86,7 +86,7 @@ public class QueuePayoutEventFixture implements QueueFixture<QueuePayoutEventFix
 
     @Override
     public Event toEntity() {
-        return new Event(0L, sqsMessageId, resourceType, resourceExternalId, EMPTY, eventDate, eventType, eventData);
+        return new Event(0L, sqsMessageId, resourceType, resourceExternalId, EMPTY, eventDate, eventType, eventData, false);
     }
 
     @Override

--- a/src/test/java/uk/gov/pay/ledger/util/fixture/QueueRefundEventFixture.java
+++ b/src/test/java/uk/gov/pay/ledger/util/fixture/QueueRefundEventFixture.java
@@ -101,7 +101,7 @@ public class QueueRefundEventFixture implements QueueFixture<QueueRefundEventFix
 
     @Override
     public Event toEntity() {
-        return new Event(0L, sqsMessageId, resourceType, resourceExternalId, parentResourceExternalId, eventDate, eventType, eventData);
+        return new Event(0L, sqsMessageId, resourceType, resourceExternalId, parentResourceExternalId, eventDate, eventType, eventData, false);
     }
 
     public String getSqsMessageId() {


### PR DESCRIPTION
Handle events having a boolean `reproject_domain_object` field on event messages.

When this field is present, skip persisting the event to the database.

Will handle performing the re-projection of transaction_metadata in the next commit.