### PR TITLE
PP-8535 add authorisation summary to get payment contract test

### DIFF
--- a/src/test/java/uk/gov/pay/ledger/pact/ContractTest.java
+++ b/src/test/java/uk/gov/pay/ledger/pact/ContractTest.java
@@ -69,6 +69,7 @@ public abstract class ContractTest {
                 .withDefaultCardDetails()
                 .withDefaultTransactionDetails()
                 .withCreatedDate(ZonedDateTime.parse("2018-09-22T10:13:16.067Z"))
+                .withVersion3ds("2.1.0")
                 .insert(app.getJdbi());
     }
 
@@ -244,6 +245,28 @@ public abstract class ContractTest {
                 .withDelayedCapture(true)
                 .withRefundSummary(RefundSummary.ofValue("pending", 100L, 0L))
                 .withAmount(100L)
+                .withDefaultTransactionDetails()
+                .insert(app.getJdbi());
+    }
+
+    @State("a transaction with 3ds version exists")
+    public void createTransactionWithVersion3ds(Map<String, String> params) {
+        String transactionExternalId = params.get("charge_id");
+        String gatewayAccountId = params.get("account_id");
+
+        if (isBlank(transactionExternalId)) {
+            transactionExternalId = "ch_123abc456xyz";
+        }
+        if (isBlank(gatewayAccountId)) {
+            gatewayAccountId = "123456";
+        }
+
+        aTransactionFixture()
+                .withExternalId(transactionExternalId)
+                .withGatewayAccountId(gatewayAccountId)
+                .withState(TransactionState.CREATED)
+                .withAmount(100L)
+                .withVersion3ds("2.1.0")
                 .withDefaultTransactionDetails()
                 .insert(app.getJdbi());
     }

--- a/src/test/java/uk/gov/pay/ledger/util/fixture/TransactionFixture.java
+++ b/src/test/java/uk/gov/pay/ledger/util/fixture/TransactionFixture.java
@@ -75,6 +75,7 @@ public class TransactionFixture implements DbFixture<TransactionFixture, Transac
     private String refundedByUserEmail;
     private String source;
     private String gatewayPayoutId;
+    private String version3ds;
 
     private TransactionFixture() {
     }
@@ -320,6 +321,11 @@ public class TransactionFixture implements DbFixture<TransactionFixture, Transac
         return this;
     }
 
+    public TransactionFixture withVersion3ds(String version3ds) {
+        this.version3ds = version3ds;
+        return this;
+    }
+
     @Override
     public TransactionFixture insert(Jdbi jdbi) {
         jdbi.withHandle(h ->
@@ -457,6 +463,11 @@ public class TransactionFixture implements DbFixture<TransactionFixture, Transac
                                 transactionDetails.addProperty("address_county", ba.getAddressCounty());
                                 transactionDetails.addProperty("address_country", ba.getAddressCountry());
                             });
+                });
+        Optional.ofNullable(version3ds).ifPresent(
+                version -> {
+                    transactionDetails.addProperty("version_3ds", version);
+                    transactionDetails.addProperty("requires_3ds", true);
                 });
 
         return transactionDetails;


### PR DESCRIPTION
## WHAT
- add new field to payload of 'a payment transaction exists' pact
- add new pact state 'a transaction with 3ds version exists'