### PR TITLE
PP-8025 Update/Add DAO methods for transaction_summary

### DIFF
--- a/src/main/java/uk/gov/pay/ledger/transactionsummary/dao/TransactionSummaryDao.java
+++ b/src/main/java/uk/gov/pay/ledger/transactionsummary/dao/TransactionSummaryDao.java
@@ -10,11 +10,10 @@ public class TransactionSummaryDao {
 
     private static final String UPSERT_STRING = "INSERT INTO transaction_summary AS ts(gateway_account_id, type, " +
             " transaction_date, state, live, moto, total_amount_in_pence, no_of_transactions, total_fee_in_pence)" +
-            " VALUES(:gatewayAccountId, :type, :transactionDate, :state, :live, :moto, :amountInPence, 1,:feeInPence)" +
+            " VALUES(:gatewayAccountId, :type, :transactionDate, :state, :live, :moto, :amountInPence, 1,0)" +
             " ON CONFLICT ON CONSTRAINT transaction_summmary_unique_key " +
             " DO UPDATE SET no_of_transactions = ts.no_of_transactions + 1, " +
-            " total_amount_in_pence = :amountInPence + ts.total_amount_in_pence," +
-            " total_fee_in_pence = :feeInPence + ts.total_fee_in_pence" +
+            " total_amount_in_pence = :amountInPence + ts.total_amount_in_pence" +
             " WHERE ts.gateway_account_id = :gatewayAccountId " +
             " AND ts.transaction_date = :transactionDate " +
             " AND ts.state = :state " +
@@ -22,10 +21,19 @@ public class TransactionSummaryDao {
             " AND ts.live = :live" +
             " AND ts.moto = :moto";
 
-    private static final String UPDATE_SUMMARY = "UPDATE transaction_summary ts " +
+    private static final String DEDUCT_TRANSACTION_SUMMARY = "UPDATE transaction_summary ts " +
             " SET no_of_transactions = ts.no_of_transactions - 1, " +
             " total_amount_in_pence = ts.total_amount_in_pence - :amountInPence, " +
             " total_fee_in_pence = ts.total_fee_in_pence - :feeInPence " +
+            " WHERE ts.gateway_account_id = :gatewayAccountId " +
+            " AND ts.transaction_date = :transactionDate " +
+            " AND ts.state = :state " +
+            " AND ts.type = :type" +
+            " AND ts.live = :live" +
+            " AND ts.moto = :moto";
+
+    private static final String UPDATE_FEE = "UPDATE transaction_summary ts " +
+            " SET total_fee_in_pence = ts.total_fee_in_pence + :feeInPence " +
             " WHERE ts.gateway_account_id = :gatewayAccountId " +
             " AND ts.transaction_date = :transactionDate " +
             " AND ts.state = :state " +
@@ -41,7 +49,7 @@ public class TransactionSummaryDao {
     }
 
     public void upsert(String gatewayAccountId, String transactionType, ZonedDateTime transactionDate,
-                       TransactionState state, boolean live, boolean moto, Long amount, Long fee) {
+                       TransactionState state, boolean live, boolean moto, Long amount) {
         jdbi.withHandle(handle ->
                 handle.createUpdate(UPSERT_STRING)
                         .bind("gatewayAccountId", gatewayAccountId)
@@ -51,16 +59,30 @@ public class TransactionSummaryDao {
                         .bind("live", live)
                         .bind("moto", moto)
                         .bind("amountInPence", amount)
+                        .execute()
+        );
+    }
+
+    public void updateFee(String gatewayAccountId, String transactionType, ZonedDateTime transactionDate,
+                          TransactionState state, boolean live, boolean moto, Long fee) {
+        jdbi.withHandle(handle ->
+                handle.createUpdate(UPDATE_FEE)
+                        .bind("gatewayAccountId", gatewayAccountId)
+                        .bind("type", transactionType)
+                        .bind("transactionDate", transactionDate)
+                        .bind("state", state)
+                        .bind("live", live)
+                        .bind("moto", moto)
                         .bind("feeInPence", fee)
                         .execute()
         );
     }
 
     public void deductTransactionSummaryFor(String gatewayAccountId, String transactionType,
-                                                ZonedDateTime transactionDate, TransactionState state, boolean live,
-                                                boolean moto, Long amount, Long fee) {
+                                            ZonedDateTime transactionDate, TransactionState state, boolean live,
+                                            boolean moto, Long amount, Long fee) {
         jdbi.withHandle(handle ->
-                handle.createUpdate(UPDATE_SUMMARY)
+                handle.createUpdate(DEDUCT_TRANSACTION_SUMMARY)
                         .bind("gatewayAccountId", gatewayAccountId)
                         .bind("type", transactionType)
                         .bind("transactionDate", transactionDate)
@@ -72,6 +94,5 @@ public class TransactionSummaryDao {
                         .execute()
         );
     }
-
 
 }


### PR DESCRIPTION
## WHAT 
- Split out updating fee from transaction_summary insert/update as fee won't be available on the first successful event (which is used to update total_amount_in_pence).
- as fee is available only on capture_confirmed event, updateFee method will be used when processing CAPTURE_CONFIRMED event or when all info to project fee is available.