### PR TITLE
PP-7906 Log queue message id for events

### DIFF
--- a/src/main/java/uk/gov/pay/ledger/queue/EventMessage.java
+++ b/src/main/java/uk/gov/pay/ledger/queue/EventMessage.java
@@ -15,10 +15,6 @@ public class EventMessage {
         return new EventMessage(eventDto, queueMessage);
     }
 
-    public String getId() {
-        return eventDto.getExternalId();
-    }
-
     public String getQueueMessageId() {
         return queueMessage.getMessageId();
     }

--- a/src/test/java/uk/gov/pay/ledger/queue/sqs/EventQueueIT.java
+++ b/src/test/java/uk/gov/pay/ledger/queue/sqs/EventQueueIT.java
@@ -79,6 +79,5 @@ public class EventQueueIT {
 
         List<EventMessage> result = eventQueue.retrieveEvents();
         assertFalse(result.isEmpty());
-        assertThat(result.get(0).getId(), is(event.getResourceExternalId()));
     }
 }


### PR DESCRIPTION
We were logging the resource external id as the `id` when we processed events. However we were already logging this on the same message as `resource_external_id`. Log the queue message id as this is useful to link up with emitted events.