### PR TITLE
PP-8025 Project transaction summary from event stream

### DIFF
--- a/src/main/java/uk/gov/pay/ledger/queue/EventDigestHandler.java
+++ b/src/main/java/uk/gov/pay/ledger/queue/EventDigestHandler.java
@@ -13,6 +13,7 @@ import uk.gov.pay.ledger.queue.eventprocessor.PayoutEventProcessor;
 import uk.gov.pay.ledger.queue.eventprocessor.RefundEventProcessor;
 import uk.gov.pay.ledger.transaction.service.TransactionMetadataService;
 import uk.gov.pay.ledger.transaction.service.TransactionService;
+import uk.gov.pay.ledger.transactionsummary.service.TransactionSummaryService;
 
 public class EventDigestHandler {
 
@@ -27,9 +28,9 @@ public class EventDigestHandler {
                               TransactionService transactionService,
                               TransactionMetadataService transactionMetadataService,
                               PayoutService payoutService,
-                              TransactionEntityFactory transactionEntityFactory) {
+                              TransactionEntityFactory transactionEntityFactory, TransactionSummaryService transactionSummaryService) {
         refundEventProcessor = new RefundEventProcessor(eventService, transactionService, transactionEntityFactory);
-        paymentEventProcessor = new PaymentEventProcessor(eventService, transactionService, transactionMetadataService, refundEventProcessor);
+        paymentEventProcessor = new PaymentEventProcessor(eventService, transactionService, transactionMetadataService, refundEventProcessor, transactionSummaryService);
         payoutEventProcessor = new PayoutEventProcessor(eventService, payoutService);
     }
 

--- a/src/main/java/uk/gov/pay/ledger/queue/EventMessageHandler.java
+++ b/src/main/java/uk/gov/pay/ledger/queue/EventMessageHandler.java
@@ -1,8 +1,6 @@
 package uk.gov.pay.ledger.queue;
 
 import com.codahale.metrics.MetricRegistry;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.inject.Inject;
 import io.sentry.Sentry;
 import org.slf4j.Logger;
@@ -17,7 +15,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static net.logstash.logback.argument.StructuredArguments.kv;
-import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import static uk.gov.pay.ledger.event.model.response.CreateEventResponse.ignoredEventResponse;
 
 public class EventMessageHandler {

--- a/src/main/java/uk/gov/pay/ledger/transaction/service/TransactionService.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/service/TransactionService.java
@@ -147,9 +147,10 @@ public class TransactionService {
     }
     // @TODO(sfount) handling writing invalid transaction should be tested at `EventMessageHandler` integration level
 
-    public void upsertTransactionFor(EventDigest eventDigest) {
+    public TransactionEntity upsertTransactionFor(EventDigest eventDigest) {
         TransactionEntity transaction = transactionEntityFactory.create(eventDigest);
         transactionDao.upsert(transaction);
+        return transaction;
     }
 
     public void upsertTransaction(TransactionEntity transaction) {

--- a/src/main/java/uk/gov/pay/ledger/transactionsummary/service/TransactionSummaryService.java
+++ b/src/main/java/uk/gov/pay/ledger/transactionsummary/service/TransactionSummaryService.java
@@ -1,0 +1,135 @@
+package uk.gov.pay.ledger.transactionsummary.service;
+
+import com.google.inject.Inject;
+import uk.gov.pay.ledger.event.model.Event;
+import uk.gov.pay.ledger.event.model.SalientEventType;
+import uk.gov.pay.ledger.event.service.EventService;
+import uk.gov.pay.ledger.transaction.entity.TransactionEntity;
+import uk.gov.pay.ledger.transaction.state.TransactionState;
+import uk.gov.pay.ledger.transactionsummary.dao.TransactionSummaryDao;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import static uk.gov.pay.ledger.event.model.SalientEventType.CAPTURE_CONFIRMED;
+import static uk.gov.pay.ledger.event.model.SalientEventType.PAYMENT_CREATED;
+import static uk.gov.pay.ledger.event.model.SalientEventType.from;
+import static uk.gov.pay.ledger.transaction.model.TransactionType.PAYMENT;
+
+public class TransactionSummaryService {
+
+    private final TransactionSummaryDao transactionSummaryDao;
+    private final EventService eventService;
+
+    @Inject
+    public TransactionSummaryService(TransactionSummaryDao transactionSummaryDao, EventService eventService) {
+        this.transactionSummaryDao = transactionSummaryDao;
+        this.eventService = eventService;
+    }
+
+    public void projectTransactionSummary(TransactionEntity transaction, Event currentEvent) {
+        if (PAYMENT.name().equals(transaction.getTransactionType())) {
+            projectPaymentTransactionSummary(transaction, currentEvent);
+        }
+    }
+
+    private void projectPaymentTransactionSummary(TransactionEntity transaction, Event currentEvent) {
+
+        if (!canProjectTransactionSummary(transaction, currentEvent)) {
+            return;
+        }
+
+        List<Event> events = eventService.getEventsForResource(transaction.getExternalId());
+        boolean hasPaymentCreatedEvent = hasSalientEvent(events, PAYMENT_CREATED);
+
+        if (!hasPaymentCreatedEvent) {
+            return;
+        }
+
+        List<Event> eventsMappingToFinishedState =
+                getEventsMappingToTransactionFinishedStateInDescendingOrder(events);
+        Optional<SalientEventType> mayBeCurrentSalientEventType = from(currentEvent.getEventType());
+
+        projectTransactionAmount(transaction, currentEvent, eventsMappingToFinishedState);
+        projectTransactionFee(transaction, mayBeCurrentSalientEventType.get(), eventsMappingToFinishedState);
+    }
+
+    private boolean canProjectTransactionSummary(TransactionEntity transaction, Event currentEvent) {
+        SalientEventType currentSalientEventType = from(currentEvent.getEventType()).orElse(null);
+
+        if (currentSalientEventType == PAYMENT_CREATED && transaction.getState().isFinished()) {
+            return true;
+        }
+
+        return getTransactionState(currentEvent).map(TransactionState::isFinished).orElse(false);
+    }
+
+    private void projectTransactionAmount(TransactionEntity transaction, Event currentEvent,
+                                          List<Event> eventsMappingToTransactionFinishedState) {
+        if (eventsMappingToTransactionFinishedState.size() > 1
+                && PAYMENT_CREATED != from(currentEvent.getEventType()).orElse(null)) {
+            Event previousEvent = eventsMappingToTransactionFinishedState.get(1);
+
+            if (currentEventTransactionStateMatchesWithPreviousEvent(currentEvent, previousEvent)) {
+                return;
+            }
+
+            transactionSummaryDao.deductTransactionSummaryFor(transaction.getGatewayAccountId(),
+                    transaction.getTransactionType(), transaction.getCreatedDate(),
+                    getTransactionState(previousEvent).get(), transaction.isLive(), transaction.isMoto(),
+                    (transaction.getTotalAmount() != null ? transaction.getTotalAmount() : transaction.getAmount()),
+                    transaction.getFee());
+        }
+        transactionSummaryDao.upsert(transaction.getGatewayAccountId(), transaction.getTransactionType(),
+                transaction.getCreatedDate(), transaction.getState(), transaction.isLive(), transaction.isMoto(),
+                (transaction.getTotalAmount() != null ? transaction.getTotalAmount() : transaction.getAmount()));
+    }
+
+    private void projectTransactionFee(TransactionEntity transaction, SalientEventType currentEvent,
+                                       List<Event> eventsMappingToFinishedState) {
+
+        long noOfCaptureConfirmedEvents = eventsMappingToFinishedState
+                .stream()
+                .map(event -> from(event.getEventType()))
+                .flatMap(Optional::stream)
+                .filter(salientEventType -> salientEventType == CAPTURE_CONFIRMED)
+                .count();
+
+        // Fee is currently immutable, so process fee only for the first capture_confirmed event seen
+        // or if payment_created is processed after a capture_confirmed event has been processed.
+        if ((currentEvent == PAYMENT_CREATED || (currentEvent == CAPTURE_CONFIRMED && noOfCaptureConfirmedEvents == 1))
+                && transaction.getFee() != null) {
+            transactionSummaryDao.updateFee(transaction.getGatewayAccountId(), transaction.getTransactionType(),
+                    transaction.getCreatedDate(), transaction.getState(), transaction.isLive(), transaction.isMoto(),
+                    transaction.getFee());
+        }
+    }
+
+    private boolean currentEventTransactionStateMatchesWithPreviousEvent(Event currentEvent, Event previousEvent) {
+        Optional<TransactionState> previousEventTransactionState = getTransactionState(previousEvent);
+        Optional<TransactionState> currentEventTransactionState = getTransactionState(currentEvent);
+
+        return previousEventTransactionState.equals(currentEventTransactionState);
+    }
+
+    private Optional<TransactionState> getTransactionState(Event previousEvent) {
+        return from(previousEvent.getEventType())
+                .map(TransactionState::fromEventType);
+    }
+
+    private List<Event> getEventsMappingToTransactionFinishedStateInDescendingOrder(List<Event> events) {
+        return events.stream().
+                filter(event -> getTransactionState(event).map(TransactionState::isFinished).orElse(false))
+                .sorted(Comparator.comparing(Event::getEventDate).reversed())
+                .collect(Collectors.toList());
+    }
+
+    private boolean hasSalientEvent(List<Event> events, SalientEventType eventToCheck) {
+        return events.stream()
+                .map(event -> from(event.getEventType()))
+                .flatMap(Optional::stream)
+                .anyMatch(salientEventType -> eventToCheck == salientEventType);
+    }
+}

--- a/src/test/java/uk/gov/pay/ledger/queue/EventDigestHandlerTest.java
+++ b/src/test/java/uk/gov/pay/ledger/queue/EventDigestHandlerTest.java
@@ -21,6 +21,7 @@ import uk.gov.pay.ledger.payout.service.PayoutService;
 import uk.gov.pay.ledger.transaction.entity.TransactionEntity;
 import uk.gov.pay.ledger.transaction.service.TransactionMetadataService;
 import uk.gov.pay.ledger.transaction.service.TransactionService;
+import uk.gov.pay.ledger.transactionsummary.service.TransactionSummaryService;
 
 import java.util.List;
 
@@ -51,20 +52,21 @@ class EventDigestHandlerTest {
     private TransactionMetadataService transactionMetadataService;
     @Mock
     private PayoutService payoutService;
-    private TransactionEntityFactory transactionEntityFactory;
     @Captor
     private ArgumentCaptor<LoggingEvent> loggingEventArgumentCaptor;
     @Mock
     private Appender<ILoggingEvent> mockAppender;
+    @Mock
+    private TransactionSummaryService transactionSummaryService;
 
     private EventDigestHandler eventDigestHandler;
     private EventDigest eventDigest;
 
     @BeforeEach
     void setUp() {
-        transactionEntityFactory = new TransactionEntityFactory(new ObjectMapper());
+        TransactionEntityFactory transactionEntityFactory = new TransactionEntityFactory(new ObjectMapper());
         eventDigestHandler =  new EventDigestHandler(eventService, transactionService,
-                transactionMetadataService, payoutService, transactionEntityFactory);
+                transactionMetadataService, payoutService, transactionEntityFactory, transactionSummaryService);
         eventDigest = EventDigest.fromEventList(List.of(anEventFixture().toEntity()));
         lenient().when(eventService.getEventDigestForResource(any(Event.class)))
                 .thenReturn(eventDigest);

--- a/src/test/java/uk/gov/pay/ledger/transactionsummary/service/TransactionSummaryServiceTest.java
+++ b/src/test/java/uk/gov/pay/ledger/transactionsummary/service/TransactionSummaryServiceTest.java
@@ -1,0 +1,278 @@
+package uk.gov.pay.ledger.transactionsummary.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.pay.ledger.event.model.Event;
+import uk.gov.pay.ledger.event.service.EventService;
+import uk.gov.pay.ledger.transaction.entity.TransactionEntity;
+import uk.gov.pay.ledger.transactionsummary.dao.TransactionSummaryDao;
+import uk.gov.pay.ledger.util.fixture.EventFixture;
+
+import java.time.ZonedDateTime;
+import java.util.List;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+import static uk.gov.pay.ledger.event.model.SalientEventType.AUTHORISATION_SUCCEEDED;
+import static uk.gov.pay.ledger.event.model.SalientEventType.CAPTURE_CONFIRMED;
+import static uk.gov.pay.ledger.event.model.SalientEventType.CAPTURE_ERRORED;
+import static uk.gov.pay.ledger.event.model.SalientEventType.CAPTURE_SUBMITTED;
+import static uk.gov.pay.ledger.event.model.SalientEventType.PAYMENT_CREATED;
+import static uk.gov.pay.ledger.event.model.SalientEventType.REFUND_SUBMITTED;
+import static uk.gov.pay.ledger.event.model.SalientEventType.USER_APPROVED_FOR_CAPTURE;
+import static uk.gov.pay.ledger.transaction.state.TransactionState.CREATED;
+import static uk.gov.pay.ledger.transaction.state.TransactionState.SUBMITTED;
+import static uk.gov.pay.ledger.transaction.state.TransactionState.SUCCESS;
+import static uk.gov.pay.ledger.util.fixture.TransactionFixture.aTransactionFixture;
+
+@ExtendWith(MockitoExtension.class)
+public class TransactionSummaryServiceTest {
+
+    private TransactionSummaryService transactionSummaryService;
+    @Mock
+    TransactionSummaryDao mockTransactionSummaryDao;
+    @Mock
+    EventService mockEventService;
+
+    @BeforeEach
+    void setUp() {
+        transactionSummaryService = new TransactionSummaryService(mockTransactionSummaryDao, mockEventService);
+    }
+
+    @Test
+    public void shouldProjectTransactionSummaryIfPaymentCreatedEventAndAnEventMappingToFinishedTransactionStateExists() {
+        TransactionEntity transactionEntity = aTransactionFixture()
+                .withState(SUCCESS)
+                .toEntity();
+        Event paymentCreatedEvent = EventFixture.anEventFixture()
+                .withEventDate(ZonedDateTime.now())
+                .withEventType(PAYMENT_CREATED.name()).toEntity();
+        Event nonSalientEvent = EventFixture.anEventFixture()
+                .withEventDate(ZonedDateTime.now())
+                .withEventType("BACKFILLER_RECREATED_USER_EMAIL_COLLECTED").toEntity();
+        Event userApprovedForCaptureEvent = EventFixture.anEventFixture()
+                .withEventDate(ZonedDateTime.now().plusSeconds(11))
+                .withEventType(USER_APPROVED_FOR_CAPTURE.name()).toEntity();
+        when(mockEventService.getEventsForResource(transactionEntity.getExternalId()))
+                .thenReturn(List.of(paymentCreatedEvent, nonSalientEvent, userApprovedForCaptureEvent));
+
+        transactionSummaryService.projectTransactionSummary(transactionEntity, paymentCreatedEvent);
+
+        verify(mockTransactionSummaryDao).upsert(transactionEntity.getGatewayAccountId(),
+                transactionEntity.getTransactionType(), transactionEntity.getCreatedDate(),
+                transactionEntity.getState(), transactionEntity.isLive(),
+                transactionEntity.isMoto(), transactionEntity.getAmount());
+        verifyNoMoreInteractions(mockTransactionSummaryDao);
+    }
+
+    @Test
+    public void shouldProjectTransactionSummaryIfCurrentEventMapsToDifferentTransactionStateOfPreviousEvent() {
+        TransactionEntity transactionEntity = aTransactionFixture()
+                .withState(SUCCESS)
+                .toEntity();
+        Event event = EventFixture.anEventFixture().withEventDate(ZonedDateTime.now())
+                .withEventType(PAYMENT_CREATED.name()).toEntity();
+        Event event2 = EventFixture.anEventFixture().withEventDate(ZonedDateTime.now().plusSeconds(1))
+                .withEventType(USER_APPROVED_FOR_CAPTURE.name()).toEntity();
+        Event event3 = EventFixture.anEventFixture().withEventDate(ZonedDateTime.now().plusSeconds(2))
+                .withEventType(CAPTURE_ERRORED.name()).toEntity();
+
+        when(mockEventService.getEventsForResource(transactionEntity.getExternalId()))
+                .thenReturn(List.of(event, event2, event3));
+
+        transactionSummaryService.projectTransactionSummary(transactionEntity, event3);
+
+        verify(mockTransactionSummaryDao).upsert(transactionEntity.getGatewayAccountId(),
+                transactionEntity.getTransactionType(), transactionEntity.getCreatedDate(),
+                transactionEntity.getState(), transactionEntity.isLive(),
+                transactionEntity.isMoto(), transactionEntity.getAmount());
+        verify(mockTransactionSummaryDao).deductTransactionSummaryFor(transactionEntity.getGatewayAccountId(),
+                transactionEntity.getTransactionType(), transactionEntity.getCreatedDate(),
+                transactionEntity.getState(), transactionEntity.isLive(),
+                transactionEntity.isMoto(), transactionEntity.getAmount(), transactionEntity.getFee());
+    }
+
+    @Test
+    public void shouldProjectTransactionSummaryIfEventIsPaymentCreatedAndNotDeductTransactionSummaryIfMultipleTerminalEventsExists() {
+        TransactionEntity transactionEntity = aTransactionFixture()
+                .withState(SUCCESS)
+                .toEntity();
+        Event event = EventFixture.anEventFixture().withEventDate(ZonedDateTime.now())
+                .withEventType(PAYMENT_CREATED.name()).toEntity();
+        Event event2 = EventFixture.anEventFixture().withEventDate(ZonedDateTime.now().plusSeconds(1))
+                .withEventType(USER_APPROVED_FOR_CAPTURE.name()).toEntity();
+        Event event3 = EventFixture.anEventFixture().withEventDate(ZonedDateTime.now().plusSeconds(2))
+                .withEventType(CAPTURE_ERRORED.name()).toEntity();
+        when(mockEventService.getEventsForResource(transactionEntity.getExternalId()))
+                .thenReturn(List.of(event, event2, event3));
+
+        transactionSummaryService.projectTransactionSummary(transactionEntity, event);
+
+        verify(mockTransactionSummaryDao).upsert(transactionEntity.getGatewayAccountId(),
+                transactionEntity.getTransactionType(), transactionEntity.getCreatedDate(),
+                transactionEntity.getState(), transactionEntity.isLive(),
+                transactionEntity.isMoto(), transactionEntity.getAmount());
+        verifyNoMoreInteractions(mockTransactionSummaryDao);
+    }
+
+    @Test
+    public void shouldUpdateTransactionSummaryForFeeIfCaptureConfirmedEventExists() {
+        TransactionEntity transactionEntity = aTransactionFixture()
+                .withState(SUCCESS)
+                .withFee(10L)
+                .toEntity();
+        Event event = EventFixture.anEventFixture().withEventDate(ZonedDateTime.now())
+                .withEventType(PAYMENT_CREATED.name()).toEntity();
+        Event event2 = EventFixture.anEventFixture().withEventDate(ZonedDateTime.now().plusSeconds(1))
+                .withEventType(CAPTURE_CONFIRMED.name()).toEntity();
+
+        when(mockEventService.getEventsForResource(transactionEntity.getExternalId()))
+                .thenReturn(List.of(event, event2));
+
+        transactionSummaryService.projectTransactionSummary(transactionEntity, event);
+
+        verify(mockTransactionSummaryDao).upsert(transactionEntity.getGatewayAccountId(),
+                transactionEntity.getTransactionType(), transactionEntity.getCreatedDate(),
+                transactionEntity.getState(), transactionEntity.isLive(),
+                transactionEntity.isMoto(), transactionEntity.getAmount());
+        verify(mockTransactionSummaryDao).updateFee(transactionEntity.getGatewayAccountId(),
+                transactionEntity.getTransactionType(), transactionEntity.getCreatedDate(),
+                transactionEntity.getState(), transactionEntity.isLive(),
+                transactionEntity.isMoto(), transactionEntity.getFee());
+        verifyNoMoreInteractions(mockTransactionSummaryDao);
+    }
+
+    @Test
+    public void shouldNotUpdateTransactionSummaryFoFeeIfFeeIsNotAvailableOnTransaction() {
+        TransactionEntity transactionEntity = aTransactionFixture()
+                .withState(SUCCESS)
+                .toEntity();
+        Event event = EventFixture.anEventFixture().withEventDate(ZonedDateTime.now())
+                .withEventType(PAYMENT_CREATED.name()).toEntity();
+        Event event2 = EventFixture.anEventFixture().withEventDate(ZonedDateTime.now().plusSeconds(1))
+                .withEventType(CAPTURE_CONFIRMED.name()).toEntity();
+
+        when(mockEventService.getEventsForResource(transactionEntity.getExternalId()))
+                .thenReturn(List.of(event, event2));
+
+        transactionSummaryService.projectTransactionSummary(transactionEntity, event);
+
+        verify(mockTransactionSummaryDao).upsert(transactionEntity.getGatewayAccountId(),
+                transactionEntity.getTransactionType(), transactionEntity.getCreatedDate(),
+                transactionEntity.getState(), transactionEntity.isLive(),
+                transactionEntity.isMoto(), transactionEntity.getAmount());
+
+        verifyNoMoreInteractions(mockTransactionSummaryDao);
+    }
+
+    @Test
+    public void shouldNotUpdateTransactionSummaryForFeeIfMultipleCaptureConfirmedEventsExists() {
+        TransactionEntity transactionEntity = aTransactionFixture()
+                .withState(SUCCESS)
+                .withFee(10L)
+                .toEntity();
+        Event event = EventFixture.anEventFixture().withEventDate(ZonedDateTime.now())
+                .withEventType(PAYMENT_CREATED.name()).toEntity();
+        Event event2 = EventFixture.anEventFixture().withEventDate(ZonedDateTime.now().plusSeconds(1))
+                .withEventType(CAPTURE_CONFIRMED.name()).toEntity();
+        Event event3 = EventFixture.anEventFixture().withEventDate(ZonedDateTime.now().plusSeconds(2))
+                .withEventType(CAPTURE_CONFIRMED.name()).toEntity();
+
+        when(mockEventService.getEventsForResource(transactionEntity.getExternalId()))
+                .thenReturn(List.of(event, event2, event3));
+
+        transactionSummaryService.projectTransactionSummary(transactionEntity, event3);
+
+        verifyNoInteractions(mockTransactionSummaryDao);
+    }
+
+    @Test
+    public void shouldNotProjectTransactionSummaryIfCurrentEventMapsToSameTransactionStateAsPreviousEvent() {
+        TransactionEntity transactionEntity = aTransactionFixture()
+                .withState(SUCCESS)
+                .toEntity();
+        Event event = EventFixture.anEventFixture().withEventDate(ZonedDateTime.now())
+                .withEventType(PAYMENT_CREATED.name()).toEntity();
+        Event event2 = EventFixture.anEventFixture()
+                .withEventDate(ZonedDateTime.now().plusSeconds(1))
+                .withEventType(USER_APPROVED_FOR_CAPTURE.name()).toEntity();
+        Event event3 = EventFixture.anEventFixture()
+                .withEventDate(ZonedDateTime.now().plusSeconds(2))
+                .withEventType(CAPTURE_SUBMITTED.name()).toEntity();
+        when(mockEventService.getEventsForResource(transactionEntity.getExternalId()))
+                .thenReturn(List.of(event, event2, event3));
+
+        transactionSummaryService.projectTransactionSummary(transactionEntity, event3);
+
+        verifyNoInteractions(mockTransactionSummaryDao);
+    }
+
+    @Test
+    public void shouldNotProjectTransactionSummaryIfOnlyPaymentCreatedEventExists() {
+        TransactionEntity transactionEntity = aTransactionFixture()
+                .withState(CREATED)
+                .toEntity();
+        Event event = EventFixture.anEventFixture().withEventType(PAYMENT_CREATED.name()).toEntity();
+
+        transactionSummaryService.projectTransactionSummary(transactionEntity, event);
+
+        verifyNoInteractions(mockTransactionSummaryDao);
+    }
+
+    @Test
+    public void shouldNotProjectTransactionSummaryIfAnEventMappingToTransactionFinishedStateExistsButPaymentCreatedEventDoNotExists() {
+        TransactionEntity transactionEntity = aTransactionFixture()
+                .withState(SUCCESS)
+                .toEntity();
+        Event event = EventFixture.anEventFixture().withEventType(USER_APPROVED_FOR_CAPTURE.name()).toEntity();
+        when(mockEventService.getEventsForResource(transactionEntity.getExternalId()))
+                .thenReturn(List.of(event));
+
+        transactionSummaryService.projectTransactionSummary(transactionEntity, event);
+
+        verifyNoInteractions(mockTransactionSummaryDao);
+    }
+
+    @Test
+    public void shouldNotProjectTransactionSummaryIfEventIsSalientEventButDoesNotMapToTransactionFinishedState() {
+        TransactionEntity transactionEntity = aTransactionFixture()
+                .withState(SUBMITTED)
+                .toEntity();
+        Event event = EventFixture.anEventFixture().withEventType(AUTHORISATION_SUCCEEDED.name()).toEntity();
+
+        transactionSummaryService.projectTransactionSummary(transactionEntity, event);
+
+        verifyNoInteractions(mockTransactionSummaryDao);
+    }
+
+    @Test
+    public void shouldNotProjectTransactionSummaryIfCurrentEventIsNonSalientEventAndTransactionIsFinished() {
+        TransactionEntity transactionEntity = aTransactionFixture()
+                .withState(SUCCESS)
+                .toEntity();
+        Event nonSalientEvent = EventFixture.anEventFixture()
+                .withEventDate(ZonedDateTime.now())
+                .withEventType("BACKFILLER_RECREATED_USER_EMAIL_COLLECTED").toEntity();
+
+        transactionSummaryService.projectTransactionSummary(transactionEntity, nonSalientEvent);
+
+        verifyNoInteractions(mockTransactionSummaryDao);
+    }
+
+    @Test
+    public void shouldNotProjectTransactionSummaryIfEventIsNotAPaymentEvent() {
+        TransactionEntity transactionEntity = aTransactionFixture()
+                .withState(SUBMITTED)
+                .toEntity();
+        Event event = EventFixture.anEventFixture().withEventType(REFUND_SUBMITTED.name()).toEntity();
+
+        transactionSummaryService.projectTransactionSummary(transactionEntity, event);
+
+        verifyNoInteractions(mockTransactionSummaryDao);
+    }
+}

--- a/src/test/resources/config/test-config.yaml
+++ b/src/test/resources/config/test-config.yaml
@@ -58,8 +58,8 @@ sqsConfig:
 queueMessageReceiverConfig:
   backgroundProcessingEnabled: ${BACKGROUND_PROCESSING_ENABLED:-false}
   threadDelayInMilliseconds: ${QUEUE_MESSAGE_RECEIVER_THREAD_DELAY_IN_MILLISECONDS:-1}
-  numberOfThreads: ${QUEUE_MESSAGE_RECEIVER_NUMBER_OF_THREADS:-1}
-  messageRetryDelayInSeconds: ${QUEUE_MESSAGE_RETRY_DELAY_IN_SECONDS:-900}
+  numberOfThreads: ${QUEUE_MESSAGE_RECEIVER_NUMBER_OF_THREADS:-3}
+  messageRetryDelayInSeconds: ${QUEUE_MESSAGE_RETRY_DELAY_IN_SECONDS:-1}
 
 reportingConfig:
   streamingCsvPageSize: ${STREAMING_CSV_PAGE_SIZE:-5000}


### PR DESCRIPTION
## WHAT
- Projects transaction summary from event stream when transaction state is finished
	- To be able to project transaction summary, PAYMENT_CREATED event should exists for the transaction as this event carries required information (gateway_account_id, moto, live, amount) along with a terminal event. So projects transaction summary if event is PAYMENT_CREATED event and transaction state is finished or for an event that maps to transaction finished state.
	- In case of multiple events (ex: USER_APPROVED_FOR_CAPTURE, CAPTURE_SUBMITTED, CAPTURED_CONFIRMED) leading to same terminal state, transaction_summary is updated only once to avoid updating summary multiple times for a payment.
- Projects fee for CAPTURE_CONFIRMED event as fee is expected only on this event. Multiple CAPTURE_CONFIRMED events with different event timestamps are ignored in this case.