### PR TITLE
PP-8440 Store and retrieve `service_id` and `live` (redux with bug fix)

### DIFF
--- a/src/main/java/uk/gov/pay/ledger/event/dao/EventDao.java
+++ b/src/main/java/uk/gov/pay/ledger/event/dao/EventDao.java
@@ -25,21 +25,21 @@ public interface EventDao {
     @CreateSqlObject
     ResourceTypeDao getResourceTypeDao();
 
-    @SqlQuery("SELECT e.id, e.sqs_message_id, rt.name AS resource_type_name, e.resource_external_id, e.parent_resource_external_id," +
+    @SqlQuery("SELECT e.id, e.sqs_message_id, e.service_id, e.live, rt.name AS resource_type_name, e.resource_external_id, e.parent_resource_external_id," +
             " e.event_date, e.event_type, e.event_data" +
             " FROM event e, resource_type rt WHERE e.id = :eventId AND e.resource_type_id = rt.id")
     Optional<Event> getById(@Bind("eventId") Long eventId);
 
-    @SqlUpdate("INSERT INTO event(sqs_message_id, resource_type_id, resource_external_id, parent_resource_external_id, " +
+    @SqlUpdate("INSERT INTO event(sqs_message_id, service_id, live, resource_type_id, resource_external_id, parent_resource_external_id, " +
                 "event_date, event_type, event_data) " +
-            "VALUES (:sqsMessageId, :resourceTypeId, :resourceExternalId, :parentResourceExternalId, " +
+            "VALUES (:sqsMessageId, :serviceId, :live, :resourceTypeId, :resourceExternalId, :parentResourceExternalId, " +
                 ":eventDate, :eventType, CAST(:eventData as jsonb))")
     @GetGeneratedKeys
     Long insert(@BindBean Event event, @Bind("resourceTypeId") int resourceTypeId);
 
-    @SqlUpdate("INSERT INTO event(sqs_message_id, resource_type_id, resource_external_id, parent_resource_external_id, " +
+    @SqlUpdate("INSERT INTO event(sqs_message_id, service_id, live, resource_type_id, resource_external_id, parent_resource_external_id, " +
             "event_date, event_type, event_data) " +
-            "SELECT :sqsMessageId, :resourceTypeId, :resourceExternalId, :parentResourceExternalId, " +
+            "SELECT :sqsMessageId, :serviceId, :live, :resourceTypeId, :resourceExternalId, :parentResourceExternalId, " +
             "       :eventDate, :eventType, CAST(:eventData as jsonb) " +
             "WHERE NOT EXISTS ( " +
             "    SELECT 1 " +
@@ -63,14 +63,14 @@ public interface EventDao {
         return insertIfDoesNotExist(event, resourceTypeId);
     }
 
-    @SqlQuery("SELECT  e.id, e.sqs_message_id, rt.name AS resource_type_name, e.resource_external_id, " +
+    @SqlQuery("SELECT  e.id, e.sqs_message_id, e.service_id, e.live, rt.name AS resource_type_name, e.resource_external_id, " +
             "e.parent_resource_external_id, e.event_date," +
             "e.event_type, e.event_data FROM event e, resource_type rt WHERE e.resource_external_id = :resourceExternalId" +
             " AND e.resource_type_id = rt.id ORDER BY e.event_date DESC")
     List<Event> getEventsByResourceExternalId(@Bind("resourceExternalId") String resourceExternalId);
 
 
-    @SqlQuery("SELECT  e.id, e.sqs_message_id, rt.name AS resource_type_name, e.resource_external_id, " +
+    @SqlQuery("SELECT  e.id, e.sqs_message_id, e.service_id, e.live, rt.name AS resource_type_name, e.resource_external_id, " +
             "          e.parent_resource_external_id, e.event_date," +
             "          e.event_type, e.event_data FROM event e, resource_type rt" +
             " WHERE e.resource_external_id in (<externalIds>)" +

--- a/src/main/java/uk/gov/pay/ledger/event/dao/mapper/EventMapper.java
+++ b/src/main/java/uk/gov/pay/ledger/event/dao/mapper/EventMapper.java
@@ -17,7 +17,7 @@ public class EventMapper implements RowMapper<Event> {
         return new Event(resultSet.getLong("id"),
                 resultSet.getString("sqs_message_id"),
                 resultSet.getString("service_id"),
-                resultSet.getBoolean("live"),
+                getBooleanWithNullCheck(resultSet, "live"),
                 ResourceType.valueOf(resultSet.getString("resource_type_name").toUpperCase()),
                 resultSet.getString("resource_external_id"),
                 resultSet.getString("parent_resource_external_id"),
@@ -26,5 +26,10 @@ public class EventMapper implements RowMapper<Event> {
                 resultSet.getString("event_data"),
                 false
         );
+    }
+
+    private Boolean getBooleanWithNullCheck(ResultSet rs, String columnName) throws SQLException {
+        var value = rs.getBoolean(columnName);
+        return rs.wasNull() ? null : value;
     }
 }

--- a/src/main/java/uk/gov/pay/ledger/event/dao/mapper/EventMapper.java
+++ b/src/main/java/uk/gov/pay/ledger/event/dao/mapper/EventMapper.java
@@ -10,6 +10,8 @@ import java.sql.SQLException;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 
+import static uk.gov.pay.ledger.util.dao.MapperUtils.getBooleanWithNullCheck;
+
 public class EventMapper implements RowMapper<Event> {
 
     @Override
@@ -26,10 +28,5 @@ public class EventMapper implements RowMapper<Event> {
                 resultSet.getString("event_data"),
                 false
         );
-    }
-
-    private Boolean getBooleanWithNullCheck(ResultSet rs, String columnName) throws SQLException {
-        var value = rs.getBoolean(columnName);
-        return rs.wasNull() ? null : value;
     }
 }

--- a/src/main/java/uk/gov/pay/ledger/event/dao/mapper/EventMapper.java
+++ b/src/main/java/uk/gov/pay/ledger/event/dao/mapper/EventMapper.java
@@ -16,6 +16,8 @@ public class EventMapper implements RowMapper<Event> {
     public Event map(ResultSet resultSet, StatementContext statementContext) throws SQLException {
         return new Event(resultSet.getLong("id"),
                 resultSet.getString("sqs_message_id"),
+                resultSet.getString("service_id"),
+                resultSet.getBoolean("live"),
                 ResourceType.valueOf(resultSet.getString("resource_type_name").toUpperCase()),
                 resultSet.getString("resource_external_id"),
                 resultSet.getString("parent_resource_external_id"),

--- a/src/main/java/uk/gov/pay/ledger/event/model/Event.java
+++ b/src/main/java/uk/gov/pay/ledger/event/model/Event.java
@@ -79,9 +79,6 @@ public class Event {
         return serviceId;
     }
 
-    public Boolean isLive() {
-        return live;
-    }
     public Boolean getLive() {
         return live;
     }

--- a/src/main/java/uk/gov/pay/ledger/event/model/Event.java
+++ b/src/main/java/uk/gov/pay/ledger/event/model/Event.java
@@ -1,7 +1,7 @@
 package uk.gov.pay.ledger.event.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import uk.gov.service.payments.commons.api.json.MicrosecondPrecisionDateTimeSerializer;
@@ -9,12 +9,14 @@ import uk.gov.service.payments.commons.api.json.MicrosecondPrecisionDateTimeSeri
 import java.time.ZonedDateTime;
 import java.util.Objects;
 
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class Event {
 
     @JsonIgnore
     private Long id;
     private String sqsMessageId;
+    private String serviceId;
+    private boolean live;
     private ResourceType resourceType;
     private String resourceExternalId;
     private String parentResourceExternalId;
@@ -29,6 +31,8 @@ public class Event {
 
     public Event(Long id,
                  String sqsMessageId,
+                 String serviceId,
+                 boolean live,
                  ResourceType resourceType,
                  String resourceExternalId,
                  String parentResourceExternalId,
@@ -38,6 +42,8 @@ public class Event {
                  boolean reprojectDomainObject) {
         this.id = id;
         this.sqsMessageId = sqsMessageId;
+        this.serviceId = serviceId;
+        this.live = live;
         this.resourceType = resourceType;
         this.resourceExternalId = resourceExternalId;
         this.parentResourceExternalId = parentResourceExternalId;
@@ -47,7 +53,9 @@ public class Event {
         this.reprojectDomainObject = reprojectDomainObject;
     }
 
-    public Event(String queueMessageId,
+    public Event(String sqsMessageId,
+                 String serviceId,
+                 boolean live,
                  ResourceType resourceType,
                  String resourceExternalId,
                  String parentResourceExternalId,
@@ -55,7 +63,7 @@ public class Event {
                  String eventType,
                  String eventData,
                  boolean reprojectDomainObject) {
-        this(null, queueMessageId, resourceType, resourceExternalId, parentResourceExternalId, eventDate, eventType,
+        this(null, sqsMessageId, serviceId, live,  resourceType, resourceExternalId, parentResourceExternalId, eventDate, eventType,
                 eventData, reprojectDomainObject);
     }
 
@@ -65,6 +73,14 @@ public class Event {
 
     public String getSqsMessageId() {
         return sqsMessageId;
+    }
+
+    public String getServiceId() {
+        return serviceId;
+    }
+
+    public boolean isLive() {
+        return live;
     }
 
     public ResourceType getResourceType() {
@@ -100,6 +116,8 @@ public class Event {
         return "Event{" +
                 "id=" + id +
                 ", sqsMessageId='" + sqsMessageId + '\'' +
+                ", serviceId='" + serviceId + '\'' +
+                ", isLive=" + live +
                 ", resourceType=" + resourceType +
                 ", resourceExternalId='" + resourceExternalId + '\'' +
                 ", parentResourceExternalId='" + parentResourceExternalId + '\'' +
@@ -114,10 +132,14 @@ public class Event {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         Event event = (Event) o;
-        return Objects.equals(id, event.id) &&
+        return live == event.live &&
+                reprojectDomainObject == event.reprojectDomainObject &&
+                Objects.equals(id, event.id) &&
                 Objects.equals(sqsMessageId, event.sqsMessageId) &&
+                Objects.equals(serviceId, event.serviceId) &&
                 resourceType == event.resourceType &&
                 Objects.equals(resourceExternalId, event.resourceExternalId) &&
+                Objects.equals(parentResourceExternalId, event.parentResourceExternalId) &&
                 Objects.equals(eventDate, event.eventDate) &&
                 Objects.equals(eventType, event.eventType) &&
                 Objects.equals(eventData, event.eventData);
@@ -125,6 +147,6 @@ public class Event {
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, sqsMessageId, resourceType, resourceExternalId, eventDate, eventType, eventData);
+        return Objects.hash(id, sqsMessageId, serviceId, live, resourceType, resourceExternalId, parentResourceExternalId, eventDate, eventType, eventData, reprojectDomainObject);
     }
 }

--- a/src/main/java/uk/gov/pay/ledger/event/model/Event.java
+++ b/src/main/java/uk/gov/pay/ledger/event/model/Event.java
@@ -16,7 +16,7 @@ public class Event {
     private Long id;
     private String sqsMessageId;
     private String serviceId;
-    private boolean live;
+    private Boolean live;
     private ResourceType resourceType;
     private String resourceExternalId;
     private String parentResourceExternalId;
@@ -32,7 +32,7 @@ public class Event {
     public Event(Long id,
                  String sqsMessageId,
                  String serviceId,
-                 boolean live,
+                 Boolean live,
                  ResourceType resourceType,
                  String resourceExternalId,
                  String parentResourceExternalId,
@@ -55,7 +55,7 @@ public class Event {
 
     public Event(String sqsMessageId,
                  String serviceId,
-                 boolean live,
+                 Boolean live,
                  ResourceType resourceType,
                  String resourceExternalId,
                  String parentResourceExternalId,
@@ -79,7 +79,10 @@ public class Event {
         return serviceId;
     }
 
-    public boolean isLive() {
+    public Boolean isLive() {
+        return live;
+    }
+    public Boolean getLive() {
         return live;
     }
 

--- a/src/main/java/uk/gov/pay/ledger/event/model/EventDigest.java
+++ b/src/main/java/uk/gov/pay/ledger/event/model/EventDigest.java
@@ -37,7 +37,7 @@ public class EventDigest {
             Map<String, Object> eventAggregate,
             ZonedDateTime eventCreatedDate
     ) {
-        this.serviceId =serviceId;
+        this.serviceId = serviceId;
         this.live = live;
         this.mostRecentEventTimestamp = mostRecentEventTimestamp;
         this.mostRecentSalientEventType = mostRecentSalientEventType;
@@ -72,7 +72,7 @@ public class EventDigest {
 
         return new EventDigest(
                 latestEvent.getServiceId(),
-                latestEvent.isLive(),
+                latestEvent.getLive(),
                 latestEvent.getEventDate(),
                 latestSalientEventType,
                 latestEvent.getResourceType(),

--- a/src/main/java/uk/gov/pay/ledger/event/model/EventDigest.java
+++ b/src/main/java/uk/gov/pay/ledger/event/model/EventDigest.java
@@ -14,37 +14,43 @@ import static org.apache.commons.lang3.StringUtils.isNotEmpty;
 
 public class EventDigest {
     private static final ObjectMapper objectMapper = new ObjectMapper();
+    private final String serviceId;
+    private final boolean live;
     private final ZonedDateTime mostRecentEventTimestamp;
     private final ResourceType resourceType;
     private final String resourceExternalId;
     private final String parentResourceExternalId;
     private final SalientEventType mostRecentSalientEventType;
     private Integer eventCount;
-    private Map<String, Object> eventPayload;
+    private Map<String, Object> eventAggregate;
     private final ZonedDateTime eventCreatedDate;
 
     private EventDigest(
+            String serviceId,
+            boolean live,
             ZonedDateTime mostRecentEventTimestamp,
             SalientEventType mostRecentSalientEventType,
             ResourceType resourceType,
             String resourceExternalId,
             String parentResourceExternalId,
             Integer eventCount,
-            Map<String, Object> eventPayload,
+            Map<String, Object> eventAggregate,
             ZonedDateTime eventCreatedDate
     ) {
+        this.serviceId =serviceId;
+        this.live = live;
         this.mostRecentEventTimestamp = mostRecentEventTimestamp;
         this.mostRecentSalientEventType = mostRecentSalientEventType;
         this.resourceType = resourceType;
         this.resourceExternalId = resourceExternalId;
         this.parentResourceExternalId = parentResourceExternalId;
         this.eventCount = eventCount;
-        this.eventPayload = eventPayload;
+        this.eventAggregate = eventAggregate;
         this.eventCreatedDate = eventCreatedDate;
     }
 
     public static EventDigest fromEventList(List<Event> events) {
-        var eventPayload = buildEventPayload(events);
+        var eventPayload = buildEventAggregate(events);
 
         var latestEvent = events.stream()
                 .findFirst()
@@ -65,6 +71,8 @@ public class EventDigest {
         String parentResourceExternalId = deriveParentResourceExternalId(events);
 
         return new EventDigest(
+                latestEvent.getServiceId(),
+                latestEvent.isLive(),
                 latestEvent.getEventDate(),
                 latestSalientEventType,
                 latestEvent.getResourceType(),
@@ -84,12 +92,20 @@ public class EventDigest {
                 .orElse(null);
     }
 
-    private static Map<String, Object> buildEventPayload(List<Event> events) {
+    private static Map<String, Object> buildEventAggregate(List<Event> events) {
         return events.stream()
                 .map(Event::getEventData)
                 .map(JsonParser::jsonStringToMap)
                 .flatMap(m -> m.entrySet().stream())
                 .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue, (later, earlier) -> later));
+    }
+
+    public String getServiceId() {
+        return serviceId;
+    }
+
+    public boolean isLive() {
+        return live;
     }
 
     public ZonedDateTime getMostRecentEventTimestamp() {
@@ -112,8 +128,8 @@ public class EventDigest {
         return Optional.ofNullable(mostRecentSalientEventType);
     }
 
-    public Map<String, Object> getEventPayload() {
-        return eventPayload;
+    public Map<String, Object> getEventAggregate() {
+        return eventAggregate;
     }
 
     public Integer getEventCount() {

--- a/src/main/java/uk/gov/pay/ledger/event/model/EventDigest.java
+++ b/src/main/java/uk/gov/pay/ledger/event/model/EventDigest.java
@@ -15,7 +15,7 @@ import static org.apache.commons.lang3.StringUtils.isNotEmpty;
 public class EventDigest {
     private static final ObjectMapper objectMapper = new ObjectMapper();
     private final String serviceId;
-    private final boolean live;
+    private final Boolean live;
     private final ZonedDateTime mostRecentEventTimestamp;
     private final ResourceType resourceType;
     private final String resourceExternalId;
@@ -27,7 +27,7 @@ public class EventDigest {
 
     private EventDigest(
             String serviceId,
-            boolean live,
+            Boolean live,
             ZonedDateTime mostRecentEventTimestamp,
             SalientEventType mostRecentSalientEventType,
             ResourceType resourceType,
@@ -104,7 +104,7 @@ public class EventDigest {
         return serviceId;
     }
 
-    public boolean isLive() {
+    public Boolean isLive() {
         return live;
     }
 

--- a/src/main/java/uk/gov/pay/ledger/event/model/TransactionEntityFactory.java
+++ b/src/main/java/uk/gov/pay/ledger/event/model/TransactionEntityFactory.java
@@ -21,17 +21,18 @@ public class TransactionEntityFactory {
     }
 
     public TransactionEntity create(EventDigest eventDigest) {
-        return create(eventDigest, eventDigest.getEventPayload());
-    }
 
-    public TransactionEntity create(EventDigest eventDigest, Map<String, Object> eventPayload) {
         TransactionState digestTransactionState = eventDigest
                 .getMostRecentSalientEventType()
                 .map(TransactionState::fromEventType)
                 .orElse(TransactionState.UNDEFINED);
 
-        String transactionDetail = convertToTransactionDetails(eventPayload);
-        TransactionEntity entity = objectMapper.convertValue(eventPayload, TransactionEntity.class);
+        var eventAggregate = eventDigest.getEventAggregate();
+        String transactionDetail = convertToTransactionDetails(eventAggregate);
+
+        TransactionEntity entity = objectMapper.convertValue(eventAggregate, TransactionEntity.class);
+        entity.setServiceId(eventDigest.getServiceId());
+        entity.setLive(eventDigest.isLive());
         entity.setTransactionDetails(transactionDetail);
         entity.setEventCount(eventDigest.getEventCount());
         entity.setState(digestTransactionState);

--- a/src/main/java/uk/gov/pay/ledger/event/model/TransactionEntityFactory.java
+++ b/src/main/java/uk/gov/pay/ledger/event/model/TransactionEntityFactory.java
@@ -9,6 +9,7 @@ import uk.gov.pay.ledger.transaction.entity.TransactionEntity;
 import uk.gov.pay.ledger.transaction.state.TransactionState;
 
 import java.util.Map;
+import java.util.Optional;
 
 public class TransactionEntityFactory {
 
@@ -32,7 +33,7 @@ public class TransactionEntityFactory {
 
         TransactionEntity entity = objectMapper.convertValue(eventAggregate, TransactionEntity.class);
         entity.setServiceId(eventDigest.getServiceId());
-        entity.setLive(eventDigest.isLive());
+        entity.setLive(Optional.ofNullable(eventDigest.isLive()).orElse(entity.isLive()));
         entity.setTransactionDetails(transactionDetail);
         entity.setEventCount(eventDigest.getEventCount());
         entity.setState(digestTransactionState);

--- a/src/main/java/uk/gov/pay/ledger/payout/dao/PayoutDao.java
+++ b/src/main/java/uk/gov/pay/ledger/payout/dao/PayoutDao.java
@@ -28,6 +28,8 @@ public class PayoutDao {
     private final String UPSERT_PAYOUT = "INSERT INTO payout " +
             "(" +
             "gateway_payout_id," +
+            "service_id," +
+            "live," +
             "amount," +
             "paid_out_date," +
             "state," +
@@ -38,6 +40,8 @@ public class PayoutDao {
             ") " +
             "VALUES (" +
             ":gatewayPayoutId, " +
+            ":serviceId, " +
+            ":live, " +
             ":amount, " +
             ":paidOutDate, " +
             ":state, " +
@@ -48,6 +52,8 @@ public class PayoutDao {
             ") " +
             "ON CONFLICT (gateway_payout_id) DO UPDATE SET " +
             "gateway_payout_id = EXCLUDED.gateway_payout_id, " +
+            "service_id = EXCLUDED.service_id, " +
+            "live = EXCLUDED.live, " +
             "amount = EXCLUDED.amount, " +
             "paid_out_date = EXCLUDED.paid_out_date, " +
             "state = EXCLUDED.state, " +

--- a/src/main/java/uk/gov/pay/ledger/payout/dao/mapper/PayoutMapper.java
+++ b/src/main/java/uk/gov/pay/ledger/payout/dao/mapper/PayoutMapper.java
@@ -12,6 +12,8 @@ import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.Optional;
 
+import static uk.gov.pay.ledger.util.dao.MapperUtils.getBooleanWithNullCheck;
+
 public class PayoutMapper implements RowMapper<PayoutEntity> {
 
     @Override
@@ -20,7 +22,7 @@ public class PayoutMapper implements RowMapper<PayoutEntity> {
                .withId(rs.getLong("id"))
                .withGatewayPayoutId(rs.getString("gateway_payout_id"))
                .withServiceId(rs.getString("service_id"))
-               .withLive(rs.getBoolean("live"))
+               .withLive(getBooleanWithNullCheck(rs,"live"))
                .withAmount(rs.getLong("amount"))
                .withState(PayoutState.from(rs.getString("state")))
                .withCreatedDate(getZonedDateTime(rs, "created_date").orElse(null))

--- a/src/main/java/uk/gov/pay/ledger/payout/dao/mapper/PayoutMapper.java
+++ b/src/main/java/uk/gov/pay/ledger/payout/dao/mapper/PayoutMapper.java
@@ -19,6 +19,8 @@ public class PayoutMapper implements RowMapper<PayoutEntity> {
        var builder = PayoutEntity.PayoutEntityBuilder.aPayoutEntity()
                .withId(rs.getLong("id"))
                .withGatewayPayoutId(rs.getString("gateway_payout_id"))
+               .withServiceId(rs.getString("service_id"))
+               .withLive(rs.getBoolean("live"))
                .withAmount(rs.getLong("amount"))
                .withState(PayoutState.from(rs.getString("state")))
                .withCreatedDate(getZonedDateTime(rs, "created_date").orElse(null))

--- a/src/main/java/uk/gov/pay/ledger/payout/entity/PayoutEntity.java
+++ b/src/main/java/uk/gov/pay/ledger/payout/entity/PayoutEntity.java
@@ -6,9 +6,9 @@ import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import uk.gov.pay.ledger.payout.state.PayoutState;
 import uk.gov.service.payments.commons.api.json.MicrosecondPrecisionDateTimeDeserializer;
 import uk.gov.service.payments.commons.api.json.MicrosecondPrecisionDateTimeSerializer;
-import uk.gov.pay.ledger.payout.state.PayoutState;
 
 import java.time.ZonedDateTime;
 
@@ -61,7 +61,7 @@ public class PayoutEntity {
         return serviceId;
     }
 
-    public boolean isLive() {
+    public Boolean getLive() {
         return live;
     }
 

--- a/src/main/java/uk/gov/pay/ledger/payout/entity/PayoutEntity.java
+++ b/src/main/java/uk/gov/pay/ledger/payout/entity/PayoutEntity.java
@@ -20,7 +20,7 @@ public class PayoutEntity {
     private Long id;
     private String gatewayPayoutId;
     private String serviceId;
-    private boolean live;
+    private Boolean live;
     private Long amount;
     @JsonIgnore
     private ZonedDateTime createdDate;
@@ -130,7 +130,7 @@ public class PayoutEntity {
         this.serviceId = serviceId;
     }
 
-    public void setLive(boolean live) {
+    public void setLive(Boolean live) {
         this.live = live;
     }
 
@@ -138,7 +138,7 @@ public class PayoutEntity {
         private Long id;
         private String gatewayPayoutId;
         private String serviceId;
-        private boolean live;
+        private Boolean live;
         private Long amount;
         private ZonedDateTime createdDate;
         private ZonedDateTime paidOutDate;
@@ -169,7 +169,7 @@ public class PayoutEntity {
             return this;
         }
 
-        public PayoutEntityBuilder withLive(boolean live) {
+        public PayoutEntityBuilder withLive(Boolean live) {
             this.live = live;
             return this;
         }

--- a/src/main/java/uk/gov/pay/ledger/payout/entity/PayoutEntity.java
+++ b/src/main/java/uk/gov/pay/ledger/payout/entity/PayoutEntity.java
@@ -19,6 +19,8 @@ public class PayoutEntity {
     @JsonIgnore
     private Long id;
     private String gatewayPayoutId;
+    private String serviceId;
+    private boolean live;
     private Long amount;
     @JsonIgnore
     private ZonedDateTime createdDate;
@@ -36,6 +38,8 @@ public class PayoutEntity {
     public PayoutEntity(PayoutEntityBuilder builder) {
         this.id = builder.id;
         this.gatewayPayoutId = builder.gatewayPayoutId;
+        this.serviceId = builder.serviceId;
+        this.live = builder.live;
         this.amount = builder.amount;
         this.createdDate = builder.createdDate;
         this.paidOutDate = builder.paidOutDate;
@@ -51,6 +55,14 @@ public class PayoutEntity {
 
     public String getGatewayPayoutId() {
         return gatewayPayoutId;
+    }
+
+    public String getServiceId() {
+        return serviceId;
+    }
+
+    public boolean isLive() {
+        return live;
     }
 
     public Long getAmount() {
@@ -114,9 +126,19 @@ public class PayoutEntity {
         return this;
     }
 
+    public void setServiceId(String serviceId) {
+        this.serviceId = serviceId;
+    }
+
+    public void setLive(boolean live) {
+        this.live = live;
+    }
+
     public static final class PayoutEntityBuilder {
         private Long id;
         private String gatewayPayoutId;
+        private String serviceId;
+        private boolean live;
         private Long amount;
         private ZonedDateTime createdDate;
         private ZonedDateTime paidOutDate;
@@ -139,6 +161,16 @@ public class PayoutEntity {
 
         public PayoutEntityBuilder withGatewayPayoutId(String gatewayPayoutId) {
             this.gatewayPayoutId = gatewayPayoutId;
+            return this;
+        }
+
+        public PayoutEntityBuilder withServiceId(String serviceId) {
+            this.serviceId = serviceId;
+            return this;
+        }
+
+        public PayoutEntityBuilder withLive(boolean live) {
+            this.live = live;
             return this;
         }
 

--- a/src/main/java/uk/gov/pay/ledger/payout/model/PayoutEntityFactory.java
+++ b/src/main/java/uk/gov/pay/ledger/payout/model/PayoutEntityFactory.java
@@ -32,6 +32,8 @@ public class PayoutEntityFactory {
         entity.setState(digestPayoutState);
         entity.setCreatedDate(eventDigest.getEventCreatedDate());
         entity.setGatewayPayoutId(eventDigest.getResourceExternalId());
+        entity.setServiceId(eventDigest.getServiceId());
+        entity.setLive(eventDigest.isLive());
         entity.setEventCount(eventDigest.getEventCount());
         entity.setPayoutDetails(payoutDetails);
         return entity;

--- a/src/main/java/uk/gov/pay/ledger/payout/model/PayoutEntityFactory.java
+++ b/src/main/java/uk/gov/pay/ledger/payout/model/PayoutEntityFactory.java
@@ -27,8 +27,8 @@ public class PayoutEntityFactory {
                 .map(PayoutState::fromEventType)
                 .orElse(PayoutState.UNDEFINED);
 
-        String payoutDetails = convertToPayoutDetails(eventDigest.getEventPayload());
-        PayoutEntity entity = objectMapper.convertValue(eventDigest.getEventPayload(), PayoutEntity.class);
+        String payoutDetails = convertToPayoutDetails(eventDigest.getEventAggregate());
+        PayoutEntity entity = objectMapper.convertValue(eventDigest.getEventAggregate(), PayoutEntity.class);
         entity.setState(digestPayoutState);
         entity.setCreatedDate(eventDigest.getEventCreatedDate());
         entity.setGatewayPayoutId(eventDigest.getResourceExternalId());

--- a/src/main/java/uk/gov/pay/ledger/payout/model/PayoutView.java
+++ b/src/main/java/uk/gov/pay/ledger/payout/model/PayoutView.java
@@ -3,9 +3,9 @@ package uk.gov.pay.ledger.payout.model;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import uk.gov.service.payments.commons.api.json.ApiResponseDateTimeSerializer;
 import uk.gov.pay.ledger.payout.entity.PayoutEntity;
 import uk.gov.pay.ledger.payout.state.PayoutState;
+import uk.gov.service.payments.commons.api.json.ApiResponseDateTimeSerializer;
 
 import java.time.ZonedDateTime;
 
@@ -38,7 +38,7 @@ public class PayoutView {
     public static PayoutView from(PayoutEntity payoutEntity) {
 
         return new PayoutView(payoutEntity.getAmount(), payoutEntity.getCreatedDate(), payoutEntity.getGatewayPayoutId(),
-                payoutEntity.getGatewayAccountId(), payoutEntity.getServiceId(), payoutEntity.isLive(), payoutEntity.getPaidOutDate(), payoutEntity.getState());
+                payoutEntity.getGatewayAccountId(), payoutEntity.getServiceId(), payoutEntity.getLive(), payoutEntity.getPaidOutDate(), payoutEntity.getState());
     }
 
     public Long getAmount() {

--- a/src/main/java/uk/gov/pay/ledger/payout/model/PayoutView.java
+++ b/src/main/java/uk/gov/pay/ledger/payout/model/PayoutView.java
@@ -17,16 +17,20 @@ public class PayoutView {
     private ZonedDateTime createdDate;
     private String gatewayPayoutId;
     private String gatewayAccountId;
+    private String serviceId;
+    private Boolean live;
     @JsonSerialize(using = ApiResponseDateTimeSerializer.class)
     private ZonedDateTime paidOutDate;
     private PayoutState state;
 
     private PayoutView(Long amount, ZonedDateTime createdDate, String gatewayPayoutId,
-                       String gatewayAccountId, ZonedDateTime paidOutDate, PayoutState state) {
+                       String gatewayAccountId, String serviceId, Boolean live, ZonedDateTime paidOutDate, PayoutState state) {
         this.amount = amount;
         this.createdDate = createdDate;
         this.gatewayPayoutId = gatewayPayoutId;
         this.gatewayAccountId = gatewayAccountId;
+        this.serviceId = serviceId;
+        this.live = live;
         this.paidOutDate = paidOutDate;
         this.state = state;
     }
@@ -34,7 +38,7 @@ public class PayoutView {
     public static PayoutView from(PayoutEntity payoutEntity) {
 
         return new PayoutView(payoutEntity.getAmount(), payoutEntity.getCreatedDate(), payoutEntity.getGatewayPayoutId(),
-                payoutEntity.getGatewayAccountId(), payoutEntity.getPaidOutDate(), payoutEntity.getState());
+                payoutEntity.getGatewayAccountId(), payoutEntity.getServiceId(), payoutEntity.isLive(), payoutEntity.getPaidOutDate(), payoutEntity.getState());
     }
 
     public Long getAmount() {
@@ -51,6 +55,14 @@ public class PayoutView {
 
     public String getGatewayAccountId() {
         return gatewayAccountId;
+    }
+
+    public String getServiceId() {
+        return serviceId;
+    }
+
+    public Boolean getLive() {
+        return live;
     }
 
     public ZonedDateTime getPaidOutDate() {

--- a/src/main/java/uk/gov/pay/ledger/queue/EventMessage.java
+++ b/src/main/java/uk/gov/pay/ledger/queue/EventMessage.java
@@ -22,6 +22,8 @@ public class EventMessage {
     public Event getEvent() {
         return new Event(
                 getQueueMessageId(),
+                eventDto.getServiceId(),
+                eventDto.isLive(),
                 eventDto.getResourceType(),
                 eventDto.getExternalId(),
                 eventDto.getParentExternalId(),

--- a/src/main/java/uk/gov/pay/ledger/queue/EventMessageDto.java
+++ b/src/main/java/uk/gov/pay/ledger/queue/EventMessageDto.java
@@ -3,23 +3,23 @@ package uk.gov.pay.ledger.queue;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import uk.gov.service.payments.commons.api.json.MicrosecondPrecisionDateTimeDeserializer;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import uk.gov.pay.ledger.event.model.ResourceType;
+import uk.gov.service.payments.commons.api.json.MicrosecondPrecisionDateTimeDeserializer;
 
 import java.time.ZonedDateTime;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class EventMessageDto {
 
-    @JsonProperty("service_id")
     private String serviceId;
 
-    @JsonProperty("live")
-    private boolean live;
+    private Boolean live;
 
     @JsonDeserialize(using = MicrosecondPrecisionDateTimeDeserializer.class)
-    @JsonProperty("timestamp")
     private ZonedDateTime timestamp;
 
     @JsonProperty("resource_external_id")
@@ -28,23 +28,20 @@ public class EventMessageDto {
     @JsonProperty("parent_resource_external_id")
     private String parentExternalId;
 
-    @JsonProperty("event_type")
     public String eventType;
 
-    @JsonProperty("resource_type")
     public ResourceType resourceType;
 
     @JsonProperty("event_details")
     private JsonNode eventData;
 
-    @JsonProperty("reproject_domain_object")
     private boolean reprojectDomainObject;
 
     public String getServiceId() {
         return serviceId;
     }
 
-    public boolean isLive() {
+    public Boolean isLive() {
         return live;
     }
 

--- a/src/main/java/uk/gov/pay/ledger/queue/EventMessageDto.java
+++ b/src/main/java/uk/gov/pay/ledger/queue/EventMessageDto.java
@@ -12,6 +12,12 @@ import java.time.ZonedDateTime;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class EventMessageDto {
 
+    @JsonProperty("service_id")
+    private String serviceId;
+
+    @JsonProperty("live")
+    private boolean live;
+
     @JsonDeserialize(using = MicrosecondPrecisionDateTimeDeserializer.class)
     @JsonProperty("timestamp")
     private ZonedDateTime timestamp;
@@ -33,6 +39,14 @@ public class EventMessageDto {
 
     @JsonProperty("reproject_domain_object")
     private boolean reprojectDomainObject;
+
+    public String getServiceId() {
+        return serviceId;
+    }
+
+    public boolean isLive() {
+        return live;
+    }
 
     public ResourceType getResourceType() {
         return resourceType;

--- a/src/main/java/uk/gov/pay/ledger/queue/eventprocessor/RefundEventProcessor.java
+++ b/src/main/java/uk/gov/pay/ledger/queue/eventprocessor/RefundEventProcessor.java
@@ -59,7 +59,7 @@ public class RefundEventProcessor extends EventProcessor {
          * for the digest can be removed.
          */
         Map<String, Object> fieldsFromPayment = getPaymentFieldsToProjectOnToRefund(paymentEventDigest);
-        refundEventDigest.getEventPayload().put("payment_details", fieldsFromPayment);
+        refundEventDigest.getEventAggregate().put("payment_details", fieldsFromPayment);
 
         TransactionEntity refundTransactionEntity = transactionEntityFactory.create(refundEventDigest);
         TransactionEntity paymentTransactionEntity = transactionEntityFactory.create(paymentEventDigest);
@@ -81,11 +81,11 @@ public class RefundEventProcessor extends EventProcessor {
     private Map<String, Object> getPaymentFieldsToProjectOnToRefund(EventDigest paymentEventDigest) {
         List<String> paymentsFieldsToCopyToRefunds = List.of("card_brand_label", "expiry_date", "card_type", "wallet_type");
 
-        var paymentPayloadIsEmpty = paymentEventDigest == null || paymentEventDigest.getEventPayload() == null;
+        var paymentPayloadIsEmpty = paymentEventDigest == null || paymentEventDigest.getEventAggregate() == null;
 
         return paymentPayloadIsEmpty
                 ? Map.of()
-                : paymentEventDigest.getEventPayload()
+                : paymentEventDigest.getEventAggregate()
                 .entrySet()
                 .stream().filter(entry -> paymentsFieldsToCopyToRefunds.contains(entry.getKey()))
                 .collect(toMap(Map.Entry::getKey, Map.Entry::getValue));

--- a/src/main/java/uk/gov/pay/ledger/transaction/dao/TransactionDao.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/dao/TransactionDao.java
@@ -116,6 +116,8 @@ public class TransactionDao {
             "INSERT INTO transaction(" +
                     "external_id," +
                     "parent_external_id," +
+                    "service_id," +
+                    "live," +
                     "gateway_account_id," +
                     "amount," +
                     "description," +
@@ -134,7 +136,6 @@ public class TransactionDao {
                     "refund_amount_available," +
                     "refund_amount_refunded, " +
                     "refund_status, " +
-                    "live, " +
                     "moto, " +
                     "gateway_transaction_id, " +
                     "source, " +
@@ -143,6 +144,8 @@ public class TransactionDao {
                     "VALUES (" +
                     ":externalId," +
                     ":parentExternalId," +
+                    ":serviceId," +
+                    ":live," +
                     ":gatewayAccountId," +
                     ":amount," +
                     ":description," +
@@ -163,7 +166,6 @@ public class TransactionDao {
                     ":refundAmountAvailable," +
                     ":refundAmountRefunded," +
                     ":refundStatus," +
-                    ":live, " +
                     ":moto, " +
                     ":gatewayTransactionId, " +
                     ":source::source, " +
@@ -173,6 +175,8 @@ public class TransactionDao {
                     "DO UPDATE SET " +
                     "external_id = EXCLUDED.external_id," +
                     "parent_external_id = EXCLUDED.parent_external_id," +
+                    "service_id = EXCLUDED.service_id," +
+                    "live = EXCLUDED.live," +
                     "gateway_account_id = EXCLUDED.gateway_account_id," +
                     "amount = EXCLUDED.amount," +
                     "description = EXCLUDED.description," +
@@ -193,7 +197,6 @@ public class TransactionDao {
                     "refund_amount_available = EXCLUDED.refund_amount_available, " +
                     "refund_amount_refunded = EXCLUDED.refund_amount_refunded, " +
                     "refund_status = EXCLUDED.refund_status, " +
-                    "live = EXCLUDED.live, " +
                     "moto = EXCLUDED.moto, " +
                     "gateway_transaction_id = EXCLUDED.gateway_transaction_id, " +
                     "source = EXCLUDED.source, " +

--- a/src/main/java/uk/gov/pay/ledger/transaction/dao/mapper/TransactionMapper.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/dao/mapper/TransactionMapper.java
@@ -44,7 +44,7 @@ public class TransactionMapper implements RowMapper<TransactionEntity> {
                 .withRefundAmountAvailable(getLongWithNullCheck(rs, "refund_amount_available"))
                 .withFee(getLongWithNullCheck(rs, "fee"))
                 .withTransactionType(rs.getString("type"))
-                .withLive(rs.getBoolean("live"))
+                .withLive(getBooleanWithNullCheck(rs,"live"))
                 .withMoto(rs.getBoolean("moto"))
                 .withGatewayTransactionId(rs.getString("gateway_transaction_id"))
                 .withGatewayPayoutId(rs.getString("gateway_payout_id"));
@@ -60,6 +60,11 @@ public class TransactionMapper implements RowMapper<TransactionEntity> {
 
     private Long getLongWithNullCheck(ResultSet rs, String columnName) throws SQLException {
         long value = rs.getLong(columnName);
+        return rs.wasNull() ? null : value;
+    }
+
+    private Boolean getBooleanWithNullCheck(ResultSet rs, String columnName) throws SQLException {
+        Boolean value = rs.getBoolean(columnName);
         return rs.wasNull() ? null : value;
     }
 

--- a/src/main/java/uk/gov/pay/ledger/transaction/dao/mapper/TransactionMapper.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/dao/mapper/TransactionMapper.java
@@ -14,6 +14,7 @@ import java.time.ZonedDateTime;
 import java.util.Optional;
 
 import static uk.gov.pay.ledger.payout.entity.PayoutEntity.PayoutEntityBuilder.aPayoutEntity;
+import static uk.gov.pay.ledger.util.dao.MapperUtils.getBooleanWithNullCheck;
 
 public class TransactionMapper implements RowMapper<TransactionEntity> {
 
@@ -60,11 +61,6 @@ public class TransactionMapper implements RowMapper<TransactionEntity> {
 
     private Long getLongWithNullCheck(ResultSet rs, String columnName) throws SQLException {
         long value = rs.getLong(columnName);
-        return rs.wasNull() ? null : value;
-    }
-
-    private Boolean getBooleanWithNullCheck(ResultSet rs, String columnName) throws SQLException {
-        Boolean value = rs.getBoolean(columnName);
         return rs.wasNull() ? null : value;
     }
 

--- a/src/main/java/uk/gov/pay/ledger/transaction/dao/mapper/TransactionMapper.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/dao/mapper/TransactionMapper.java
@@ -21,6 +21,7 @@ public class TransactionMapper implements RowMapper<TransactionEntity> {
     public TransactionEntity map(ResultSet rs, StatementContext ctx) throws SQLException {
         var transactionBuilder = new TransactionEntity.Builder()
                 .withId(rs.getLong("id"))
+                .withServiceId(rs.getString("service_id"))
                 .withGatewayAccountId(rs.getString("gateway_account_id"))
                 .withExternalId(rs.getString("external_id"))
                 .withParentExternalId(rs.getString("parent_external_id"))

--- a/src/main/java/uk/gov/pay/ledger/transaction/entity/TransactionEntity.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/entity/TransactionEntity.java
@@ -2,21 +2,23 @@ package uk.gov.pay.ledger.transaction.entity;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
-import uk.gov.service.payments.commons.model.Source;
 import uk.gov.pay.ledger.payout.entity.PayoutEntity;
 import uk.gov.pay.ledger.transaction.state.TransactionState;
+import uk.gov.service.payments.commons.model.Source;
 
 import java.time.ZonedDateTime;
 import java.util.Optional;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class TransactionEntity {
 
     @JsonIgnore
     private Long id;
+    private String serviceId;
+    private boolean live;
     private String gatewayAccountId;
     @JsonIgnore
     private String externalId;
@@ -44,7 +46,6 @@ public class TransactionEntity {
     private String refundStatus;
     private Long refundAmountRefunded;
     private Long refundAmountAvailable;
-    private boolean live;
     private boolean moto;
     private String gatewayTransactionId;
     private Source source;
@@ -56,6 +57,8 @@ public class TransactionEntity {
 
     public TransactionEntity(Builder builder) {
         this.id = builder.id;
+        this.serviceId = builder.serviceId;
+        this.live = builder.live;
         this.gatewayAccountId = builder.gatewayAccountId;
         this.externalId = builder.externalId;
         this.parentExternalId = builder.parentExternalId;
@@ -78,7 +81,6 @@ public class TransactionEntity {
         this.refundAmountAvailable = builder.refundAmountAvailable;
         this.fee = builder.fee;
         this.transactionType = builder.transactionType;
-        this.live = builder.live;
         this.moto = builder.moto;
         this.gatewayTransactionId = builder.gatewayTransactionId;
         this.source = builder.source;
@@ -92,6 +94,10 @@ public class TransactionEntity {
 
     public String getGatewayAccountId() {
         return gatewayAccountId;
+    }
+
+    public String getServiceId() {
+        return serviceId;
     }
 
     public String getExternalId() {
@@ -178,6 +184,10 @@ public class TransactionEntity {
         this.transactionType = transactionType;
     }
 
+    public void setLive(boolean live) {
+        this.live = live;
+    }
+
     public Long getNetAmount() {
         return netAmount;
     }
@@ -240,9 +250,14 @@ public class TransactionEntity {
         this.email = paymentTransaction.email;
     }
 
+    public void setServiceId(String serviceId) {
+        this.serviceId = serviceId;
+    }
+
     public static class Builder {
         private Long fee;
         private Long id;
+        private String serviceId;
         private String gatewayAccountId;
         private String externalId;
         private String parentExternalId;
@@ -280,6 +295,11 @@ public class TransactionEntity {
 
         public Builder withId(Long id) {
             this.id = id;
+            return this;
+        }
+
+        public Builder withServiceId(String serviceId) {
+            this.serviceId = serviceId;
             return this;
         }
 

--- a/src/main/java/uk/gov/pay/ledger/transaction/entity/TransactionEntity.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/entity/TransactionEntity.java
@@ -18,7 +18,7 @@ public class TransactionEntity {
     @JsonIgnore
     private Long id;
     private String serviceId;
-    private boolean live;
+    private Boolean live;
     private String gatewayAccountId;
     @JsonIgnore
     private String externalId;
@@ -184,7 +184,7 @@ public class TransactionEntity {
         this.transactionType = transactionType;
     }
 
-    public void setLive(boolean live) {
+    public void setLive(Boolean live) {
         this.live = live;
     }
 
@@ -216,7 +216,11 @@ public class TransactionEntity {
         return transactionType;
     }
 
-    public boolean isLive() {
+    public Boolean isLive() {
+        return live;
+    }
+
+    public Boolean getLive() {
         return live;
     }
 
@@ -279,7 +283,7 @@ public class TransactionEntity {
         private Long refundAmountRefunded;
         private Long refundAmountAvailable;
         private String transactionType;
-        private boolean live;
+        private Boolean live;
         private Source source;
         private String gatewayTransactionId;
         private boolean moto;
@@ -413,7 +417,7 @@ public class TransactionEntity {
             return this;
         }
 
-        public Builder withLive(boolean live) {
+        public Builder withLive(Boolean live) {
             this.live = live;
             return this;
         }

--- a/src/main/java/uk/gov/pay/ledger/transaction/model/Payment.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/model/Payment.java
@@ -51,7 +51,7 @@ public class Payment extends Transaction {
     }
 
     public Payment(Builder builder) {
-        super(builder.id, builder.gatewayAccountId, builder.amount, builder.externalId, builder.gatewayPayoutId);
+        super(builder.id, builder.gatewayAccountId, builder.serviceId, builder.live, builder.amount, builder.externalId, builder.gatewayPayoutId);
         this.credentialExternalId = builder.credentialExternalId;
         this.corporateCardSurcharge = builder.corporateCardSurcharge;
         this.fee = builder.fee;
@@ -187,6 +187,7 @@ public class Payment extends Transaction {
     }
 
     public static class Builder {
+        public String serviceId;
         private Long id;
         private Boolean moto;
         private String reference;
@@ -367,6 +368,11 @@ public class Payment extends Transaction {
 
         public Builder withCredentialExternalId(String credentialExternalId) {
             this.credentialExternalId = credentialExternalId;
+            return this;
+        }
+
+        public Builder withServiceId(String serviceId) {
+            this.serviceId = serviceId;
             return this;
         }
     }

--- a/src/main/java/uk/gov/pay/ledger/transaction/model/Refund.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/model/Refund.java
@@ -17,7 +17,7 @@ public class Refund extends Transaction {
     private final SettlementSummary settlementSummary;
 
     public Refund(Builder builder) {
-        super(builder.id, builder.gatewayAccountId, builder.amount, builder.externalId, builder.gatewayPayoutId);
+        super(builder.id, builder.gatewayAccountId, builder.serviceId, builder.live, builder.amount, builder.externalId, builder.gatewayPayoutId);
         this.state = builder.state;
         this.createdDate = builder.createdDate;
         this.eventCount = builder.eventCount;
@@ -71,6 +71,8 @@ public class Refund extends Transaction {
     }
 
     public static class Builder {
+        public String serviceId;
+        public Boolean live;
         private TransactionState state;
         private ZonedDateTime createdDate;
         private Integer eventCount;
@@ -160,6 +162,16 @@ public class Refund extends Transaction {
 
         public Builder withSettlementSummary(SettlementSummary refundSettlementSummary) {
             this.settlementSummary = refundSettlementSummary;
+            return this;
+        }
+
+        public Builder withLive(Boolean live) {
+            this.live = live;
+            return this;
+        }
+
+        public Builder withServiceId(String serviceId) {
+            this.serviceId = serviceId;
             return this;
         }
     }

--- a/src/main/java/uk/gov/pay/ledger/transaction/model/Transaction.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/model/Transaction.java
@@ -10,6 +10,8 @@ public abstract class Transaction {
     @JsonIgnore
     protected Long id;
     protected String gatewayAccountId;
+    protected String serviceId;
+    protected Boolean live;
     protected Long amount;
     protected String externalId;
     private String gatewayPayoutId;
@@ -17,9 +19,11 @@ public abstract class Transaction {
     public Transaction() {
     }
 
-    public Transaction(Long id, String gatewayAccountId, Long amount, String externalId, String gatewayPayoutId) {
+    public Transaction(Long id, String gatewayAccountId, String serviceId, Boolean live, Long amount, String externalId, String gatewayPayoutId) {
         this.id = id;
         this.gatewayAccountId = gatewayAccountId;
+        this.serviceId = serviceId;
+        this.live = live;
         this.amount = amount;
         this.externalId = externalId;
         this.gatewayPayoutId = gatewayPayoutId;
@@ -31,6 +35,14 @@ public abstract class Transaction {
 
     public String getGatewayAccountId() {
         return gatewayAccountId;
+    }
+
+    public String getServiceId() {
+        return serviceId;
+    }
+
+    public Boolean getLive() {
+        return live;
     }
 
     public Long getAmount() {

--- a/src/main/java/uk/gov/pay/ledger/transaction/model/TransactionFactory.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/model/TransactionFactory.java
@@ -75,6 +75,7 @@ public class TransactionFactory {
 
             return new Payment.Builder()
                     .withGatewayAccountId(entity.getGatewayAccountId())
+                    .withServiceId(entity.getServiceId())
                     .withCredentialExternalId(credentialExternalId)
                     .withAmount(entity.getAmount())
                     .withReference(entity.getReference())
@@ -135,6 +136,8 @@ public class TransactionFactory {
 
             return new Refund.Builder()
                     .withGatewayAccountId(entity.getGatewayAccountId())
+                    .withServiceId(entity.getServiceId())
+                    .withLive(entity.isLive())
                     .withAmount(entity.getAmount())
                     .withGatewayTransactionId(entity.getGatewayTransactionId())
                     .withState(entity.getState())

--- a/src/main/java/uk/gov/pay/ledger/transaction/search/model/TransactionView.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/search/model/TransactionView.java
@@ -28,6 +28,7 @@ public class TransactionView {
     @JsonIgnore
     private Long id;
     private String gatewayAccountId;
+    private String serviceId;
     private String credentialExternalId;
     private Long amount;
     private Long totalAmount;
@@ -64,6 +65,7 @@ public class TransactionView {
     public TransactionView(Builder builder) {
         this.id = builder.id;
         this.gatewayAccountId = builder.gatewayAccountId;
+        this.serviceId = builder.serviceId;
         this.credentialExternalId = builder.credentialExternalId;
         this.amount = builder.amount;
         this.totalAmount = builder.totalAmount;
@@ -107,6 +109,7 @@ public class TransactionView {
             Builder paymentBuilder = new Builder()
                     .withId(payment.getId())
                     .withGatewayAccountId(payment.getGatewayAccountId())
+                    .withServiceId(payment.getServiceId())
                     .withCredentialExternalId(payment.getCredentialExternalId())
                     .withAmount(payment.getAmount())
                     .withTotalAmount(payment.getTotalAmount())
@@ -169,6 +172,10 @@ public class TransactionView {
 
     public String getGatewayAccountId() {
         return gatewayAccountId;
+    }
+
+    public String getServiceId() {
+        return serviceId;
     }
 
     public String getCredentialExternalId() {
@@ -345,6 +352,7 @@ public class TransactionView {
         private String gatewayPayoutId;
         private TransactionView paymentDetails;
         private String credentialExternalId;
+        private String serviceId;
 
         public Builder() {
         }
@@ -515,6 +523,11 @@ public class TransactionView {
 
         public Builder withCredentialExternalId(String credentialExternalId) {
             this.credentialExternalId = credentialExternalId;
+            return this;
+        }
+
+        public Builder withServiceId(String serviceId) {
+            this.serviceId = serviceId;
             return this;
         }
     }

--- a/src/main/java/uk/gov/pay/ledger/transaction/service/TransactionMetadataService.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/service/TransactionMetadataService.java
@@ -66,7 +66,7 @@ public class TransactionMetadataService {
     }
 
     public void reprojectFromEventDigest(EventDigest eventDigest) {
-        var eventData = eventDigest.getEventPayload();
+        var eventData = eventDigest.getEventAggregate();
 
         transactionDao.findTransactionByExternalId(eventDigest.getResourceExternalId())
                 .ifPresent(transactionEntity -> {

--- a/src/main/java/uk/gov/pay/ledger/transactionsummary/dao/TransactionSummaryDao.java
+++ b/src/main/java/uk/gov/pay/ledger/transactionsummary/dao/TransactionSummaryDao.java
@@ -82,7 +82,7 @@ public class TransactionSummaryDao {
     }
 
     public void upsert(String gatewayAccountId, String transactionType, LocalDate transactionDate,
-                       TransactionState state, boolean live, boolean moto, Long amount) {
+                       TransactionState state, Boolean live, boolean moto, Long amount) {
         jdbi.withHandle(handle ->
                 handle.createUpdate(UPSERT_STRING)
                         .bind("gatewayAccountId", gatewayAccountId)

--- a/src/main/java/uk/gov/pay/ledger/util/dao/MapperUtils.java
+++ b/src/main/java/uk/gov/pay/ledger/util/dao/MapperUtils.java
@@ -1,0 +1,11 @@
+package uk.gov.pay.ledger.util.dao;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+public class MapperUtils {
+    public static Boolean getBooleanWithNullCheck(ResultSet rs, String columnName) throws SQLException {
+        var value = rs.getBoolean(columnName);
+        return rs.wasNull() ? null : value;
+    }
+}

--- a/src/test/java/uk/gov/pay/ledger/event/model/TransactionEntityFactoryTest.java
+++ b/src/test/java/uk/gov/pay/ledger/event/model/TransactionEntityFactoryTest.java
@@ -58,21 +58,23 @@ public class TransactionEntityFactoryTest {
         TransactionEntity transactionEntity = transactionEntityFactory.create(eventDigest);
 
         assertThat(transactionEntity.getExternalId(), is(eventDigest.getResourceExternalId()));
+        assertThat(transactionEntity.getServiceId(), is(paymentCreatedEvent.getServiceId()));
+        assertThat(transactionEntity.isLive(), is(paymentCreatedEvent.isLive()));
         assertThat(transactionEntity.getState().toString(), is("CREATED"));
         assertThat(transactionEntity.getCreatedDate(), is(paymentCreatedEvent.getEventDate()));
         assertThat(transactionEntity.getEventCount(), is(eventDigest.getEventCount()));
-        assertThat(transactionEntity.getReference(), is(eventDigest.getEventPayload().get("reference")));
-        assertThat(transactionEntity.getGatewayAccountId(), is(eventDigest.getEventPayload().get("gateway_account_id")));
-        assertThat(transactionEntity.getCardholderName(), is(eventDigest.getEventPayload().get("cardholder_name")));
-        assertThat(transactionEntity.getEmail(), is(eventDigest.getEventPayload().get("email")));
-        assertThat(transactionEntity.getCardBrand(), is(eventDigest.getEventPayload().get("card_brand")));
-        assertThat(transactionEntity.getDescription(), is(eventDigest.getEventPayload().get("description")));
-        assertThat(transactionEntity.getFirstDigitsCardNumber(), is(eventDigest.getEventPayload().get("first_digits_card_number")));
-        assertThat(transactionEntity.getLastDigitsCardNumber(), is(eventDigest.getEventPayload().get("last_digits_card_number")));
-        assertThat(transactionEntity.getAmount(), is(((Integer)eventDigest.getEventPayload().get("amount")).longValue()));
-        assertThat(transactionEntity.getNetAmount(), is(((Integer)eventDigest.getEventPayload().get("net_amount")).longValue()));
-        assertThat(transactionEntity.getTotalAmount(), is(((Integer)eventDigest.getEventPayload().get("total_amount")).longValue()));
-        assertThat(transactionEntity.getFee(), is(((Integer)eventDigest.getEventPayload().get("fee")).longValue()));
+        assertThat(transactionEntity.getReference(), is(eventDigest.getEventAggregate().get("reference")));
+        assertThat(transactionEntity.getGatewayAccountId(), is(eventDigest.getEventAggregate().get("gateway_account_id")));
+        assertThat(transactionEntity.getCardholderName(), is(eventDigest.getEventAggregate().get("cardholder_name")));
+        assertThat(transactionEntity.getEmail(), is(eventDigest.getEventAggregate().get("email")));
+        assertThat(transactionEntity.getCardBrand(), is(eventDigest.getEventAggregate().get("card_brand")));
+        assertThat(transactionEntity.getDescription(), is(eventDigest.getEventAggregate().get("description")));
+        assertThat(transactionEntity.getFirstDigitsCardNumber(), is(eventDigest.getEventAggregate().get("first_digits_card_number")));
+        assertThat(transactionEntity.getLastDigitsCardNumber(), is(eventDigest.getEventAggregate().get("last_digits_card_number")));
+        assertThat(transactionEntity.getAmount(), is(((Integer)eventDigest.getEventAggregate().get("amount")).longValue()));
+        assertThat(transactionEntity.getNetAmount(), is(((Integer)eventDigest.getEventAggregate().get("net_amount")).longValue()));
+        assertThat(transactionEntity.getTotalAmount(), is(((Integer)eventDigest.getEventAggregate().get("total_amount")).longValue()));
+        assertThat(transactionEntity.getFee(), is(((Integer)eventDigest.getEventAggregate().get("fee")).longValue()));
         assertThat(transactionEntity.getTransactionType(), is("PAYMENT"));
         assertThat(transactionEntity.getSource(), is(notNullValue()));
         assertThat(transactionEntity.isLive(), is(true));
@@ -88,7 +90,7 @@ public class TransactionEntityFactoryTest {
         assertThat(transactionDetails.get("delayed_capture").getAsBoolean(), is(false));
         assertThat(transactionDetails.get("return_url").getAsString(), is("https://example.org"));
         assertThat(transactionDetails.get("corporate_surcharge").getAsInt(), is(5));
-        assertThat(transactionDetails.get("gateway_transaction_id").getAsString(), is(eventDigest.getEventPayload().get("gateway_transaction_id")));
+        assertThat(transactionDetails.get("gateway_transaction_id").getAsString(), is(eventDigest.getEventAggregate().get("gateway_transaction_id")));
         assertThat(transactionDetails.get("external_metadata").getAsJsonObject().get("key").getAsString(), is("value"));
     }
 

--- a/src/test/java/uk/gov/pay/ledger/event/model/TransactionEntityFactoryTest.java
+++ b/src/test/java/uk/gov/pay/ledger/event/model/TransactionEntityFactoryTest.java
@@ -59,7 +59,7 @@ public class TransactionEntityFactoryTest {
 
         assertThat(transactionEntity.getExternalId(), is(eventDigest.getResourceExternalId()));
         assertThat(transactionEntity.getServiceId(), is(paymentCreatedEvent.getServiceId()));
-        assertThat(transactionEntity.isLive(), is(paymentCreatedEvent.isLive()));
+        assertThat(transactionEntity.isLive(), is(paymentCreatedEvent.getLive()));
         assertThat(transactionEntity.getState().toString(), is("CREATED"));
         assertThat(transactionEntity.getCreatedDate(), is(paymentCreatedEvent.getEventDate()));
         assertThat(transactionEntity.getEventCount(), is(eventDigest.getEventCount()));

--- a/src/test/java/uk/gov/pay/ledger/event/service/EventServiceTest.java
+++ b/src/test/java/uk/gov/pay/ledger/event/service/EventServiceTest.java
@@ -73,8 +73,8 @@ public class EventServiceTest {
     public void laterEventsShouldOverrideEarlierEventsInEventDetailsDigest() {
         EventDigest eventDigest = eventService.getEventDigestForResource(event1);
 
-        assertThat(eventDigest.getEventPayload().get("description"), is("a payment"));
-        assertThat(eventDigest.getEventPayload().get("amount"), is(1000));
+        assertThat(eventDigest.getEventAggregate().get("description"), is("a payment"));
+        assertThat(eventDigest.getEventAggregate().get("amount"), is(1000));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/ledger/payout/dao/PayoutDaoIT.java
+++ b/src/test/java/uk/gov/pay/ledger/payout/dao/PayoutDaoIT.java
@@ -1,9 +1,7 @@
 package uk.gov.pay.ledger.payout.dao;
 
-import io.dropwizard.testing.junit5.DropwizardExtensionsSupport;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.testcontainers.shaded.org.apache.commons.lang.RandomStringUtils;
 import uk.gov.pay.ledger.extension.AppWithPostgresAndSqsExtension;
@@ -61,7 +59,7 @@ public class PayoutDaoIT {
         assertThat(payout.getAmount(), is(100L));
         assertThat(payout.getGatewayPayoutId(), is(gatewayPayoutId));
         assertThat(payout.getServiceId(), is(serviceId));
-        assertThat(payout.isLive(), is(live));
+        assertThat(payout.getLive(), is(live));
         assertThat(payout.getState(), is(PayoutState.PAID_OUT));
         assertThat(payout.getCreatedDate(), is(createdDate));
         assertThat(payout.getPaidOutDate(), is(paidOutDate));

--- a/src/test/java/uk/gov/pay/ledger/payout/dao/PayoutDaoIT.java
+++ b/src/test/java/uk/gov/pay/ledger/payout/dao/PayoutDaoIT.java
@@ -39,7 +39,7 @@ public class PayoutDaoIT {
         var paidOutDate = createdDate.minusDays(1);
         var id = RandomStringUtils.randomNumeric(4);
         var gatewayAccountId = RandomStringUtils.randomAlphanumeric(10);
-        var serviceId = RandomStringUtils.randomAlphanumeric(10);
+        var serviceId = RandomStringUtils.randomAlphanumeric(26);
         var live = true;
 
         aPayoutFixture()

--- a/src/test/java/uk/gov/pay/ledger/payout/dao/PayoutDaoIT.java
+++ b/src/test/java/uk/gov/pay/ledger/payout/dao/PayoutDaoIT.java
@@ -39,11 +39,16 @@ public class PayoutDaoIT {
         var paidOutDate = createdDate.minusDays(1);
         var id = RandomStringUtils.randomNumeric(4);
         var gatewayAccountId = RandomStringUtils.randomAlphanumeric(10);
+        var serviceId = RandomStringUtils.randomAlphanumeric(10);
+        var live = true;
+
         aPayoutFixture()
                 .withId(Long.valueOf(id))
                 .withAmount(100L)
                 .withCreatedDate(createdDate)
                 .withGatewayPayoutId(gatewayPayoutId)
+                .withServiceId(serviceId)
+                .withLive(live)
                 .withPaidOutDate(paidOutDate)
                 .withState(PayoutState.PAID_OUT)
                 .withEventCount(1)
@@ -51,9 +56,12 @@ public class PayoutDaoIT {
                 .withGatewayAccountId(gatewayAccountId)
                 .build().insert(rule.getJdbi());
         var payout = payoutDao.findByGatewayPayoutId(gatewayPayoutId).get();
+
         assertThat(payout.getId(), is(Long.valueOf(id)));
         assertThat(payout.getAmount(), is(100L));
         assertThat(payout.getGatewayPayoutId(), is(gatewayPayoutId));
+        assertThat(payout.getServiceId(), is(serviceId));
+        assertThat(payout.isLive(), is(live));
         assertThat(payout.getState(), is(PayoutState.PAID_OUT));
         assertThat(payout.getCreatedDate(), is(createdDate));
         assertThat(payout.getPaidOutDate(), is(paidOutDate));

--- a/src/test/java/uk/gov/pay/ledger/payout/model/PayoutEntityFactoryTest.java
+++ b/src/test/java/uk/gov/pay/ledger/payout/model/PayoutEntityFactoryTest.java
@@ -57,7 +57,7 @@ public class PayoutEntityFactoryTest {
 
         assertThat(payoutEntity.getGatewayPayoutId(), is(payoutCreatedEvent.getResourceExternalId()));
         assertThat(payoutEntity.getServiceId(), is(payoutCreatedEvent.getServiceId()));
-        assertThat(payoutEntity.isLive(), is(payoutCreatedEvent.isLive()));
+        assertThat(payoutEntity.isLive(), is(payoutCreatedEvent.getLive()));
         assertThat(payoutEntity.getAmount(), is(10000L));
         assertThat(payoutEntity.getCreatedDate(), is(payoutCreatedEvent.getEventDate()));
         assertThat(payoutEntity.getPaidOutDate(), is(paidOutDate));

--- a/src/test/java/uk/gov/pay/ledger/payout/model/PayoutEntityFactoryTest.java
+++ b/src/test/java/uk/gov/pay/ledger/payout/model/PayoutEntityFactoryTest.java
@@ -57,7 +57,7 @@ public class PayoutEntityFactoryTest {
 
         assertThat(payoutEntity.getGatewayPayoutId(), is(payoutCreatedEvent.getResourceExternalId()));
         assertThat(payoutEntity.getServiceId(), is(payoutCreatedEvent.getServiceId()));
-        assertThat(payoutEntity.isLive(), is(payoutCreatedEvent.getLive()));
+        assertThat(payoutEntity.getLive(), is(payoutCreatedEvent.getLive()));
         assertThat(payoutEntity.getAmount(), is(10000L));
         assertThat(payoutEntity.getCreatedDate(), is(payoutCreatedEvent.getEventDate()));
         assertThat(payoutEntity.getPaidOutDate(), is(paidOutDate));

--- a/src/test/java/uk/gov/pay/ledger/payout/model/PayoutEntityFactoryTest.java
+++ b/src/test/java/uk/gov/pay/ledger/payout/model/PayoutEntityFactoryTest.java
@@ -56,6 +56,8 @@ public class PayoutEntityFactoryTest {
         PayoutEntity payoutEntity = payoutEntityFactory.create(eventDigest);
 
         assertThat(payoutEntity.getGatewayPayoutId(), is(payoutCreatedEvent.getResourceExternalId()));
+        assertThat(payoutEntity.getServiceId(), is(payoutCreatedEvent.getServiceId()));
+        assertThat(payoutEntity.isLive(), is(payoutCreatedEvent.isLive()));
         assertThat(payoutEntity.getAmount(), is(10000L));
         assertThat(payoutEntity.getCreatedDate(), is(payoutCreatedEvent.getEventDate()));
         assertThat(payoutEntity.getPaidOutDate(), is(paidOutDate));

--- a/src/test/java/uk/gov/pay/ledger/payout/resource/PayoutResourceSearchIT.java
+++ b/src/test/java/uk/gov/pay/ledger/payout/resource/PayoutResourceSearchIT.java
@@ -50,6 +50,8 @@ public class PayoutResourceSearchIT {
                 .statusCode(Response.Status.OK.getStatusCode())
                 .contentType(JSON)
                 .body("results[0].gateway_account_id", is(payoutToVerify.getGatewayAccountId()))
+                .body("results[0].service_id", is(payoutToVerify.getServiceId()))
+                .body("results[0].live", is(payoutToVerify.isLive()))
                 .body("results[0].gateway_payout_id", is(payoutToVerify.getGatewayPayoutId()))
                 .body("results[0].created_date", is(ISO_INSTANT_MILLISECOND_PRECISION.format(payoutToVerify.getCreatedDate())))
                 .body("results[0].paid_out_date", is(ISO_INSTANT_MILLISECOND_PRECISION.format(payoutToVerify.getPaidOutDate())))

--- a/src/test/java/uk/gov/pay/ledger/payout/resource/PayoutResourceSearchIT.java
+++ b/src/test/java/uk/gov/pay/ledger/payout/resource/PayoutResourceSearchIT.java
@@ -1,10 +1,8 @@
 package uk.gov.pay.ledger.payout.resource;
 
-import io.dropwizard.testing.junit5.DropwizardExtensionsSupport;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import uk.gov.pay.ledger.extension.AppWithPostgresAndSqsExtension;
 import uk.gov.pay.ledger.payout.entity.PayoutEntity;
@@ -16,9 +14,9 @@ import static io.restassured.RestAssured.given;
 import static io.restassured.http.ContentType.JSON;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.Matchers.containsString;
-import static uk.gov.service.payments.commons.model.ApiResponseDateTimeFormatter.ISO_INSTANT_MILLISECOND_PRECISION;
 import static uk.gov.pay.ledger.util.DatabaseTestHelper.aDatabaseTestHelper;
 import static uk.gov.pay.ledger.util.fixture.PayoutFixture.aPersistedPayoutList;
+import static uk.gov.service.payments.commons.model.ApiResponseDateTimeFormatter.ISO_INSTANT_MILLISECOND_PRECISION;
 
 public class PayoutResourceSearchIT {
 
@@ -51,7 +49,7 @@ public class PayoutResourceSearchIT {
                 .contentType(JSON)
                 .body("results[0].gateway_account_id", is(payoutToVerify.getGatewayAccountId()))
                 .body("results[0].service_id", is(payoutToVerify.getServiceId()))
-                .body("results[0].live", is(payoutToVerify.isLive()))
+                .body("results[0].live", is(payoutToVerify.getLive()))
                 .body("results[0].gateway_payout_id", is(payoutToVerify.getGatewayPayoutId()))
                 .body("results[0].created_date", is(ISO_INSTANT_MILLISECOND_PRECISION.format(payoutToVerify.getCreatedDate())))
                 .body("results[0].paid_out_date", is(ISO_INSTANT_MILLISECOND_PRECISION.format(payoutToVerify.getPaidOutDate())))

--- a/src/test/java/uk/gov/pay/ledger/queue/QueueMessageReceiverIT.java
+++ b/src/test/java/uk/gov/pay/ledger/queue/QueueMessageReceiverIT.java
@@ -101,37 +101,6 @@ public class QueueMessageReceiverIT {
     }
 
     @Test
-    public void shouldSetLiveFromEventDetailsIfNotSetAtTopLevel2() throws InterruptedException {
-        final String resourceExternalId = "rexid";
-        String gatewayAccountId = "test_gateway_account_id";
-
-        aQueuePaymentEventFixture()
-                .withLive(null)
-                .withResourceExternalId(resourceExternalId)
-                .withEventDate(CREATED_AT.minusMinutes(1))
-                .withGatewayAccountId(gatewayAccountId)
-                .withEventType(SalientEventType.PAYMENT_CREATED.name())
-                .withDefaultEventDataForEventType(SalientEventType.PAYMENT_CREATED.name())
-                .insert(rule.getSqsClient());
-
-        aQueuePaymentEventFixture()
-                .withLive(null)
-                .withResourceExternalId(resourceExternalId)
-                .withEventDate(CREATED_AT)
-                .withEventType(SalientEventType.CAPTURE_CONFIRMED_BY_GATEWAY_NOTIFICATION.name())
-                .insert(rule.getSqsClient());
-
-        Thread.sleep(500);
-
-        given().port(rule.getAppRule().getLocalPort())
-                .contentType(JSON)
-                .get("/v1/transaction-summary/" + resourceExternalId + "?account_id=" + gatewayAccountId)
-                .then()
-                .statusCode(200)
-                .body("transaction_id", is(resourceExternalId));
-    }
-
-    @Test
     public void shouldContinueToHandleMessagesFromQueueForDownstreamExceptions() throws InterruptedException {
         final String resourceExternalId = "rexid";
         final String resourceExternalId2 = "rexid2";

--- a/src/test/java/uk/gov/pay/ledger/transaction/dao/TransactionDaoIT.java
+++ b/src/test/java/uk/gov/pay/ledger/transaction/dao/TransactionDaoIT.java
@@ -131,6 +131,8 @@ class TransactionDaoIT {
 
     private void assertTransactionEntity(TransactionEntity transaction, TransactionFixture fixture) {
         assertThat(transaction.getId(), notNullValue());
+        assertThat(transaction.getServiceId(), is(fixture.getServiceId()));
+        assertThat(transaction.isLive(), is(fixture.isLive()));
         assertThat(transaction.getGatewayAccountId(), is(fixture.getGatewayAccountId()));
         assertThat(transaction.getExternalId(), is(fixture.getExternalId()));
         assertThat(transaction.getAmount(), is(fixture.getAmount()));
@@ -215,6 +217,8 @@ class TransactionDaoIT {
                 .get();
 
         assertThat(transaction.getId(), notNullValue());
+        assertThat(transaction.getServiceId(), is(transactionEntity.getServiceId()));
+        assertThat(transaction.isLive(), is(transactionEntity.isLive()));
         assertThat(transaction.getGatewayAccountId(), is(transactionEntity.getGatewayAccountId()));
         assertThat(transaction.getExternalId(), is(transactionEntity.getExternalId()));
         assertThat(transaction.getAmount(), is(transactionEntity.getAmount()));

--- a/src/test/java/uk/gov/pay/ledger/transaction/model/TransactionFactoryTest.java
+++ b/src/test/java/uk/gov/pay/ledger/transaction/model/TransactionFactoryTest.java
@@ -26,6 +26,8 @@ public class TransactionFactoryTest {
 
     private Long id = 1L;
     private String gatewayAccountId = "ruwe2424";
+    private String serviceId = "test_service_id";
+    private Boolean live = true;
     private String externalId = "ch_q72347235";
     private Long amount = 100L;
     private String reference = "ref_237156782465";
@@ -84,6 +86,8 @@ public class TransactionFactoryTest {
         fullDataObject = new TransactionEntity.Builder()
                 .withId(id)
                 .withGatewayAccountId(gatewayAccountId)
+                .withServiceId(serviceId)
+                .withLive(live)
                 .withExternalId(externalId)
                 .withAmount(amount)
                 .withReference(reference)
@@ -109,6 +113,8 @@ public class TransactionFactoryTest {
         minimalDataObject = new TransactionEntity.Builder()
                 .withId(id)
                 .withGatewayAccountId(gatewayAccountId)
+                .withServiceId(serviceId)
+                .withLive(live)
                 .withExternalId(externalId)
                 .withAmount(amount)
                 .withReference(reference)
@@ -143,6 +149,8 @@ public class TransactionFactoryTest {
         Payment payment = (Payment) transactionFactory.createTransactionEntity(minimalDataObject);
 
         assertThat(payment.getGatewayAccountId(), is(gatewayAccountId));
+        assertThat(payment.getServiceId(), is(serviceId));
+        assertThat(payment.getLive(), is(live));
         assertThat(payment.getAmount(), is(amount));
         assertThat(payment.getExternalId(), is(externalId));
         assertThat(payment.getReference(), is(reference));
@@ -183,6 +191,8 @@ public class TransactionFactoryTest {
                 .withTransactionType("REFUND")
                 .withId(id)
                 .withGatewayAccountId(gatewayAccountId)
+                .withServiceId(serviceId)
+                .withLive(live)
                 .withExternalId(externalId)
                 .withParentExternalId("parent-ext-id")
                 .withAmount(amount)
@@ -195,6 +205,8 @@ public class TransactionFactoryTest {
         Refund refundEntity = (Refund) transactionFactory.createTransactionEntity(refund);
 
         assertThat(refundEntity.getGatewayAccountId(), is(gatewayAccountId));
+        assertThat(refundEntity.getServiceId(), is(serviceId));
+        assertThat(refundEntity.getLive(), is(live));
         assertThat(refundEntity.getAmount(), is(amount));
         assertThat(refundEntity.getExternalId(), is(externalId));
         assertThat(refundEntity.getParentExternalId(), is("parent-ext-id"));
@@ -271,6 +283,8 @@ public class TransactionFactoryTest {
 
     private void assertCorrectPaymentTransactionWithFullData(Payment payment) {
         assertThat(payment.getGatewayAccountId(), is(gatewayAccountId));
+        assertThat(payment.getServiceId(), is(serviceId));
+        assertThat(payment.getLive(), is(live));
         assertThat(payment.getCredentialExternalId(), is("credential-external-id"));
         assertThat(payment.getAmount(), is(amount));
         assertThat(payment.getExternalId(), is(externalId));

--- a/src/test/java/uk/gov/pay/ledger/transactionsummary/dao/TransactionSummaryDaoIT.java
+++ b/src/test/java/uk/gov/pay/ledger/transactionsummary/dao/TransactionSummaryDaoIT.java
@@ -22,6 +22,7 @@ import static java.time.LocalDate.parse;
 import static org.apache.commons.lang3.RandomStringUtils.randomAlphanumeric;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.number.BigDecimalCloseTo.closeTo;
 import static uk.gov.pay.ledger.transaction.model.TransactionType.PAYMENT;
 import static uk.gov.pay.ledger.transaction.model.TransactionType.REFUND;
@@ -73,6 +74,15 @@ public class TransactionSummaryDaoIT {
         assertThat(transactionSummary.get(0).get("moto"), is(true));
         assertThat(transactionSummary.get(0).get("total_amount_in_pence"), is(200L));
         assertThat(transactionSummary.get(0).get("no_of_transactions"), is(1L));
+    }
+
+    @Test
+    public void upsertWithLiveNullShouldNotCauseException(){
+        String gatewayAccountId = "account-" + randomAlphanumeric(10);
+        transactionSummaryDao.upsert(gatewayAccountId, "PAYMENT",
+                parse("2018-09-22"), SUCCESS, null, false, 100L);
+        List<Map<String, Object>> transactionSummary = dbHelper.getTransactionSummary(gatewayAccountId);
+        assertThat(transactionSummary.get(0).get("live"), is(nullValue()));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/ledger/util/DatabaseTestHelper.java
+++ b/src/test/java/uk/gov/pay/ledger/util/DatabaseTestHelper.java
@@ -104,4 +104,12 @@ public class DatabaseTestHelper {
                         .mapToMap()
                         .list());
     }
+
+    public List<Map<String, Object>> getTransactionSummary(String gatewayAccountId) {
+        return jdbi.withHandle(handle ->
+                handle.createQuery("SELECT * FROM transaction_summary where gateway_account_id = :gatewayAccountId")
+                        .bind("gatewayAccountId", gatewayAccountId)
+                        .mapToMap()
+                        .list());
+    }
 }

--- a/src/test/java/uk/gov/pay/ledger/util/fixture/EventFixture.java
+++ b/src/test/java/uk/gov/pay/ledger/util/fixture/EventFixture.java
@@ -13,6 +13,8 @@ import java.time.ZonedDateTime;
 public class EventFixture implements DbFixture<EventFixture, Event> {
     private Long id = RandomUtils.nextLong(1, 99999);
     private String sqsMessageId = RandomStringUtils.randomAlphanumeric(50);
+    private String serviceId;
+    private boolean live;
     private ResourceType resourceType = ResourceType.PAYMENT;
     private String resourceExternalId = RandomStringUtils.randomAlphanumeric(20);
     private String parentResourceExternalId = StringUtils.EMPTY;
@@ -81,6 +83,8 @@ public class EventFixture implements DbFixture<EventFixture, Event> {
                                 "    event(\n" +
                                 "        id,\n" +
                                 "        sqs_message_id, \n" +
+                                "        service_id, \n" +
+                                "        live, \n" +
                                 "        resource_type_id, \n" +
                                 "        resource_external_id,\n" +
                                 "        parent_resource_external_id,\n" +
@@ -88,9 +92,11 @@ public class EventFixture implements DbFixture<EventFixture, Event> {
                                 "        event_type,\n" +
                                 "        event_data\n" +
                                 "    )\n" +
-                                "   VALUES(?, ?, (SELECT rt.id FROM resource_type rt WHERE upper(rt.name) = ?), ?, ?, ?, ?, CAST(? as jsonb))\n",
+                                "   VALUES(?, ?, ?, ?,(SELECT rt.id FROM resource_type rt WHERE upper(rt.name) = ?), ?, ?, ?, ?, CAST(? as jsonb))\n",
                         id,
                         sqsMessageId,
+                        serviceId,
+                        live,
                         resourceType,
                         resourceExternalId,
                         parentResourceExternalId,
@@ -104,7 +110,7 @@ public class EventFixture implements DbFixture<EventFixture, Event> {
 
     @Override
     public Event toEntity() {
-        return new Event(id, sqsMessageId, resourceType, resourceExternalId, parentResourceExternalId, eventDate, eventType, eventData, reprojectDomainObject);
+        return new Event(id, sqsMessageId, serviceId, live, resourceType, resourceExternalId, parentResourceExternalId, eventDate, eventType, eventData, reprojectDomainObject);
     }
 
     public Long getId() {

--- a/src/test/java/uk/gov/pay/ledger/util/fixture/PayoutFixture.java
+++ b/src/test/java/uk/gov/pay/ledger/util/fixture/PayoutFixture.java
@@ -19,6 +19,8 @@ public class PayoutFixture implements DbFixture<PayoutFixture, PayoutEntity> {
 
     private Long id;
     private String gatewayPayoutId;
+    private String serviceId;
+    private boolean live;
     private Long amount;
     private ZonedDateTime createdDate = now(UTC);
     private ZonedDateTime paidOutDate;
@@ -35,6 +37,8 @@ public class PayoutFixture implements DbFixture<PayoutFixture, PayoutEntity> {
                                 " payout(\n" +
                                 "   id,\n" +
                                 "   gateway_payout_id,\n" +
+                                "   service_id,\n" +
+                                "   live,\n" +
                                 "   amount,\n" +
                                 "   created_date,\n" +
                                 "   paid_out_date,\n" +
@@ -43,8 +47,8 @@ public class PayoutFixture implements DbFixture<PayoutFixture, PayoutEntity> {
                                 "   payout_details,\n" +
                                 "   gateway_account_id\n" +
                                 " )\n" +
-                                " VALUES (?,?,?,?,?,?,?,CAST(? as jsonb),?)",
-                        id, gatewayPayoutId, amount, createdDate, paidOutDate,
+                                " VALUES (?,?,?,?,?,?,?,?,?,CAST(? as jsonb),?)",
+                        id, gatewayPayoutId, serviceId, live, amount, createdDate, paidOutDate,
                         state, eventCount, payoutDetails, gatewayAccountId
                 ));
         return this;
@@ -56,6 +60,8 @@ public class PayoutFixture implements DbFixture<PayoutFixture, PayoutEntity> {
                 .withAmount(amount)
                 .withCreatedDate(createdDate)
                 .withGatewayPayoutId(gatewayPayoutId)
+                .withServiceId(serviceId)
+                .withLive(live)
                 .withId(id)
                 .withPaidOutDate(paidOutDate)
                 .withState(state)
@@ -101,6 +107,8 @@ public class PayoutFixture implements DbFixture<PayoutFixture, PayoutEntity> {
         private Integer eventCount = 1;
         private String payoutDetails = "{}";
         private String gatewayAccountId = RandomStringUtils.randomAlphanumeric(10);
+        private String serviceId;
+        private boolean live;
 
         private PayoutFixtureBuilder() {
         }
@@ -144,6 +152,16 @@ public class PayoutFixture implements DbFixture<PayoutFixture, PayoutEntity> {
             return this;
         }
 
+        public PayoutFixtureBuilder withServiceId(String serviceId) {
+            this.serviceId = serviceId;
+            return this;
+        }
+
+        public PayoutFixtureBuilder withLive(boolean live) {
+            this.live = live;
+            return this;
+        }
+
         public PayoutFixtureBuilder withPayoutDetails(String payoutDetails) {
             this.payoutDetails = payoutDetails;
             return this;
@@ -153,10 +171,13 @@ public class PayoutFixture implements DbFixture<PayoutFixture, PayoutEntity> {
             this.gatewayAccountId = gatewayAccountId;
             return this;
         }
+
         public PayoutFixture build() {
             PayoutFixture payoutFixture = new PayoutFixture();
             payoutFixture.amount = this.amount;
             payoutFixture.gatewayPayoutId = this.gatewayPayoutId;
+            payoutFixture.serviceId = this.serviceId;
+            payoutFixture.live = this.live;
             payoutFixture.id = this.id;
             payoutFixture.state = this.state;
             payoutFixture.createdDate = this.createdDate;

--- a/src/test/java/uk/gov/pay/ledger/util/fixture/PayoutFixture.java
+++ b/src/test/java/uk/gov/pay/ledger/util/fixture/PayoutFixture.java
@@ -107,7 +107,7 @@ public class PayoutFixture implements DbFixture<PayoutFixture, PayoutEntity> {
         private Integer eventCount = 1;
         private String payoutDetails = "{}";
         private String gatewayAccountId = RandomStringUtils.randomAlphanumeric(10);
-        private String serviceId = RandomStringUtils.randomAlphanumeric(10);
+        private String serviceId = RandomStringUtils.randomAlphanumeric(26);
         private boolean live = true;
 
         private PayoutFixtureBuilder() {

--- a/src/test/java/uk/gov/pay/ledger/util/fixture/PayoutFixture.java
+++ b/src/test/java/uk/gov/pay/ledger/util/fixture/PayoutFixture.java
@@ -107,8 +107,8 @@ public class PayoutFixture implements DbFixture<PayoutFixture, PayoutEntity> {
         private Integer eventCount = 1;
         private String payoutDetails = "{}";
         private String gatewayAccountId = RandomStringUtils.randomAlphanumeric(10);
-        private String serviceId;
-        private boolean live;
+        private String serviceId = RandomStringUtils.randomAlphanumeric(10);
+        private boolean live = true;
 
         private PayoutFixtureBuilder() {
         }

--- a/src/test/java/uk/gov/pay/ledger/util/fixture/QueueEventFixtureUtil.java
+++ b/src/test/java/uk/gov/pay/ledger/util/fixture/QueueEventFixtureUtil.java
@@ -29,7 +29,7 @@ public class QueueEventFixtureUtil {
                 eventDate.toString(),
                 resourceExternalId,
                 serviceId,
-                live.toString(),
+                live,
                 parentResourceExternalId == null ? "" : parentResourceExternalId,
                 eventType,
                 resourceType.toString().toLowerCase(),

--- a/src/test/java/uk/gov/pay/ledger/util/fixture/QueueEventFixtureUtil.java
+++ b/src/test/java/uk/gov/pay/ledger/util/fixture/QueueEventFixtureUtil.java
@@ -14,11 +14,13 @@ import java.time.format.DateTimeFormatter;
 
 public class QueueEventFixtureUtil {
 
-    public static String insert(AmazonSQS sqsClient, String eventType, ZonedDateTime eventDate, String resourceExternalId,
+    public static String insert(AmazonSQS sqsClient, String eventType, ZonedDateTime eventDate, String serviceId, Boolean live, String resourceExternalId,
                                            String parentResourceExternalId, ResourceType resourceType, String eventData) {
         String messageBody = String.format("{" +
                         "\"timestamp\": \"%s\"," +
                         "\"resource_external_id\": \"%s\"," +
+                        "\"service_id\": \"%s\"," +
+                        "\"live\": \"%s\"," +
                         (parentResourceExternalId == null || parentResourceExternalId.isEmpty() ? "%s" : "\"parent_resource_external_id\": \"%s\",") +
                         "\"event_type\":\"%s\"," +
                         "\"resource_type\": \"%s\"," +
@@ -26,6 +28,8 @@ public class QueueEventFixtureUtil {
                         "}",
                 eventDate.toString(),
                 resourceExternalId,
+                serviceId,
+                live.toString(),
                 parentResourceExternalId == null ? "" : parentResourceExternalId,
                 eventType,
                 resourceType.toString().toLowerCase(),

--- a/src/test/java/uk/gov/pay/ledger/util/fixture/QueuePaymentEventFixture.java
+++ b/src/test/java/uk/gov/pay/ledger/util/fixture/QueuePaymentEventFixture.java
@@ -20,7 +20,7 @@ import static uk.gov.service.payments.commons.model.Source.CARD_API;
 public class QueuePaymentEventFixture implements QueueFixture<QueuePaymentEventFixture, Event> {
     private String sqsMessageId;
     private String serviceId = RandomStringUtils.randomAlphanumeric(20);;
-    private boolean live = true;
+    private Boolean live = true;
     private ResourceType resourceType = ResourceType.PAYMENT;
     private String resourceExternalId = RandomStringUtils.randomAlphanumeric(20);
     private String parentResourceExternalId = StringUtils.EMPTY;
@@ -104,6 +104,11 @@ public class QueuePaymentEventFixture implements QueueFixture<QueuePaymentEventF
 
     public QueuePaymentEventFixture includeMetadata(boolean includeMetada) {
         this.includeMetada = includeMetada;
+        return this;
+    }
+
+    public QueuePaymentEventFixture withLive(Boolean live) {
+        this.live = live;
         return this;
     }
 

--- a/src/test/java/uk/gov/pay/ledger/util/fixture/QueuePaymentEventFixture.java
+++ b/src/test/java/uk/gov/pay/ledger/util/fixture/QueuePaymentEventFixture.java
@@ -19,8 +19,8 @@ import static uk.gov.service.payments.commons.model.Source.CARD_API;
 
 public class QueuePaymentEventFixture implements QueueFixture<QueuePaymentEventFixture, Event> {
     private String sqsMessageId;
-    private String serviceId;
-    private boolean live;
+    private String serviceId = RandomStringUtils.randomAlphanumeric(20);;
+    private boolean live = true;
     private ResourceType resourceType = ResourceType.PAYMENT;
     private String resourceExternalId = RandomStringUtils.randomAlphanumeric(20);
     private String parentResourceExternalId = StringUtils.EMPTY;
@@ -130,7 +130,6 @@ public class QueuePaymentEventFixture implements QueueFixture<QueuePaymentEventF
                                 .put("payment_provider", "sandbox")
                                 .put("delayed_capture", false)
                                 .put("moto", false)
-                                .put("live", true)
                                 .put("external_metadata", metadata)
                                 .put("email", "j.doe@example.org")
                                 .put("cardholder_name", "J citizen")
@@ -249,7 +248,7 @@ public class QueuePaymentEventFixture implements QueueFixture<QueuePaymentEventF
 
     @Override
     public QueuePaymentEventFixture insert(AmazonSQS sqsClient) {
-        this.sqsMessageId = QueueEventFixtureUtil.insert(sqsClient, eventType, eventDate, resourceExternalId,
+        this.sqsMessageId = QueueEventFixtureUtil.insert(sqsClient, eventType, eventDate, serviceId, live, resourceExternalId,
                 parentResourceExternalId, resourceType, eventData);
         return this;
     }

--- a/src/test/java/uk/gov/pay/ledger/util/fixture/QueuePaymentEventFixture.java
+++ b/src/test/java/uk/gov/pay/ledger/util/fixture/QueuePaymentEventFixture.java
@@ -19,6 +19,8 @@ import static uk.gov.service.payments.commons.model.Source.CARD_API;
 
 public class QueuePaymentEventFixture implements QueueFixture<QueuePaymentEventFixture, Event> {
     private String sqsMessageId;
+    private String serviceId;
+    private boolean live;
     private ResourceType resourceType = ResourceType.PAYMENT;
     private String resourceExternalId = RandomStringUtils.randomAlphanumeric(20);
     private String parentResourceExternalId = StringUtils.EMPTY;
@@ -38,6 +40,16 @@ public class QueuePaymentEventFixture implements QueueFixture<QueuePaymentEventF
 
     public static QueuePaymentEventFixture aQueuePaymentEventFixture() {
         return new QueuePaymentEventFixture();
+    }
+
+    public QueuePaymentEventFixture withServiceId(String serviceId) {
+        this.serviceId = serviceId;
+        return this;
+    }
+
+    public QueuePaymentEventFixture withResourceType(boolean live) {
+        this.live = live;
+        return this;
     }
 
     public QueuePaymentEventFixture withResourceType(ResourceType resourceType) {
@@ -204,7 +216,7 @@ public class QueuePaymentEventFixture implements QueueFixture<QueuePaymentEventF
 
     @Override
     public Event toEntity() {
-        return new Event(0L, sqsMessageId, resourceType, resourceExternalId, parentResourceExternalId, eventDate, eventType, eventData, reprojectDomainObject);
+        return new Event(0L, sqsMessageId, serviceId, live, resourceType, resourceExternalId, parentResourceExternalId, eventDate, eventType, eventData, reprojectDomainObject);
     }
 
     public String getSqsMessageId() {

--- a/src/test/java/uk/gov/pay/ledger/util/fixture/QueuePayoutEventFixture.java
+++ b/src/test/java/uk/gov/pay/ledger/util/fixture/QueuePayoutEventFixture.java
@@ -93,7 +93,7 @@ public class QueuePayoutEventFixture implements QueueFixture<QueuePayoutEventFix
 
     @Override
     public QueuePayoutEventFixture insert(AmazonSQS sqsClient) {
-        this.sqsMessageId = QueueEventFixtureUtil.insert(sqsClient, eventType, eventDate, null, true, resourceExternalId,
+        this.sqsMessageId = QueueEventFixtureUtil.insert(sqsClient, eventType, eventDate, serviceId, live, resourceExternalId,
                 EMPTY, resourceType, eventData);
         return this;
     }

--- a/src/test/java/uk/gov/pay/ledger/util/fixture/QueuePayoutEventFixture.java
+++ b/src/test/java/uk/gov/pay/ledger/util/fixture/QueuePayoutEventFixture.java
@@ -93,7 +93,7 @@ public class QueuePayoutEventFixture implements QueueFixture<QueuePayoutEventFix
 
     @Override
     public QueuePayoutEventFixture insert(AmazonSQS sqsClient) {
-        this.sqsMessageId = QueueEventFixtureUtil.insert(sqsClient, eventType, eventDate, resourceExternalId,
+        this.sqsMessageId = QueueEventFixtureUtil.insert(sqsClient, eventType, eventDate, null, true, resourceExternalId,
                 EMPTY, resourceType, eventData);
         return this;
     }

--- a/src/test/java/uk/gov/pay/ledger/util/fixture/QueuePayoutEventFixture.java
+++ b/src/test/java/uk/gov/pay/ledger/util/fixture/QueuePayoutEventFixture.java
@@ -14,6 +14,8 @@ import static uk.gov.pay.ledger.event.model.ResourceType.PAYOUT;
 
 public class QueuePayoutEventFixture implements QueueFixture<QueuePayoutEventFixture, Event> {
     private String sqsMessageId;
+    private String serviceId;
+    private boolean live;
     private ResourceType resourceType = PAYOUT;
     private String resourceExternalId = "resource_external_id";
     private ZonedDateTime eventDate = ZonedDateTime.parse("2020-05-13T18:45:00.000000Z");
@@ -86,7 +88,7 @@ public class QueuePayoutEventFixture implements QueueFixture<QueuePayoutEventFix
 
     @Override
     public Event toEntity() {
-        return new Event(0L, sqsMessageId, resourceType, resourceExternalId, EMPTY, eventDate, eventType, eventData, false);
+        return new Event(0L, sqsMessageId, serviceId, live, resourceType, resourceExternalId, EMPTY, eventDate, eventType, eventData, false);
     }
 
     @Override

--- a/src/test/java/uk/gov/pay/ledger/util/fixture/QueueRefundEventFixture.java
+++ b/src/test/java/uk/gov/pay/ledger/util/fixture/QueueRefundEventFixture.java
@@ -140,7 +140,7 @@ public class QueueRefundEventFixture implements QueueFixture<QueueRefundEventFix
 
     @Override
     public QueueRefundEventFixture insert(AmazonSQS sqsClient) {
-        this.sqsMessageId = QueueEventFixtureUtil.insert(sqsClient, eventType, eventDate, resourceExternalId,
+        this.sqsMessageId = QueueEventFixtureUtil.insert(sqsClient, eventType, eventDate, null, true, resourceExternalId,
                 parentResourceExternalId, resourceType, eventData);
         return this;
     }

--- a/src/test/java/uk/gov/pay/ledger/util/fixture/QueueRefundEventFixture.java
+++ b/src/test/java/uk/gov/pay/ledger/util/fixture/QueueRefundEventFixture.java
@@ -12,6 +12,8 @@ import java.time.ZonedDateTime;
 public class QueueRefundEventFixture implements QueueFixture<QueueRefundEventFixture, Event> {
     private String sqsMessageId;
     private ResourceType resourceType = ResourceType.REFUND;
+    private String serviceId;
+    private boolean live;
     private Long amount = 50L;
     private String gatewayAccountId = "123456";
     private String resourceExternalId = "resource_external_id";
@@ -101,7 +103,7 @@ public class QueueRefundEventFixture implements QueueFixture<QueueRefundEventFix
 
     @Override
     public Event toEntity() {
-        return new Event(0L, sqsMessageId, resourceType, resourceExternalId, parentResourceExternalId, eventDate, eventType, eventData, false);
+        return new Event(0L, sqsMessageId, serviceId, live, resourceType, resourceExternalId, parentResourceExternalId, eventDate, eventType, eventData, false);
     }
 
     public String getSqsMessageId() {

--- a/src/test/java/uk/gov/pay/ledger/util/fixture/TransactionFixture.java
+++ b/src/test/java/uk/gov/pay/ledger/util/fixture/TransactionFixture.java
@@ -7,10 +7,8 @@ import com.google.gson.JsonParser;
 import io.dropwizard.jackson.Jackson;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.RandomUtils;
-import org.hamcrest.Matcher;
 import org.jdbi.v3.core.Jdbi;
 import org.jetbrains.annotations.NotNull;
-import uk.gov.service.payments.commons.model.Source;
 import uk.gov.pay.ledger.transaction.entity.TransactionEntity;
 import uk.gov.pay.ledger.transaction.model.Address;
 import uk.gov.pay.ledger.transaction.model.CardDetails;
@@ -19,6 +17,7 @@ import uk.gov.pay.ledger.transaction.model.TransactionFactory;
 import uk.gov.pay.ledger.transaction.model.TransactionType;
 import uk.gov.pay.ledger.transaction.search.model.RefundSummary;
 import uk.gov.pay.ledger.transaction.state.TransactionState;
+import uk.gov.service.payments.commons.model.Source;
 
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
@@ -34,7 +33,7 @@ import static uk.gov.pay.ledger.util.fixture.TransactionMetadataFixture.aTransac
 public class TransactionFixture implements DbFixture<TransactionFixture, TransactionEntity> {
 
     private Long id = RandomUtils.nextLong(1, 99999);
-    private String serviceId = RandomStringUtils.randomAlphanumeric(10);
+    private String serviceId = RandomStringUtils.randomAlphanumeric(26);
     private String gatewayAccountId = RandomStringUtils.randomAlphanumeric(10);
     private String credentialExternalId = "credential-external-id";
     private String externalId = RandomStringUtils.randomAlphanumeric(20);

--- a/src/test/java/uk/gov/pay/ledger/util/fixture/TransactionFixture.java
+++ b/src/test/java/uk/gov/pay/ledger/util/fixture/TransactionFixture.java
@@ -34,6 +34,7 @@ import static uk.gov.pay.ledger.util.fixture.TransactionMetadataFixture.aTransac
 public class TransactionFixture implements DbFixture<TransactionFixture, TransactionEntity> {
 
     private Long id = RandomUtils.nextLong(1, 99999);
+    private String serviceId = RandomStringUtils.randomAlphanumeric(10);
     private String gatewayAccountId = RandomStringUtils.randomAlphanumeric(10);
     private String credentialExternalId = "credential-external-id";
     private String externalId = RandomStringUtils.randomAlphanumeric(20);
@@ -329,6 +330,7 @@ public class TransactionFixture implements DbFixture<TransactionFixture, Transac
                                 "        id,\n" +
                                 "        external_id,\n" +
                                 "        parent_external_id,\n" +
+                                "        service_id,\n" +
                                 "        gateway_account_id,\n" +
                                 "        amount,\n" +
                                 "        description,\n" +
@@ -355,10 +357,11 @@ public class TransactionFixture implements DbFixture<TransactionFixture, Transac
                                 "        source,\n" +
                                 "        gateway_payout_id\n" +
                                 "    )\n" +
-                                "VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, CAST(? as jsonb), ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?::transaction_type, ?, ?, ?, ?::source, ?)\n",
+                                "VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, CAST(? as jsonb), ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?::transaction_type, ?, ?, ?, ?::source, ?)\n",
                         id,
                         externalId,
                         parentExternalId,
+                        serviceId,
                         gatewayAccountId,
                         amount,
                         description,
@@ -464,6 +467,7 @@ public class TransactionFixture implements DbFixture<TransactionFixture, Transac
     public TransactionEntity toEntity() {
         var builder = new TransactionEntity.Builder()
                 .withId(id)
+                .withServiceId(serviceId)
                 .withGatewayAccountId(gatewayAccountId)
                 .withExternalId(externalId)
                 .withParentExternalId(parentExternalId)
@@ -496,6 +500,14 @@ public class TransactionFixture implements DbFixture<TransactionFixture, Transac
 
     public String getExternalId() {
         return externalId;
+    }
+
+    public String getServiceId() {
+        return serviceId;
+    }
+
+    public boolean isLive() {
+        return live;
     }
 
     public Long getAmount() {


### PR DESCRIPTION
Re-introduces changes reverted in https://github.com/alphagov/pay-ledger/pull/1383 with additional fixes to prevent a null pointer exception in the case where `live` is `null` either in the top-level and/or `event_details` of an Event.