### PR TITLE
PP-8543 - Add search transaction authorisation summary test

### DIFF
--- a/src/test/java/uk/gov/pay/ledger/transaction/resource/TransactionResourceIT.java
+++ b/src/test/java/uk/gov/pay/ledger/transaction/resource/TransactionResourceIT.java
@@ -3,17 +3,16 @@ package uk.gov.pay.ledger.transaction.resource;
 import com.google.gson.JsonObject;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.hamcrest.Matchers;
-import org.hamcrest.core.Is;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
-import uk.gov.service.payments.commons.model.Source;
 import uk.gov.pay.ledger.event.model.Event;
 import uk.gov.pay.ledger.extension.AppWithPostgresAndSqsExtension;
 import uk.gov.pay.ledger.transaction.entity.TransactionEntity;
 import uk.gov.pay.ledger.transaction.state.TransactionState;
 import uk.gov.pay.ledger.util.fixture.EventFixture;
 import uk.gov.pay.ledger.util.fixture.TransactionFixture;
+import uk.gov.service.payments.commons.model.Source;
 
 import javax.ws.rs.core.Response;
 import java.time.ZonedDateTime;
@@ -25,10 +24,10 @@ import static org.apache.commons.lang3.RandomStringUtils.randomAlphanumeric;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.Matchers.hasKey;
-import static uk.gov.service.payments.commons.model.ApiResponseDateTimeFormatter.ISO_INSTANT_MILLISECOND_PRECISION;
 import static uk.gov.pay.ledger.util.DatabaseTestHelper.aDatabaseTestHelper;
 import static uk.gov.pay.ledger.util.fixture.PayoutFixture.PayoutFixtureBuilder.aPayoutFixture;
 import static uk.gov.pay.ledger.util.fixture.TransactionFixture.aTransactionFixture;
+import static uk.gov.service.payments.commons.model.ApiResponseDateTimeFormatter.ISO_INSTANT_MILLISECOND_PRECISION;
 
 public class TransactionResourceIT {
 


### PR DESCRIPTION
Description:
- The previous PR (https://github.com/alphagov/pay-ledger/pull/1404) means that AuthorisationSummary is returned in TransactionView
which is used by TransactionSearchResponse. Hence searching for transactions returns the AuthorisationSummary JSON blob.
- Adds a test for this