### PR TITLE
PP-8440 Add service_id and live to event, transaction, payout tables

### DIFF
--- a/src/main/resources/migrations/00064_add_service_id_and_live_coumn_to_event_table.sql
+++ b/src/main/resources/migrations/00064_add_service_id_and_live_coumn_to_event_table.sql
@@ -1,0 +1,8 @@
+--liquibase formatted sql
+
+--changeset uk.gov.pay:add_service_id_and_live_to_event_table
+ALTER TABLE event
+ADD COLUMN service_id VARCHAR(32),
+ADD COLUMN live BOOLEAN;
+
+--rollback ALTER TABLE event DROP COLUMN service_id, DROP column live;

--- a/src/main/resources/migrations/00065_add_service_id_column_to_transaction_table.sql
+++ b/src/main/resources/migrations/00065_add_service_id_column_to_transaction_table.sql
@@ -1,0 +1,11 @@
+--liquibase formatted sql
+
+--changeset uk.gov.pay:add_service_id_to_transaction_table
+ALTER TABLE transaction
+    ADD COLUMN service_id VARCHAR(32);
+
+--rollback ALTER TABLE transaction DROP COLUMN service_id;
+
+--changeset uk.gov.pay:add_index_on_service_id_to_transaction_table runInTransaction:false
+CREATE INDEX CONCURRENTLY transaction_service_id_idx
+    ON transaction(service_id);

--- a/src/main/resources/migrations/00066_add_service_id_and_live_column_to_payout_table.sql
+++ b/src/main/resources/migrations/00066_add_service_id_and_live_column_to_payout_table.sql
@@ -1,0 +1,17 @@
+--liquibase formatted sql
+
+--changeset uk.gov.pay:add_service_id_to_payout_table
+ALTER TABLE payout
+    ADD COLUMN service_id VARCHAR(32),
+    ADD COLUMN live BOOLEAN;
+
+--rollback ALTER TABLE payout DROP COLUMN service_id, DROP COLUMN live;
+
+--changeset uk.gov.pay:add_index_on_service_id_payout_table runInTransaction:false
+CREATE INDEX CONCURRENTLY payout_service_id_idx
+    ON payout(service_id);
+
+--changeset uk.gov.pay:add_partial_index_on_live_payout_table runInTransaction:false
+CREATE INDEX CONCURRENTLY payout_live_idx
+    ON payout(live)
+    WHERE live is true;


### PR DESCRIPTION
We are re-orienting all payment data around services rather than gateway accounts. To enable this, events coming in to ledger will have a top level attribute of `service_id` and `live`.

This adds necessary columns to store these values in event table. I have been consistent with column naming by using
`live` to indicate whether an event is live or test.

Also adds service_id column to transaction table, and adds index on `service_id`. Added concurrently to avoid long lived table lock.

Also adds service_id and live column to payouts, with same index as transaction table,  plus partial index on live payoputs for our old friend toolbox.