### PR TITLE
PP-8050 Use LocalDate for transaction summary

### DIFF
--- a/src/main/java/uk/gov/pay/ledger/transactionsummary/dao/TransactionSummaryDao.java
+++ b/src/main/java/uk/gov/pay/ledger/transactionsummary/dao/TransactionSummaryDao.java
@@ -81,7 +81,7 @@ public class TransactionSummaryDao {
         this.jdbi = jdbi;
     }
 
-    public void upsert(String gatewayAccountId, String transactionType, ZonedDateTime transactionDate,
+    public void upsert(String gatewayAccountId, String transactionType, LocalDate transactionDate,
                        TransactionState state, boolean live, boolean moto, Long amount) {
         jdbi.withHandle(handle ->
                 handle.createUpdate(UPSERT_STRING)
@@ -96,7 +96,7 @@ public class TransactionSummaryDao {
         );
     }
 
-    public void updateFee(String gatewayAccountId, String transactionType, ZonedDateTime transactionDate,
+    public void updateFee(String gatewayAccountId, String transactionType, LocalDate transactionDate,
                           TransactionState state, boolean live, boolean moto, Long fee) {
         jdbi.withHandle(handle ->
                 handle.createUpdate(UPDATE_FEE)
@@ -112,7 +112,7 @@ public class TransactionSummaryDao {
     }
 
     public void deductTransactionSummaryFor(String gatewayAccountId, String transactionType,
-                                            ZonedDateTime transactionDate, TransactionState state, boolean live,
+                                            LocalDate transactionDate, TransactionState state, boolean live,
                                             boolean moto, Long amount, Long fee) {
         jdbi.withHandle(handle ->
                 handle.createUpdate(DEDUCT_TRANSACTION_SUMMARY)

--- a/src/test/java/uk/gov/pay/ledger/queue/QueueMessageReceiverIT.java
+++ b/src/test/java/uk/gov/pay/ledger/queue/QueueMessageReceiverIT.java
@@ -14,6 +14,7 @@ import uk.gov.pay.ledger.transaction.entity.TransactionEntity;
 import uk.gov.pay.ledger.util.DatabaseTestHelper;
 import uk.gov.pay.ledger.util.fixture.QueuePaymentEventFixture;
 
+import java.time.LocalDate;
 import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Map;
@@ -278,7 +279,7 @@ public class QueueMessageReceiverIT {
 
         Thread.sleep(500);
 
-        List<Map<String, Object>> transactionSummary = dbHelper.getTransactionSummary(gatewayAccountId, PAYMENT, SUCCESS, CREATED_AT, true, false);
+        List<Map<String, Object>> transactionSummary = dbHelper.getTransactionSummary(gatewayAccountId, PAYMENT, SUCCESS, LocalDate.parse("2019-06-07"), true, false);
 
         assertThat(transactionSummary.get(0).get("gateway_account_id"), is(gatewayAccountId));
         assertThat(transactionSummary.get(0).get("transaction_date").toString(), Matchers.is("2019-06-07"));

--- a/src/test/java/uk/gov/pay/ledger/report/resource/PerformanceReportResourceIT.java
+++ b/src/test/java/uk/gov/pay/ledger/report/resource/PerformanceReportResourceIT.java
@@ -10,12 +10,12 @@ import uk.gov.pay.ledger.util.DatabaseTestHelper;
 import uk.gov.service.payments.commons.model.ErrorIdentifier;
 
 import javax.ws.rs.core.Response;
-import java.time.ZonedDateTime;
 import java.util.stream.LongStream;
 import java.util.stream.Stream;
 
 import static io.restassured.RestAssured.given;
 import static io.restassured.http.ContentType.JSON;
+import static java.time.LocalDate.parse;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.Matchers.contains;
 import static uk.gov.pay.ledger.transaction.model.TransactionType.PAYMENT;
@@ -103,8 +103,8 @@ public class PerformanceReportResourceIT {
 
     @Test
     public void report_volume_total_amount_and_average_amount_for_date_range() {
-        Stream.of("2019-12-12T10:00:00Z", "2019-12-11T10:00:00Z", "2017-11-30T10:00:00Z").forEach(time -> aTransactionSummaryFixture()
-                .withTransactionDate(ZonedDateTime.parse(time))
+        Stream.of("2019-12-12", "2019-12-11", "2017-11-30").forEach(date -> aTransactionSummaryFixture()
+                .withTransactionDate(parse(date))
                 .withAmount(1000L)
                 .withState(TransactionState.SUCCESS)
                 .withType(PAYMENT)
@@ -140,8 +140,8 @@ public class PerformanceReportResourceIT {
 
     @Test
     public void report_volume_total_amount_and_average_amount_for_date_range_per_gateway_account() {
-        Stream.of("2019-12-12T10:00:00Z", "2019-12-11T10:00:00Z", "2017-11-30T10:00:00Z").forEach(time -> aTransactionSummaryFixture()
-                .withTransactionDate(ZonedDateTime.parse(time))
+        Stream.of("2019-12-12", "2019-12-11", "2017-11-30").forEach(date -> aTransactionSummaryFixture()
+                .withTransactionDate(parse(date))
                 .withAmount(1000L)
                 .withGatewayAccountId("1")
                 .withState(TransactionState.SUCCESS)
@@ -150,8 +150,8 @@ public class PerformanceReportResourceIT {
                 .withNoOfTransactions(1L)
                 .insert(rule.getJdbi()));
 
-        Stream.of("2019-12-12T10:00:00Z", "2019-12-11T10:00:00Z", "2017-11-30T10:00:00Z").forEach(time -> aTransactionSummaryFixture()
-                .withTransactionDate(ZonedDateTime.parse(time))
+        Stream.of("2019-12-12", "2019-12-11", "2017-11-30").forEach(date -> aTransactionSummaryFixture()
+                .withTransactionDate(parse(date))
                 .withAmount(1000L)
                 .withGatewayAccountId("2")
                 .withState(TransactionState.SUCCESS)

--- a/src/test/java/uk/gov/pay/ledger/transactionsummary/dao/TransactionSummaryDaoIT.java
+++ b/src/test/java/uk/gov/pay/ledger/transactionsummary/dao/TransactionSummaryDaoIT.java
@@ -13,13 +13,12 @@ import uk.gov.pay.ledger.util.fixture.TransactionSummaryFixture;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
-import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
 
 import static java.math.BigDecimal.ZERO;
-import static java.time.ZonedDateTime.parse;
+import static java.time.LocalDate.parse;
 import static org.apache.commons.lang3.RandomStringUtils.randomAlphanumeric;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
@@ -51,12 +50,12 @@ public class TransactionSummaryDaoIT {
         String gatewayAccountId1 = "account-" + randomAlphanumeric(10);
         String gatewayAccountId2 = "account-" + randomAlphanumeric(10);
         transactionSummaryDao.upsert(gatewayAccountId1, "PAYMENT",
-                parse("2018-09-22T08:46:01.123456Z"), SUCCESS, false, false, 100L);
+                parse("2018-09-22"), SUCCESS, false, false, 100L);
         transactionSummaryDao.upsert(gatewayAccountId2, "PAYMENT",
-                parse("2018-09-23T09:46:01.123456Z"), FAILED_REJECTED, true, true, 200L);
+                parse("2018-09-23"), FAILED_REJECTED, true, true, 200L);
 
         List<Map<String, Object>> transactionSummary = dbHelper.getTransactionSummary(gatewayAccountId1, PAYMENT,
-                SUCCESS, parse("2018-09-22T00:00:00.000000Z"), false, false);
+                SUCCESS, parse("2018-09-22"), false, false);
         assertThat(transactionSummary.get(0).get("gateway_account_id"), is(gatewayAccountId1));
         assertThat(transactionSummary.get(0).get("transaction_date").toString(), is("2018-09-22"));
         assertThat(transactionSummary.get(0).get("state"), is("SUCCESS"));
@@ -66,7 +65,7 @@ public class TransactionSummaryDaoIT {
         assertThat(transactionSummary.get(0).get("no_of_transactions"), is(1L));
 
         transactionSummary = dbHelper.getTransactionSummary(gatewayAccountId2, PAYMENT,
-                FAILED_REJECTED, parse("2018-09-23T00:00:00.000000Z"), true, true);
+                FAILED_REJECTED, parse("2018-09-23"), true, true);
         assertThat(transactionSummary.get(0).get("gateway_account_id"), is(gatewayAccountId2));
         assertThat(transactionSummary.get(0).get("transaction_date").toString(), is("2018-09-23"));
         assertThat(transactionSummary.get(0).get("state"), is("FAILED_REJECTED"));
@@ -81,7 +80,7 @@ public class TransactionSummaryDaoIT {
         String gatewayAccountId = "account-" + randomAlphanumeric(10);
         TransactionSummaryFixture transactionSummaryFixture = aTransactionSummaryFixture()
                 .withGatewayAccountId(gatewayAccountId)
-                .withTransactionDate(parse("2018-09-22T00:00:00.000000Z"))
+                .withTransactionDate(parse("2018-09-22"))
                 .withType(PAYMENT)
                 .withState(SUCCESS)
                 .withAmount(1000L)
@@ -93,7 +92,7 @@ public class TransactionSummaryDaoIT {
                 false, false, 123L);
 
         List<Map<String, Object>> transactionSummary = dbHelper.getTransactionSummary(gatewayAccountId, PAYMENT,
-                SUCCESS, parse("2018-09-22T00:00:00.000000Z"), false, false);
+                SUCCESS, parse("2018-09-22"), false, false);
         assertThat(transactionSummary.get(0).get("gateway_account_id"), is(gatewayAccountId));
         assertThat(transactionSummary.get(0).get("transaction_date").toString(), is("2018-09-22"));
         assertThat(transactionSummary.get(0).get("state"), is("SUCCESS"));
@@ -108,7 +107,7 @@ public class TransactionSummaryDaoIT {
         String gatewayAccountId = "account-" + randomAlphanumeric(10);
         TransactionSummaryFixture transactionSummaryFixture = aTransactionSummaryFixture()
                 .withGatewayAccountId(gatewayAccountId)
-                .withTransactionDate(parse("2018-09-22T00:00:00.000000Z"))
+                .withTransactionDate(parse("2018-09-22"))
                 .withType(PAYMENT)
                 .withState(SUCCESS)
                 .withAmount(1000L)
@@ -120,7 +119,7 @@ public class TransactionSummaryDaoIT {
                 false, false, 123L, 23L);
 
         List<Map<String, Object>> transactionSummary = dbHelper.getTransactionSummary(gatewayAccountId, PAYMENT,
-                SUCCESS, parse("2018-09-22T00:00:00.000000Z"), false, false);
+                SUCCESS, parse("2018-09-22"), false, false);
         assertThat(transactionSummary.get(0).get("gateway_account_id"), is(gatewayAccountId));
         assertThat(transactionSummary.get(0).get("transaction_date").toString(), is("2018-09-22"));
         assertThat(transactionSummary.get(0).get("state"), is("SUCCESS"));
@@ -136,7 +135,7 @@ public class TransactionSummaryDaoIT {
         String gatewayAccountId = "account-" + randomAlphanumeric(10);
         TransactionSummaryFixture transactionSummaryFixture = aTransactionSummaryFixture()
                 .withGatewayAccountId(gatewayAccountId)
-                .withTransactionDate(parse("2018-09-22T00:00:00.000000Z"))
+                .withTransactionDate(parse("2018-09-22"))
                 .withType(PAYMENT)
                 .withState(SUCCESS)
                 .withAmount(1000L)
@@ -148,7 +147,7 @@ public class TransactionSummaryDaoIT {
                 false, false, 23L);
 
         List<Map<String, Object>> transactionSummary = dbHelper.getTransactionSummary(gatewayAccountId, PAYMENT,
-                SUCCESS, parse("2018-09-22T00:00:00.000000Z"), false, false);
+                SUCCESS, parse("2018-09-22"), false, false);
         assertThat(transactionSummary.get(0).get("gateway_account_id"), is(gatewayAccountId));
         assertThat(transactionSummary.get(0).get("transaction_date").toString(), is("2018-09-22"));
         assertThat(transactionSummary.get(0).get("state"), is("SUCCESS"));
@@ -166,7 +165,7 @@ public class TransactionSummaryDaoIT {
                 .withState(STARTED)
                 .withType(PAYMENT)
                 .withLive(true)
-                .withTransactionDate(ZonedDateTime.parse("2019-01-01T02:00:00Z"))
+                .withTransactionDate(parse("2019-01-01"))
                 .insert(rule.getJdbi());
 
         aTransactionSummaryFixture()
@@ -175,7 +174,7 @@ public class TransactionSummaryDaoIT {
                 .withState(SUCCESS)
                 .withType(REFUND)
                 .withLive(true)
-                .withTransactionDate(ZonedDateTime.parse("2019-01-01T02:00:00Z"))
+                .withTransactionDate(parse("2019-01-01"))
                 .insert(rule.getJdbi());
 
         aTransactionSummaryFixture()
@@ -184,7 +183,7 @@ public class TransactionSummaryDaoIT {
                 .withState(SUCCESS)
                 .withType(PAYMENT)
                 .withLive(true)
-                .withTransactionDate(ZonedDateTime.parse("2018-01-01T02:00:00Z"))
+                .withTransactionDate(parse("2018-01-01"))
                 .insert(rule.getJdbi());
 
         List<String> relevantGatewayAccounts = List.of("1", "2");
@@ -195,12 +194,12 @@ public class TransactionSummaryDaoIT {
                 .withState(SUCCESS)
                 .withType(PAYMENT)
                 .withLive(true)
-                .withTransactionDate(ZonedDateTime.parse("2019-01-01T02:00:00Z"))
+                .withTransactionDate(parse("2019-01-01"))
                 .insert(rule.getJdbi()));
 
         BigDecimal expectedValue = BigDecimal.valueOf(1000);
-        LocalDate startDate = LocalDate.parse("2019-01-01");
-        LocalDate endDate = LocalDate.parse("2019-02-01");
+        LocalDate startDate = parse("2019-01-01");
+        LocalDate endDate = parse("2019-02-01");
 
         List<GatewayAccountMonthlyPerformanceReportEntity> performanceReport = transactionSummaryDao.monthlyPerformanceReportForGatewayAccounts(startDate, endDate);
 
@@ -226,8 +225,8 @@ public class TransactionSummaryDaoIT {
 
     @Test
     public void report_volume_total_amount_and_average_amount_for_date_range() {
-        Stream.of("2019-12-31T10:00:00Z", "2019-12-30T10:00:00Z", "2017-11-29T10:00:00Z").forEach(time -> aTransactionSummaryFixture()
-                .withTransactionDate(ZonedDateTime.parse(time))
+        Stream.of("2019-12-31", "2019-12-30", "2017-11-29").forEach(date -> aTransactionSummaryFixture()
+                .withTransactionDate(LocalDate.parse(date))
                 .withAmount(100L)
                 .withState(TransactionState.SUCCESS)
                 .withType(PAYMENT)
@@ -235,8 +234,8 @@ public class TransactionSummaryDaoIT {
                 .withNoOfTransactions(1L)
                 .insert(rule.getJdbi()));
 
-        Stream.of("2019-12-12T10:00:00Z", "2019-12-11T10:00:00Z", "2017-11-30T10:00:00Z").forEach(time -> aTransactionSummaryFixture()
-                .withTransactionDate(ZonedDateTime.parse(time))
+        Stream.of("2019-12-12", "2019-12-11", "2017-11-30").forEach(date -> aTransactionSummaryFixture()
+                .withTransactionDate(LocalDate.parse(date))
                 .withAmount(1000L)
                 .withState(TransactionState.SUCCESS)
                 .withType(PAYMENT)

--- a/src/test/java/uk/gov/pay/ledger/transactionsummary/service/TransactionSummaryServiceTest.java
+++ b/src/test/java/uk/gov/pay/ledger/transactionsummary/service/TransactionSummaryServiceTest.java
@@ -11,9 +11,11 @@ import uk.gov.pay.ledger.transaction.entity.TransactionEntity;
 import uk.gov.pay.ledger.transactionsummary.dao.TransactionSummaryDao;
 import uk.gov.pay.ledger.util.fixture.EventFixture;
 
+import java.time.LocalDate;
 import java.time.ZonedDateTime;
 import java.util.List;
 
+import static java.time.ZoneOffset.UTC;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
@@ -64,7 +66,7 @@ public class TransactionSummaryServiceTest {
         transactionSummaryService.projectTransactionSummary(transactionEntity, paymentCreatedEvent);
 
         verify(mockTransactionSummaryDao).upsert(transactionEntity.getGatewayAccountId(),
-                transactionEntity.getTransactionType(), transactionEntity.getCreatedDate(),
+                transactionEntity.getTransactionType(), LocalDate.ofInstant(transactionEntity.getCreatedDate().toInstant(), UTC),
                 transactionEntity.getState(), transactionEntity.isLive(),
                 transactionEntity.isMoto(), transactionEntity.getAmount());
         verifyNoMoreInteractions(mockTransactionSummaryDao);
@@ -88,11 +90,11 @@ public class TransactionSummaryServiceTest {
         transactionSummaryService.projectTransactionSummary(transactionEntity, event3);
 
         verify(mockTransactionSummaryDao).upsert(transactionEntity.getGatewayAccountId(),
-                transactionEntity.getTransactionType(), transactionEntity.getCreatedDate(),
+                transactionEntity.getTransactionType(), LocalDate.ofInstant(transactionEntity.getCreatedDate().toInstant(), UTC),
                 transactionEntity.getState(), transactionEntity.isLive(),
                 transactionEntity.isMoto(), transactionEntity.getAmount());
         verify(mockTransactionSummaryDao).deductTransactionSummaryFor(transactionEntity.getGatewayAccountId(),
-                transactionEntity.getTransactionType(), transactionEntity.getCreatedDate(),
+                transactionEntity.getTransactionType(), LocalDate.ofInstant(transactionEntity.getCreatedDate().toInstant(), UTC),
                 transactionEntity.getState(), transactionEntity.isLive(),
                 transactionEntity.isMoto(), transactionEntity.getAmount(), transactionEntity.getFee());
     }
@@ -114,7 +116,7 @@ public class TransactionSummaryServiceTest {
         transactionSummaryService.projectTransactionSummary(transactionEntity, event);
 
         verify(mockTransactionSummaryDao).upsert(transactionEntity.getGatewayAccountId(),
-                transactionEntity.getTransactionType(), transactionEntity.getCreatedDate(),
+                transactionEntity.getTransactionType(), LocalDate.ofInstant(transactionEntity.getCreatedDate().toInstant(), UTC),
                 transactionEntity.getState(), transactionEntity.isLive(),
                 transactionEntity.isMoto(), transactionEntity.getAmount());
         verifyNoMoreInteractions(mockTransactionSummaryDao);
@@ -137,11 +139,11 @@ public class TransactionSummaryServiceTest {
         transactionSummaryService.projectTransactionSummary(transactionEntity, event);
 
         verify(mockTransactionSummaryDao).upsert(transactionEntity.getGatewayAccountId(),
-                transactionEntity.getTransactionType(), transactionEntity.getCreatedDate(),
+                transactionEntity.getTransactionType(), LocalDate.ofInstant(transactionEntity.getCreatedDate().toInstant(), UTC),
                 transactionEntity.getState(), transactionEntity.isLive(),
                 transactionEntity.isMoto(), transactionEntity.getAmount());
         verify(mockTransactionSummaryDao).updateFee(transactionEntity.getGatewayAccountId(),
-                transactionEntity.getTransactionType(), transactionEntity.getCreatedDate(),
+                transactionEntity.getTransactionType(), LocalDate.ofInstant(transactionEntity.getCreatedDate().toInstant(), UTC),
                 transactionEntity.getState(), transactionEntity.isLive(),
                 transactionEntity.isMoto(), transactionEntity.getFee());
         verifyNoMoreInteractions(mockTransactionSummaryDao);
@@ -163,7 +165,7 @@ public class TransactionSummaryServiceTest {
         transactionSummaryService.projectTransactionSummary(transactionEntity, event);
 
         verify(mockTransactionSummaryDao).upsert(transactionEntity.getGatewayAccountId(),
-                transactionEntity.getTransactionType(), transactionEntity.getCreatedDate(),
+                transactionEntity.getTransactionType(), LocalDate.ofInstant(transactionEntity.getCreatedDate().toInstant(), UTC),
                 transactionEntity.getState(), transactionEntity.isLive(),
                 transactionEntity.isMoto(), transactionEntity.getAmount());
 

--- a/src/test/java/uk/gov/pay/ledger/util/DatabaseTestHelper.java
+++ b/src/test/java/uk/gov/pay/ledger/util/DatabaseTestHelper.java
@@ -4,7 +4,7 @@ import org.jdbi.v3.core.Jdbi;
 import uk.gov.pay.ledger.transaction.model.TransactionType;
 import uk.gov.pay.ledger.transaction.state.TransactionState;
 
-import java.time.ZonedDateTime;
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Map;
 
@@ -85,7 +85,7 @@ public class DatabaseTestHelper {
     }
 
     public List<Map<String, Object>> getTransactionSummary(String gatewayAccountId, TransactionType type,
-                                                           TransactionState state, ZonedDateTime transactionDate,
+                                                           TransactionState state, LocalDate transactionDate,
                                                            boolean live, boolean moto) {
         return jdbi.withHandle(handle ->
                 handle.createQuery("SELECT * FROM transaction_summary where gateway_account_id = :gatewayAccountId" +

--- a/src/test/java/uk/gov/pay/ledger/util/fixture/TransactionSummaryFixture.java
+++ b/src/test/java/uk/gov/pay/ledger/util/fixture/TransactionSummaryFixture.java
@@ -6,15 +6,17 @@ import org.jdbi.v3.core.Jdbi;
 import uk.gov.pay.ledger.transaction.model.TransactionType;
 import uk.gov.pay.ledger.transaction.state.TransactionState;
 
+import java.time.LocalDate;
 import java.time.ZonedDateTime;
 
-import static java.time.ZonedDateTime.parse;
+import static java.time.LocalDate.parse;
+
 
 public class TransactionSummaryFixture {
     private String gatewayAccountId = RandomStringUtils.randomAlphanumeric(10);
     private TransactionType type = TransactionType.PAYMENT;
     private TransactionState state = TransactionState.SUCCESS;
-    private ZonedDateTime transactionDate = parse("2018-09-22T10:13:16.067Z");
+    private LocalDate transactionDate = parse("2018-09-22");
     private boolean live;
     private boolean moto;
     private Long amount = RandomUtils.nextLong(1, 99999);
@@ -69,7 +71,7 @@ public class TransactionSummaryFixture {
         return this;
     }
 
-    public TransactionSummaryFixture withTransactionDate(ZonedDateTime transactionDate) {
+    public TransactionSummaryFixture withTransactionDate(LocalDate transactionDate) {
         this.transactionDate = transactionDate;
         return this;
     }
@@ -111,7 +113,7 @@ public class TransactionSummaryFixture {
         return state;
     }
 
-    public ZonedDateTime getTransactionDate() {
+    public LocalDate getTransactionDate() {
         return transactionDate;
     }
 


### PR DESCRIPTION
# WHAT
- Use LocalDate explicitly for operations on transaction summary instead of using ZonedDateTime as granualarity of data (in transaction_summary) is at day level