### PR TITLE
PP-7918: Drop the table that tested the concourse db migration

### DIFF
--- a/src/main/resources/migrations/00063_drop_test_concourse_db_migration.sql
+++ b/src/main/resources/migrations/00063_drop_test_concourse_db_migration.sql
@@ -1,0 +1,4 @@
+--liquibase formatted sql
+
+--changeset uk.gov.pay:test_concourse_db_migration
+drop table test_concourse_db_migration;


### PR DESCRIPTION
The database migration ran
[successfully](https://cd.gds-reliability.engineering/teams/pay-dev/pipelines/deploy-to-test/jobs/ledger-db-migration/builds/24)
so reverting the test table.