### PR TITLE
PP-7918: Create table to test the concourse db migration

### DIFF
--- a/src/main/resources/migrations/00062_create_table_to_test_concourse_db_migration.sql
+++ b/src/main/resources/migrations/00062_create_table_to_test_concourse_db_migration.sql
@@ -1,0 +1,7 @@
+--liquibase formatted sql
+
+--changeset uk.gov.pay:test_concourse_db_migration
+CREATE TABLE test_concourse_db_migration (
+    id BIGSERIAL PRIMARY KEY
+);
+--rollback drop table test_concourse_db_migration;


### PR DESCRIPTION
We want to test the [ledger database migration job](https://cd.gds-reliability.engineering/teams/pay-dev/pipelines/deploy-to-test/jobs/ledger-db-migration/).
This table will be deleted.