### PR TITLE
PP-8026 - Refactor monthly gateway performance report with transaction summary

### DIFF
--- a/src/main/java/uk/gov/pay/ledger/report/dao/PerformanceReportDao.java
+++ b/src/main/java/uk/gov/pay/ledger/report/dao/PerformanceReportDao.java
@@ -23,23 +23,6 @@ public class PerformanceReportDao {
 
     private static final String WITH_DATE_RANGE = " and created_date between :startDate and :toDate";
 
-    private static final String MONTHLY_GATEWAY_ACCOUNT_PERFORMANCE_STATISTICS = "SELECT " +
-            "t.gateway_account_id, " +
-            "COALESCE(COUNT(t.amount), 0) AS volume, " +
-            "COALESCE(SUM(t.amount), 0) AS total_amount, " +
-            "COALESCE(AVG(t.amount), 0) AS avg_amount, " +
-            "COALESCE(MIN(t.amount), 0) AS min_amount, " +
-            "COALESCE(MAX(t.amount), 0) AS max_amount, " +
-            "EXTRACT(YEAR from created_date) AS year, " +
-            "EXTRACT(MONTH from created_date) AS month " +
-            "FROM transaction t " +
-            "WHERE t.state = 'SUCCESS' " +
-            "AND t.type = 'PAYMENT' " +
-            "AND t.live = TRUE " +
-            "AND created_date BETWEEN :startDate AND :endDate " +
-            "GROUP BY t.gateway_account_id, year, month " +
-            "ORDER BY t.gateway_account_id, year, month";
-
     private final Jdbi jdbi;
 
     @Inject
@@ -61,14 +44,5 @@ public class PerformanceReportDao {
             });
             return query.map(new PerformanceReportEntityMapper()).one();
         });
-    }
-
-    public List<GatewayAccountMonthlyPerformanceReportEntity> monthlyPerformanceReportForGatewayAccounts(ZonedDateTime startDate, ZonedDateTime endDate) {
-        return jdbi.withHandle(handle ->
-                handle
-                        .createQuery(MONTHLY_GATEWAY_ACCOUNT_PERFORMANCE_STATISTICS)
-                        .bind("startDate", startDate)
-                        .bind("endDate", endDate)
-                        .map(new GatewayAccountMonthlyPerformanceReportEntityMapper()).list());
     }
 }

--- a/src/main/java/uk/gov/pay/ledger/report/entity/GatewayAccountMonthlyPerformanceReportEntity.java
+++ b/src/main/java/uk/gov/pay/ledger/report/entity/GatewayAccountMonthlyPerformanceReportEntity.java
@@ -12,8 +12,6 @@ public class GatewayAccountMonthlyPerformanceReportEntity {
     private final long totalVolume;
     private final BigDecimal totalAmount;
     private final BigDecimal averageAmount;
-    private final BigDecimal minimumAmount;
-    private final BigDecimal maximumAmount;
     private final long month;
     private final long year;
 
@@ -21,16 +19,12 @@ public class GatewayAccountMonthlyPerformanceReportEntity {
                                                         long totalVolume,
                                                         BigDecimal totalAmount,
                                                         BigDecimal averageAmount,
-                                                        BigDecimal minimumAmount,
-                                                        BigDecimal maximumAmount,
                                                         long year,
                                                         long month) {
         this.gatewayAccountId = gatewayAccountId;
         this.totalVolume = totalVolume;
         this.totalAmount = totalAmount;
         this.averageAmount = averageAmount;
-        this.minimumAmount = minimumAmount;
-        this.maximumAmount = maximumAmount;
         this.year = year;
         this.month = month;
     }
@@ -49,14 +43,6 @@ public class GatewayAccountMonthlyPerformanceReportEntity {
 
     public BigDecimal getAverageAmount() {
         return averageAmount;
-    }
-
-    public BigDecimal getMinimumAmount() {
-        return minimumAmount;
-    }
-
-    public BigDecimal getMaximumAmount() {
-        return maximumAmount;
     }
 
     public long getYear() {

--- a/src/main/java/uk/gov/pay/ledger/report/mapper/GatewayAccountMonthlyPerformanceReportEntityMapper.java
+++ b/src/main/java/uk/gov/pay/ledger/report/mapper/GatewayAccountMonthlyPerformanceReportEntityMapper.java
@@ -17,8 +17,6 @@ public class GatewayAccountMonthlyPerformanceReportEntityMapper implements RowMa
                 rs.getLong("volume"),
                 new BigDecimal(rs.getString("total_amount")),
                 new BigDecimal(rs.getString("avg_amount")),
-                new BigDecimal(rs.getString("min_amount")),
-                new BigDecimal(rs.getString("max_amount")),
                 rs.getLong("year"),
                 rs.getLong("month")
         );

--- a/src/main/java/uk/gov/pay/ledger/report/resource/PerformanceReportResource.java
+++ b/src/main/java/uk/gov/pay/ledger/report/resource/PerformanceReportResource.java
@@ -7,12 +7,14 @@ import uk.gov.pay.ledger.report.entity.GatewayAccountMonthlyPerformanceReportEnt
 import uk.gov.pay.ledger.report.entity.PerformanceReportEntity;
 import uk.gov.pay.ledger.report.params.PerformanceReportParams.PerformanceReportParamsBuilder;
 import uk.gov.pay.ledger.transaction.state.TransactionState;
+import uk.gov.pay.ledger.transactionsummary.dao.TransactionSummaryDao;
 
 import javax.inject.Inject;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
+import java.time.LocalDate;
 import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Optional;
@@ -26,10 +28,12 @@ import static org.apache.commons.lang3.StringUtils.isNotBlank;
 public class PerformanceReportResource {
 
     private final PerformanceReportDao performanceReportDao;
+    private final TransactionSummaryDao transactionSummaryDao;
 
     @Inject
-    public PerformanceReportResource(PerformanceReportDao performanceReportDao) {
+    public PerformanceReportResource(PerformanceReportDao performanceReportDao, TransactionSummaryDao transactionSummaryDao) {
         this.performanceReportDao = performanceReportDao;
+        this.transactionSummaryDao = transactionSummaryDao;
     }
 
     @Path("/performance-report")
@@ -73,10 +77,10 @@ public class PerformanceReportResource {
                                                                                                  @QueryParam("to_date") String toDate) {
         if (isBlank(fromDate) || isBlank(toDate)) {
             throw new ValidationException("Both from_date and to_date must be provided");
-        } else if (ZonedDateTime.parse(fromDate).isAfter(ZonedDateTime.parse(toDate))) {
+        } else if (LocalDate.parse(fromDate).isAfter(LocalDate.parse(toDate))) {
             throw new ValidationException("from_date must be earlier or equal to to_date");
         }
 
-        return performanceReportDao.monthlyPerformanceReportForGatewayAccounts(ZonedDateTime.parse(fromDate), ZonedDateTime.parse(toDate));
+        return transactionSummaryDao.monthlyPerformanceReportForGatewayAccounts(LocalDate.parse(fromDate), LocalDate.parse(toDate));
     }
 }


### PR DESCRIPTION
Description:
- Refactors /gateway-performance-report to use the transaction_summary table via TransactionSummaryDao
- Since the transaction_summary table doesn't contain a minimum and maximum amount nor can it be calculated from the table it is omitted in the JSON response
- The transaction_summary table no longer has timezone so where appropriate ZonedDateTime has been replaced with LocalDateTime
- The corresponding Toolbox PR for sending dates instead of timezones will need to be merged as LocalDate.parse(...) will throw an exception if timezones are contained. Currently Toolbox sends
timezone data
- Unnecessary .log() from previous testing has been removed