### PR TITLE
PP-8050 Project transaction_summary for new events only

### DIFF
--- a/src/main/java/uk/gov/pay/ledger/queue/EventDigestHandler.java
+++ b/src/main/java/uk/gov/pay/ledger/queue/EventDigestHandler.java
@@ -52,7 +52,7 @@ public class EventDigestHandler {
         }
     }
 
-    public void processEvent(Event event) {
-        processorFor(event).process(event);
+    public void processEvent(Event event, boolean isANewEvent) {
+        processorFor(event).process(event, isANewEvent);
     }
 }

--- a/src/main/java/uk/gov/pay/ledger/queue/eventprocessor/EventProcessor.java
+++ b/src/main/java/uk/gov/pay/ledger/queue/eventprocessor/EventProcessor.java
@@ -3,5 +3,5 @@ package uk.gov.pay.ledger.queue.eventprocessor;
 import uk.gov.pay.ledger.event.model.Event;
 
 public abstract class EventProcessor {
-    public abstract void process(Event event);
+    public abstract void process(Event event, boolean isANewEvent);
 }

--- a/src/main/java/uk/gov/pay/ledger/queue/eventprocessor/PaymentEventProcessor.java
+++ b/src/main/java/uk/gov/pay/ledger/queue/eventprocessor/PaymentEventProcessor.java
@@ -38,7 +38,7 @@ public class PaymentEventProcessor extends EventProcessor {
     }
 
     @Override
-    public void process(Event event) {
+    public void process(Event event, boolean isANewEvent) {
         List<Event> events = eventService.getEventsForResource(event.getResourceExternalId());
         EventDigest paymentEventDigest = EventDigest.fromEventList(events);
 
@@ -67,8 +67,8 @@ public class PaymentEventProcessor extends EventProcessor {
                     .forEach(refundTransactionEntity -> refundEventProcessor.reprojectRefundTransaction(refundTransactionEntity.getExternalId(), paymentEventDigest));
         }
 
-        if (!event.isReprojectDomainObject()) {
-            transactionSummaryService.projectTransactionSummary(transactionEntity, event);
+        if (!event.isReprojectDomainObject() && isANewEvent) {
+            transactionSummaryService.projectTransactionSummary(transactionEntity, event, events);
         }
     }
 

--- a/src/main/java/uk/gov/pay/ledger/queue/eventprocessor/PayoutEventProcessor.java
+++ b/src/main/java/uk/gov/pay/ledger/queue/eventprocessor/PayoutEventProcessor.java
@@ -14,7 +14,7 @@ public class PayoutEventProcessor extends EventProcessor {
     }
 
     @Override
-    public void process(Event event) {
+    public void process(Event event, boolean isANewEvent) {
         payoutService.upsertPayoutFor(eventService.getEventDigestForResource(event));
     }
 }

--- a/src/main/java/uk/gov/pay/ledger/queue/eventprocessor/RefundEventProcessor.java
+++ b/src/main/java/uk/gov/pay/ledger/queue/eventprocessor/RefundEventProcessor.java
@@ -29,7 +29,7 @@ public class RefundEventProcessor extends EventProcessor {
     }
 
     @Override
-    public void process(Event event) {
+    public void process(Event event, boolean isANewEvent) {
         EventDigest refundEventDigest = eventService.getEventDigestForResource(event);
         Optional<EventDigest> mayBePaymentEventDigest = Optional.empty();
 

--- a/src/main/java/uk/gov/pay/ledger/transactionsummary/service/TransactionSummaryService.java
+++ b/src/main/java/uk/gov/pay/ledger/transactionsummary/service/TransactionSummaryService.java
@@ -3,8 +3,8 @@ package uk.gov.pay.ledger.transactionsummary.service;
 import com.google.inject.Inject;
 import uk.gov.pay.ledger.event.model.Event;
 import uk.gov.pay.ledger.event.model.SalientEventType;
-import uk.gov.pay.ledger.event.service.EventService;
 import uk.gov.pay.ledger.transaction.entity.TransactionEntity;
+import uk.gov.pay.ledger.transaction.model.TransactionType;
 import uk.gov.pay.ledger.transaction.state.TransactionState;
 import uk.gov.pay.ledger.transactionsummary.dao.TransactionSummaryDao;
 
@@ -16,65 +16,69 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 
 import static java.time.ZoneOffset.UTC;
-import static java.time.ZonedDateTime.parse;
 import static uk.gov.pay.ledger.event.model.SalientEventType.CAPTURE_CONFIRMED;
+import static uk.gov.pay.ledger.event.model.SalientEventType.CAPTURE_SUBMITTED;
 import static uk.gov.pay.ledger.event.model.SalientEventType.PAYMENT_CREATED;
 import static uk.gov.pay.ledger.event.model.SalientEventType.from;
-import static uk.gov.pay.ledger.transaction.model.TransactionType.PAYMENT;
 
 public class TransactionSummaryService {
 
     private final TransactionSummaryDao transactionSummaryDao;
-    private final EventService eventService;
+
+    private final List<String> ignoreEventsForTransactionAmount = List.of(CAPTURE_CONFIRMED.name(),
+            CAPTURE_SUBMITTED.name());
 
     @Inject
-    public TransactionSummaryService(TransactionSummaryDao transactionSummaryDao, EventService eventService) {
+    public TransactionSummaryService(TransactionSummaryDao transactionSummaryDao) {
         this.transactionSummaryDao = transactionSummaryDao;
-        this.eventService = eventService;
     }
 
-    public void projectTransactionSummary(TransactionEntity transaction, Event currentEvent) {
-        if (PAYMENT.name().equals(transaction.getTransactionType())) {
-            projectPaymentTransactionSummary(transaction, currentEvent);
+    public void projectTransactionSummary(TransactionEntity transaction, Event currentEvent, List<Event> events) {
+        if (TransactionType.PAYMENT.name().equals(transaction.getTransactionType())) {
+            projectPaymentTransactionSummary(transaction, currentEvent, events);
         }
     }
 
-    private void projectPaymentTransactionSummary(TransactionEntity transaction, Event currentEvent) {
-
+    private void projectPaymentTransactionSummary(TransactionEntity transaction, Event currentEvent,
+                                                  List<Event> events) {
         if (!canProjectTransactionSummary(transaction, currentEvent)) {
             return;
         }
 
-        List<Event> events = eventService.getEventsForResource(transaction.getExternalId());
-        boolean hasPaymentCreatedEvent = hasSalientEvent(events, PAYMENT_CREATED);
-
-        if (!hasPaymentCreatedEvent) {
+        if (!hasPaymentCreatedOrNotificationEvent(events)) {
             return;
         }
 
-        List<Event> eventsMappingToFinishedState =
-                getEventsMappingToTransactionFinishedStateInDescendingOrder(events);
-        Optional<SalientEventType> mayBeCurrentSalientEventType = from(currentEvent.getEventType());
+        if (!ignoreEventsForTransactionAmount.contains(currentEvent.getEventType())) {
+            projectTransactionAmount(transaction, currentEvent, events);
+        }
 
-        projectTransactionAmount(transaction, currentEvent, eventsMappingToFinishedState);
-        projectTransactionFee(transaction, mayBeCurrentSalientEventType.get(), eventsMappingToFinishedState);
+        Optional<SalientEventType> mayBeCurrentSalientEventType = from(currentEvent.getEventType());
+        mayBeCurrentSalientEventType.ifPresent(salientEventType ->
+                projectTransactionFee(transaction, mayBeCurrentSalientEventType.get(), events));
     }
 
     private boolean canProjectTransactionSummary(TransactionEntity transaction, Event currentEvent) {
-        SalientEventType currentSalientEventType = from(currentEvent.getEventType()).orElse(null);
-
-        if (currentSalientEventType == PAYMENT_CREATED && transaction.getState().isFinished()) {
+        if (isAPaymentOrNotificationCreatedEvent(currentEvent) && transaction.getState().isFinished()) {
             return true;
         }
 
         return getTransactionState(currentEvent).map(TransactionState::isFinished).orElse(false);
     }
 
+    private boolean isAPaymentOrNotificationCreatedEvent(Event event) {
+        return from(event.getEventType()).orElse(null) == PAYMENT_CREATED
+                || "PAYMENT_NOTIFICATION_CREATED".equals(event.getEventType());
+    }
+
     private void projectTransactionAmount(TransactionEntity transaction, Event currentEvent,
-                                          List<Event> eventsMappingToTransactionFinishedState) {
-        if (eventsMappingToTransactionFinishedState.size() > 1
+                                          List<Event> events) {
+        List<Event> eventsMappingToFinishedState =
+                getEventsMappingToTransactionFinishedStateInDescendingOrder(events);
+
+        if (eventsMappingToFinishedState.size() > 1
                 && PAYMENT_CREATED != from(currentEvent.getEventType()).orElse(null)) {
-            Event previousEvent = eventsMappingToTransactionFinishedState.get(1);
+            Event previousEvent = eventsMappingToFinishedState.get(1);
 
             if (currentEventTransactionStateMatchesWithPreviousEvent(currentEvent, previousEvent)) {
                 return;
@@ -87,14 +91,15 @@ public class TransactionSummaryService {
                     transaction.getFee());
         }
         transactionSummaryDao.upsert(transaction.getGatewayAccountId(), transaction.getTransactionType(),
-                toLocalDate(transaction.getCreatedDate()), transaction.getState(), transaction.isLive(), transaction.isMoto(),
+                toLocalDate(transaction.getCreatedDate()), transaction.getState(),
+                transaction.isLive(), transaction.isMoto(),
                 (transaction.getTotalAmount() != null ? transaction.getTotalAmount() : transaction.getAmount()));
     }
 
     private void projectTransactionFee(TransactionEntity transaction, SalientEventType currentEvent,
-                                       List<Event> eventsMappingToFinishedState) {
+                                       List<Event> events) {
 
-        long noOfCaptureConfirmedEvents = eventsMappingToFinishedState
+        long noOfCaptureConfirmedEvents = events
                 .stream()
                 .map(event -> from(event.getEventType()))
                 .flatMap(Optional::stream)
@@ -106,8 +111,8 @@ public class TransactionSummaryService {
         if ((currentEvent == PAYMENT_CREATED || (currentEvent == CAPTURE_CONFIRMED && noOfCaptureConfirmedEvents == 1))
                 && transaction.getFee() != null) {
             transactionSummaryDao.updateFee(transaction.getGatewayAccountId(), transaction.getTransactionType(),
-                    toLocalDate(transaction.getCreatedDate()), transaction.getState(), transaction.isLive(), transaction.isMoto(),
-                    transaction.getFee());
+                    toLocalDate(transaction.getCreatedDate()), transaction.getState(), transaction.isLive(),
+                    transaction.isMoto(), transaction.getFee());
         }
     }
 
@@ -128,16 +133,15 @@ public class TransactionSummaryService {
     }
 
     private List<Event> getEventsMappingToTransactionFinishedStateInDescendingOrder(List<Event> events) {
-        return events.stream().
-                filter(event -> getTransactionState(event).map(TransactionState::isFinished).orElse(false))
+        return events.stream()
+                .filter(event -> !ignoreEventsForTransactionAmount.contains(event.getEventType()))
+                .filter(event -> getTransactionState(event).map(TransactionState::isFinished).orElse(false))
                 .sorted(Comparator.comparing(Event::getEventDate).reversed())
                 .collect(Collectors.toList());
     }
 
-    private boolean hasSalientEvent(List<Event> events, SalientEventType eventToCheck) {
+    private boolean hasPaymentCreatedOrNotificationEvent(List<Event> events) {
         return events.stream()
-                .map(event -> from(event.getEventType()))
-                .flatMap(Optional::stream)
-                .anyMatch(salientEventType -> eventToCheck == salientEventType);
+                .anyMatch(this::isAPaymentOrNotificationCreatedEvent);
     }
 }

--- a/src/test/java/uk/gov/pay/ledger/queue/EventDigestHandlerTest.java
+++ b/src/test/java/uk/gov/pay/ledger/queue/EventDigestHandlerTest.java
@@ -77,7 +77,7 @@ class EventDigestHandlerTest {
         Event event = anEventFixture().withResourceType(PAYMENT).toEntity();
         when(eventService.getEventsForResource(event.getResourceExternalId())).thenReturn(List.of(anEventFixture().toEntity()));
 
-        eventDigestHandler.processEvent(event);
+        eventDigestHandler.processEvent(event, true);
 
         verify(transactionService).upsertTransactionFor(any(EventDigest.class));
         verify(transactionMetadataService).upsertMetadataFor(event);
@@ -91,7 +91,7 @@ class EventDigestHandlerTest {
                 .toEntity();
 
         when(eventService.getEventsForResource(event.getResourceExternalId())).thenReturn(List.of(anEventFixture().toEntity()));
-        eventDigestHandler.processEvent(event);
+        eventDigestHandler.processEvent(event, true);
 
         verify(transactionService).upsertTransactionFor(any(EventDigest.class));
         verify(transactionMetadataService).reprojectFromEventDigest(any(EventDigest.class));
@@ -101,7 +101,7 @@ class EventDigestHandlerTest {
     @Test
     void shouldUpsertTransactionIfResourceTypeIsRefund() {
         Event event = anEventFixture().withResourceType(REFUND).toEntity();
-        eventDigestHandler.processEvent(event);
+        eventDigestHandler.processEvent(event, true);
 
         verify(eventService).getEventDigestForResource(event);
         verify(transactionService).upsertTransactionFor(eventDigest);
@@ -110,7 +110,7 @@ class EventDigestHandlerTest {
     @Test
     void shouldUpsertPayoutIfResourceTypeIsPayout() {
         Event event = anEventFixture().withResourceType(PAYOUT).toEntity();
-        eventDigestHandler.processEvent(event);
+        eventDigestHandler.processEvent(event, true);
 
         verify(eventService).getEventDigestForResource(event);
         verify(payoutService).upsertPayoutFor(eventDigest);
@@ -123,7 +123,7 @@ class EventDigestHandlerTest {
 
         Event event = anEventFixture().withResourceType(AGREEMENT).toEntity();
 
-        assertThrows(RuntimeException.class, () -> eventDigestHandler.processEvent(event));
+        assertThrows(RuntimeException.class, () -> eventDigestHandler.processEvent(event, true));
 
         verify(transactionService, never()).upsertTransactionFor(any());
         verify(transactionMetadataService, never()).upsertMetadataFor(any());
@@ -152,7 +152,7 @@ class EventDigestHandlerTest {
         when(eventService.getEventDigestForResource(parentExternalId))
                 .thenReturn(paymentEventDigest);
 
-        eventDigestHandler.processEvent(event);
+        eventDigestHandler.processEvent(event, true);
 
         verify(eventService).getEventDigestForResource(event);
         verify(eventService).getEventDigestForResource(parentExternalId);

--- a/src/test/java/uk/gov/pay/ledger/queue/EventMessageHandlerTest.java
+++ b/src/test/java/uk/gov/pay/ledger/queue/EventMessageHandlerTest.java
@@ -80,7 +80,7 @@ class EventMessageHandlerTest {
 
         eventMessageHandler.handle();
 
-        verify(eventDigestHandler).processEvent(event);
+        verify(eventDigestHandler).processEvent(event, false);
         verify(eventQueue).markMessageAsProcessed(any(EventMessage.class));
     }
 
@@ -97,9 +97,9 @@ class EventMessageHandlerTest {
                 .toEntity();
         when(eventMessage.getEvent()).thenReturn(event);
         when(metricRegistry.histogram((any()))).thenReturn(histogram);
-        
+
         eventMessageHandler.handle();
-        verify(eventDigestHandler).processEvent(event);
+        verify(eventDigestHandler).processEvent(event, false);
         verify(eventQueue).markMessageAsProcessed(any(EventMessage.class));
         verify(eventService, never()).createIfDoesNotExist(any());
 


### PR DESCRIPTION
## WHAT
- Ledger can receive event multiple times for various reasons (parity checker reemitting events, emitting events for a charge for manual fixes, backfilling charges for any reason). In case ledger receives event more than once we don't want to project transaction summary so only project if ledger sees event for the first time.
- Currently summary is projected only when PAYMENT_CREATED event exists but for telephone payment reported the equivalent is "PAYMENT_NOTIFICATION_CREATED" event.
- Excludes CAPTURE_SUBMITTED & CAPTURE_CONFIRMED events as the prior events USER_APPROVED_FOR_CAPTURE and SERVICE_APPROVED_FOR_CAPTURE lead to same transaction state.
- Project transaction summary based on the current working list of events as getting events from database could result in new events (processed by ledger) not seen when projecting transaction.