### PR TITLE
PP-7906 Reproject transaction_metadata

### DIFF
--- a/src/main/java/uk/gov/pay/ledger/queue/EventMessageHandler.java
+++ b/src/main/java/uk/gov/pay/ledger/queue/EventMessageHandler.java
@@ -58,8 +58,9 @@ public class EventMessageHandler {
 
         CreateEventResponse response;
 
-        // we don't persist events created by internal admins for re-projecting domain objects so as to not pollute
-        // the event feed.
+        // We don't persist events created by internal admins for re-projecting domain objects so as to not pollute
+        // the event feed. This also means that any event data on the event will be ignored when processing, and only
+        // previous events will be used when re-projecting the domain object.
         if (event.isReprojectDomainObject()) {
             response = ignoredEventResponse();
         } else {

--- a/src/main/java/uk/gov/pay/ledger/queue/eventprocessor/PaymentEventProcessor.java
+++ b/src/main/java/uk/gov/pay/ledger/queue/eventprocessor/PaymentEventProcessor.java
@@ -37,7 +37,12 @@ public class PaymentEventProcessor extends EventProcessor {
         EventDigest paymentEventDigest = EventDigest.fromEventList(events);
 
         transactionService.upsertTransactionFor(paymentEventDigest);
-        transactionMetadataService.upsertMetadataFor(event);
+
+        if (event.isReprojectDomainObject()) {
+            transactionMetadataService.reprojectFromEventDigest(paymentEventDigest);
+        } else {
+            transactionMetadataService.upsertMetadataFor(event);
+        }
 
         /**
          * If the payment has associated refunds, we want to update the payment details that we also store on refunds to


### PR DESCRIPTION
Reproject `transaction_metadata` rows from the EventDigest when an event is processed with the field `reproject_domain_object` set to true.

This will not take into account any of the event details on the event being processed, only previous events for the transaction from the database.

When an event is processed without this field, or set to false, continue to only upsert to the `transaction_metadata` when the event being processed has `external_metatada` in its event details.