### PR TITLE
PP-8050 Use CAPTURE_SUBMITTED event to project transaction summary

### DIFF
--- a/src/main/java/uk/gov/pay/ledger/transactionsummary/service/TransactionSummaryService.java
+++ b/src/main/java/uk/gov/pay/ledger/transactionsummary/service/TransactionSummaryService.java
@@ -17,16 +17,21 @@ import java.util.stream.Collectors;
 
 import static java.time.ZoneOffset.UTC;
 import static uk.gov.pay.ledger.event.model.SalientEventType.CAPTURE_CONFIRMED;
-import static uk.gov.pay.ledger.event.model.SalientEventType.CAPTURE_SUBMITTED;
 import static uk.gov.pay.ledger.event.model.SalientEventType.PAYMENT_CREATED;
+import static uk.gov.pay.ledger.event.model.SalientEventType.SERVICE_APPROVED_FOR_CAPTURE;
+import static uk.gov.pay.ledger.event.model.SalientEventType.USER_APPROVED_FOR_CAPTURE;
 import static uk.gov.pay.ledger.event.model.SalientEventType.from;
 
 public class TransactionSummaryService {
 
     private final TransactionSummaryDao transactionSummaryDao;
 
+    // CAPTURE_SUBMITTED event (common to payment notifications, service approved and user approved payments) will be
+    // considered to project transaction summary for success state. Ignore the following events that result into the
+    // same success state and to avoid counting the transaction multiple times
     private final List<String> ignoreEventsForTransactionAmount = List.of(CAPTURE_CONFIRMED.name(),
-            CAPTURE_SUBMITTED.name());
+            USER_APPROVED_FOR_CAPTURE.name(),
+            SERVICE_APPROVED_FOR_CAPTURE.name());
 
     @Inject
     public TransactionSummaryService(TransactionSummaryDao transactionSummaryDao) {

--- a/src/test/java/uk/gov/pay/ledger/queue/QueueMessageReceiverIT.java
+++ b/src/test/java/uk/gov/pay/ledger/queue/QueueMessageReceiverIT.java
@@ -257,7 +257,7 @@ public class QueueMessageReceiverIT {
         aQueuePaymentEventFixture()
                 .withResourceExternalId(resourceExternalId)
                 .withEventDate(CREATED_AT.plusSeconds(1))
-                .withEventType("USER_APPROVED_FOR_CAPTURE")
+                .withEventType("CAPTURE_SUBMITTED")
                 .withEventData("{}")
                 .withDefaultEventDataForEventType("DEFAULT")
                 .insert(rule.getSqsClient());

--- a/src/test/java/uk/gov/pay/ledger/transactionsummary/service/TransactionSummaryServiceTest.java
+++ b/src/test/java/uk/gov/pay/ledger/transactionsummary/service/TransactionSummaryServiceTest.java
@@ -21,6 +21,7 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static uk.gov.pay.ledger.event.model.SalientEventType.AUTHORISATION_SUCCEEDED;
 import static uk.gov.pay.ledger.event.model.SalientEventType.CAPTURE_CONFIRMED;
 import static uk.gov.pay.ledger.event.model.SalientEventType.CAPTURE_ERRORED;
+import static uk.gov.pay.ledger.event.model.SalientEventType.CAPTURE_SUBMITTED;
 import static uk.gov.pay.ledger.event.model.SalientEventType.PAYMENT_CREATED;
 import static uk.gov.pay.ledger.event.model.SalientEventType.PAYMENT_STATUS_CORRECTED_TO_SUCCESS_BY_ADMIN;
 import static uk.gov.pay.ledger.event.model.SalientEventType.REFUND_SUBMITTED;
@@ -78,7 +79,7 @@ public class TransactionSummaryServiceTest {
                 .withEventType("PAYMENT_NOTIFICATION_CREATED").toEntity();
         Event userApprovedForCaptureEvent = EventFixture.anEventFixture()
                 .withEventDate(ZonedDateTime.now())
-                .withEventType(USER_APPROVED_FOR_CAPTURE.name()).toEntity();
+                .withEventType(CAPTURE_SUBMITTED.name()).toEntity();
 
         List<Event> events = List.of(paymentCreatedEvent, userApprovedForCaptureEvent);
 
@@ -99,7 +100,7 @@ public class TransactionSummaryServiceTest {
         Event event = EventFixture.anEventFixture().withEventDate(ZonedDateTime.now())
                 .withEventType(PAYMENT_CREATED.name()).toEntity();
         Event event2 = EventFixture.anEventFixture().withEventDate(ZonedDateTime.now().plusSeconds(1))
-                .withEventType(USER_APPROVED_FOR_CAPTURE.name()).toEntity();
+                .withEventType(CAPTURE_SUBMITTED.name()).toEntity();
         Event event3 = EventFixture.anEventFixture().withEventDate(ZonedDateTime.now().plusSeconds(2))
                 .withEventType(CAPTURE_ERRORED.name()).toEntity();
 
@@ -216,7 +217,7 @@ public class TransactionSummaryServiceTest {
                 .withEventType(PAYMENT_CREATED.name()).toEntity();
         Event event2 = EventFixture.anEventFixture()
                 .withEventDate(ZonedDateTime.now().plusSeconds(1))
-                .withEventType(SERVICE_APPROVED_FOR_CAPTURE.name()).toEntity();
+                .withEventType(CAPTURE_SUBMITTED.name()).toEntity();
         Event event3 = EventFixture.anEventFixture()
                 .withEventDate(ZonedDateTime.now().plusSeconds(2))
                 .withEventType(PAYMENT_STATUS_CORRECTED_TO_SUCCESS_BY_ADMIN.name()).toEntity();


### PR DESCRIPTION
## WHAT
- Current transaction summary (for success state) is projected for USER_APPROVED_FOR_CAPTURE OR SERVICE_APPROVED_FOR_CAPTURE events. But for telephone payments these events are not available.
- Use CAPTURE_SUBMITTED event instead as it is available for all use cases (user approved, service approved, telephone payments)