### PR TITLE
[PP-8695] Remove ECS Deploy Step from Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -185,14 +185,6 @@ pipeline {
         checkPactCompatibility("ledger", gitCommit(), "test")
       }
     }
-    stage('Deploy') {
-      when {
-        branch 'master'
-      }
-      steps {
-        deployEcs("ledger")
-      }
-    }
     stage('Pact Tag') {
       when {
         branch 'master'


### PR DESCRIPTION
## What?
This should un-break the Jenkins Pact Tests now that microservices_v1 are gone.