### PR TITLE
PP-8095 Update vulnerability disclosure in README.MD

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -63,8 +63,6 @@ The following variables control the background process:
 
 ## Responsible Disclosure
 
-GOV.UK Pay aims to stay secure for everyone. If you are a security researcher and have discovered a security
-vulnerability in this code, we appreciate your help in disclosing it to us in a responsible manner. We will give
-appropriate credit to those reporting confirmed issues. Please
-e-mail&nbsp;[gds-team-pay-security@digital.cabinet-office.gov.uk](mailto:gds-team-pay-security@digital.cabinet-office.gov.uk)
-with details of any issue you find, we aim to reply quickly.
+## Vulnerability Disclosure
+
+GOV.UK Pay aims to stay secure for everyone. If you are a security researcher and have discovered a security vulnerability in this code, we appreciate your help in disclosing it to us in a responsible manner. Please refer to our [vulnerability disclosure policy](https://www.gov.uk/help/report-vulnerability) and our [security.txt](https://vdp.cabinetoffice.gov.uk/.well-known/security.txt) file for details.


### PR DESCRIPTION
Update `README.MD` to reference the Cabinet Office CDIO Cyber Security vulnerability disclosure policy and security.txt file rather than the GOV.UK Pay security vulnerability email address.