### PR TITLE
PP-8270 Add `credential_external_id` to pact tests

### DIFF
--- a/src/test/java/uk/gov/pay/ledger/pact/PaymentCreatedEventQueueContractTest.java
+++ b/src/test/java/uk/gov/pay/ledger/pact/PaymentCreatedEventQueueContractTest.java
@@ -39,6 +39,7 @@ public class PaymentCreatedEventQueueContractTest {
     private String externalId = "created_externalId";
     private ZonedDateTime eventDate = ZonedDateTime.parse("2018-03-12T16:25:01.123456Z");
     private String gatewayAccountId = "gateway_account_id";
+    private String credentialExternalId = "credential-external-id-1";
 
     @Pact(provider = "connector", consumer = "ledger")
     public MessagePact createPaymentCreatedEventPact(MessagePactBuilder builder) {
@@ -46,6 +47,7 @@ public class PaymentCreatedEventQueueContractTest {
                 .withResourceExternalId(externalId)
                 .withEventDate(eventDate)
                 .withGatewayAccountId(gatewayAccountId)
+                .withCredentialExternalId(credentialExternalId)
                 .withDefaultEventDataForEventType("PAYMENT_CREATED");
 
         Map<String, String> metadata = new HashMap<>();
@@ -88,6 +90,7 @@ public class PaymentCreatedEventQueueContractTest {
         assertThat(transaction.get().getTransactionDetails(), containsString("\"address_postcode\": \"N1 3QU\""));
         assertThat(transaction.get().getTransactionDetails(), containsString("\"address_city\": \"London\""));
         assertThat(transaction.get().getTransactionDetails(), containsString("\"address_country\": \"GB\""));
+        assertThat(transaction.get().getTransactionDetails(), containsString("\"credential_external_id\": \"" + credentialExternalId + "\""));
     }
 
     public void setMessage(byte[] messageContents) {

--- a/src/test/java/uk/gov/pay/ledger/pact/PaymentNotificationCreatedEventQueueContractTest.java
+++ b/src/test/java/uk/gov/pay/ledger/pact/PaymentNotificationCreatedEventQueueContractTest.java
@@ -39,6 +39,7 @@ public class PaymentNotificationCreatedEventQueueContractTest {
     private String externalId = "notifications_externalId";
     private ZonedDateTime eventDate = ZonedDateTime.parse("2018-03-12T16:25:01.123456Z");
     private String gatewayAccountId = "gateway_account_id";
+    private String credentialExternalId = "credential-external-id-1";
 
     @Pact(provider = "connector", consumer = "ledger")
     public MessagePact createPaymentNotificationCreatedEventPact(MessagePactBuilder builder) {
@@ -47,6 +48,7 @@ public class PaymentNotificationCreatedEventQueueContractTest {
                 .withResourceExternalId(externalId)
                 .withEventDate(eventDate)
                 .withGatewayAccountId(gatewayAccountId)
+                .withCredentialExternalId(credentialExternalId)
                 .withEventType(paymentDetailsEnteredEventName)
                 .withDefaultEventDataForEventType(paymentDetailsEnteredEventName);
 
@@ -95,6 +97,7 @@ public class PaymentNotificationCreatedEventQueueContractTest {
         assertThat(transaction.get().getTransactionDetails(), containsString("\"card_brand_label\": \"Visa\""));
         assertThat(transaction.get().getTransactionDetails(), containsString("\"payment_provider\": \"sandbox\""));
         assertThat(transaction.get().getTransactionDetails(), containsString("\"expiry_date\": \"11/21\""));
+        assertThat(transaction.get().getTransactionDetails(), containsString("\"credential_external_id\": \"" + credentialExternalId + "\""));
     }
 
     public void setMessage(byte[] messageContents) {

--- a/src/test/java/uk/gov/pay/ledger/util/fixture/QueuePaymentEventFixture.java
+++ b/src/test/java/uk/gov/pay/ledger/util/fixture/QueuePaymentEventFixture.java
@@ -26,6 +26,7 @@ public class QueuePaymentEventFixture implements QueueFixture<QueuePaymentEventF
     private String eventType = "PAYMENT_CREATED";
     private String eventData = "{\"event_data\": \"event data\"}";
     private String gatewayAccountId = RandomStringUtils.randomAlphanumeric(5);
+    private String credentialExternalId = RandomStringUtils.randomAlphanumeric(32);
     private Source source;
     private Map<String, Object> metadata = new HashMap<>();
     private boolean includeMetada = true;
@@ -74,6 +75,11 @@ public class QueuePaymentEventFixture implements QueueFixture<QueuePaymentEventF
         return this;
     }
 
+    public QueuePaymentEventFixture withCredentialExternalId(String credentialExternalId) {
+        this.credentialExternalId = credentialExternalId;
+        return this;
+    }
+
     public QueuePaymentEventFixture withSource(Source source) {
         this.source = source;
         return this;
@@ -108,6 +114,7 @@ public class QueuePaymentEventFixture implements QueueFixture<QueuePaymentEventF
                                 .put("reference", "aref")
                                 .put("return_url", "https://example.org")
                                 .put("gateway_account_id", gatewayAccountId)
+                                .put("credential_external_id", credentialExternalId)
                                 .put("payment_provider", "sandbox")
                                 .put("delayed_capture", false)
                                 .put("moto", false)
@@ -161,6 +168,7 @@ public class QueuePaymentEventFixture implements QueueFixture<QueuePaymentEventF
                 externalMetadata.addProperty("status", "success");
                 eventData = gsonBuilder.create()
                     .toJson(ImmutableMap.builder()
+                            .put("credential_external_id", credentialExternalId)
                             .put("amount", 1000)
                             .put("description", "New passport application")
                             .put("reference", "MRPC12345")


### PR DESCRIPTION
## WHAT 
- Added new field `credential_external_id` expected for PAYMENT_CREATED and PAYMENT_NOTIFICATION_CREATED event pacts