### PR TITLE
PP-8047 Add dependabot configuration for Github actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,3 +20,8 @@ updates:
   - dependencies
   - govuk-pay
   - java
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: daily
+    time: "03:00"


### PR DESCRIPTION
Add dependabot configuration to raise pull requests to update GitHub actions when there are new versions. as per https://docs.github.com/en/code-security/supply-chain-security/keeping-your-actions-up-to-date-with-dependabot

with @SandorArpa