### PR TITLE
PP-8286 Add "Payment Provider" column to CSV stream

### DIFF
--- a/src/main/java/uk/gov/pay/ledger/transaction/model/CsvTransactionFactory.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/model/CsvTransactionFactory.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.inject.Inject;
-import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.pay.ledger.transaction.entity.TransactionEntity;
@@ -57,6 +56,7 @@ public class CsvTransactionFactory {
     private static final String FIELD_FEE = "Fee";
     private static final String FIELD_NET = "Net";
     private static final String FIELD_MOTO = "MOTO";
+    private static final String FIELD_PAYMENT_PROVIDER = "Payment Provider";
     private ObjectMapper objectMapper;
 
     @Inject
@@ -92,6 +92,7 @@ public class CsvTransactionFactory {
                 result.put(FIELD_FEE, penceToCurrency(transactionEntity.getFee()));
                 result.put(FIELD_STATE, PaymentState.getDisplayName(transactionEntity.getState()));
                 result.put(FIELD_MOTO, transactionEntity.isMoto());
+                result.put(FIELD_PAYMENT_PROVIDER, safeGetAsString(transactionDetails, "payment_provider"));
             }
             if (TransactionType.REFUND.toString().equals(transactionEntity.getTransactionType())) {
                 result.putAll(
@@ -190,6 +191,8 @@ public class CsvTransactionFactory {
         if (includeMotoHeader) {
             headers.put(FIELD_MOTO, FIELD_MOTO);
         }
+
+        headers.put(FIELD_PAYMENT_PROVIDER, FIELD_PAYMENT_PROVIDER);
 
         if (metadataKeys != null) {
             metadataKeys.stream().sorted()

--- a/src/test/java/uk/gov/pay/ledger/report/resource/ReportResourceIT.java
+++ b/src/test/java/uk/gov/pay/ledger/report/resource/ReportResourceIT.java
@@ -87,7 +87,7 @@ public class ReportResourceIT {
                 )
                 .then()
                 .statusCode(Response.Status.OK.getStatusCode())
-                .contentType(JSON).log().body()
+                .contentType(JSON)
                 .body("payments.count", is(2))
                 .body("payments.gross_amount", is(3000))
                 .body("net_income", is(3000));

--- a/src/test/java/uk/gov/pay/ledger/transaction/model/CsvTransactionFactoryTest.java
+++ b/src/test/java/uk/gov/pay/ledger/transaction/model/CsvTransactionFactoryTest.java
@@ -64,6 +64,7 @@ public class CsvTransactionFactoryTest {
         assertThat(csvDataMap.get("Corporate Card Surcharge"), is("0.23"));
         assertThat(csvDataMap.get("Total Amount"), is("1.23"));
         assertThat(csvDataMap.get("MOTO"), is(true));
+        assertThat(csvDataMap.get("Payment Provider"), is("sandbox"));
     }
 
     @Test
@@ -154,6 +155,7 @@ public class CsvTransactionFactoryTest {
         assertThat(csvHeaders.get("Corporate Card Surcharge"), is(notNullValue()));
         assertThat(csvHeaders.get("Wallet Type"), is(notNullValue()));
         assertThat(csvHeaders.get("Card Type"), is(notNullValue()));
+        assertThat(csvHeaders.get("Payment Provider"), is(notNullValue()));
 
         assertThat(csvHeaders.get("test-key-1 (metadata)"), is(notNullValue()));
         assertThat(csvHeaders.get("test-key-2 (metadata)"), is(notNullValue()));

--- a/src/test/java/uk/gov/pay/ledger/transaction/resource/TransactionResourceCsvIT.java
+++ b/src/test/java/uk/gov/pay/ledger/transaction/resource/TransactionResourceCsvIT.java
@@ -109,7 +109,7 @@ public class TransactionResourceCsvIT {
         assertThat(csvRecords.size(), is(2));
 
         CSVRecord paymentRecord = csvRecords.get(0);
-        assertThat(paymentRecord.size(), is(22));
+        assertThat(paymentRecord.size(), is(23));
         assertCommonPaymentFields(paymentRecord, transactionFixture);
         assertThat(paymentRecord.get("Amount"), is("1.23"));
         assertThat(paymentRecord.get("GOV.UK Payment ID"), is(transactionFixture.getExternalId()));
@@ -127,6 +127,7 @@ public class TransactionResourceCsvIT {
         assertThat(paymentRecord.isMapped("Net"), is(false));
         assertThat(paymentRecord.isMapped("Fee"), is(false));
         assertThat(paymentRecord.isMapped("MOTO"), is(false));
+        assertThat(paymentRecord.get("Payment Provider"), is("sandbox"));
 
         CSVRecord refundRecord = csvRecords.get(1);
         assertCommonPaymentFields(refundRecord, refundTransactionFixture);
@@ -175,7 +176,7 @@ public class TransactionResourceCsvIT {
         assertThat(csvRecords.size(), is(1));
 
         CSVRecord paymentRecord = csvRecords.get(0);
-        assertThat(paymentRecord.size(), is(23));
+        assertThat(paymentRecord.size(), is(24));
         assertThat(paymentRecord.get("Net"), is("11.00"));
         assertThat(paymentRecord.get("Fee"), is("1.00"));
     }
@@ -208,7 +209,7 @@ public class TransactionResourceCsvIT {
         assertThat(csvRecords.size(), is(1));
 
         CSVRecord paymentRecord = csvRecords.get(0);
-        assertThat(paymentRecord.size(), is(22));
+        assertThat(paymentRecord.size(), is(23));
         assertThat(paymentRecord.get("MOTO"), is("true"));
     }
 
@@ -255,11 +256,11 @@ public class TransactionResourceCsvIT {
         assertThat(csvRecords.size(), is(2));
 
         CSVRecord paymentRecord = csvRecords.get(0);
-        assertThat(paymentRecord.size(), is(23));
+        assertThat(paymentRecord.size(), is(24));
         assertThat(paymentRecord.get("Net"), is("10.00"));
         assertThat(paymentRecord.get("Fee"), is("2.00"));
         CSVRecord paymentRecord2 = csvRecords.get(1);
-        assertThat(paymentRecord2.size(), is(23));
+        assertThat(paymentRecord2.size(), is(24));
         assertThat(paymentRecord2.get("Net"), is("11.00"));
         assertThat(paymentRecord2.get("Fee"), is("1.00"));
     }
@@ -298,7 +299,7 @@ public class TransactionResourceCsvIT {
         List<CSVRecord> csvRecords = CSVParser.parse(csvResponseStream, UTF_8, DEFAULT).getRecords();
 
         CSVRecord header = csvRecords.get(0);
-        assertThat(header.size(), is(25));
+        assertThat(header.size(), is(26));
         assertThat(header.get(0), is("Reference"));
         assertThat(header.get(1), is("Description"));
         assertThat(header.get(2), is("Email"));
@@ -323,7 +324,8 @@ public class TransactionResourceCsvIT {
         assertThat(header.get(21), is("Net"));
         assertThat(header.get(22), is("Card Type"));
         assertThat(header.get(23), is("MOTO"));
-        assertThat(header.get(24), is("a-metadata-key (metadata)"));
+        assertThat(header.get(24), is("Payment Provider"));
+        assertThat(header.get(25), is("a-metadata-key (metadata)"));
     }
 
     @Test


### PR DESCRIPTION
## WHAT
- Added new column "Payment Provider" to the CSV stream. Field will be added as last field but before metadata fields
- Only available for payment transactions, as payment provider is not available for refund transactions