### PR TITLE
PP-8732: Fix Pact contracts

### DIFF
--- a/src/test/java/uk/gov/pay/ledger/event/model/TransactionEntityFactoryTest.java
+++ b/src/test/java/uk/gov/pay/ledger/event/model/TransactionEntityFactoryTest.java
@@ -32,6 +32,7 @@ public class TransactionEntityFactoryTest {
     @Test
     public void fromShouldConvertEventDigestToTransactionEntity() {
         Event paymentCreatedEvent = aQueuePaymentEventFixture()
+                .withLive(true)
                 .withEventType(SalientEventType.PAYMENT_CREATED.name())
                 .withDefaultEventDataForEventType(SalientEventType.PAYMENT_CREATED.name())
                 .withResourceType(ResourceType.PAYMENT)

--- a/src/test/java/uk/gov/pay/ledger/pact/CancelledByUserEventQueueContractTest.java
+++ b/src/test/java/uk/gov/pay/ledger/pact/CancelledByUserEventQueueContractTest.java
@@ -52,7 +52,8 @@ public class CancelledByUserEventQueueContractTest {
                 .withEventDate(eventDate)
                 .withGatewayAccountId(gatewayAccountId)
                 .withEventType(SalientEventType.CANCELLED_BY_USER.toString())
-                .withDefaultEventDataForEventType(SalientEventType.CANCELLED_BY_USER.toString());
+                .withDefaultEventDataForEventType(SalientEventType.CANCELLED_BY_USER.toString())
+                .withLive(true);
 
         Map<String, String> metadata = new HashMap<>();
         metadata.put("contentType", "application/json");

--- a/src/test/java/uk/gov/pay/ledger/pact/CaptureConfirmedEventQueueContractTest.java
+++ b/src/test/java/uk/gov/pay/ledger/pact/CaptureConfirmedEventQueueContractTest.java
@@ -53,7 +53,8 @@ public class CaptureConfirmedEventQueueContractTest {
                 .withEventDate(eventDate)
                 .withGatewayAccountId(gatewayAccountId)
                 .withEventType(eventType)
-                .withDefaultEventDataForEventType(eventType);
+                .withDefaultEventDataForEventType(eventType)
+                .withLive(true);
 
         Map<String, String> metadata = new HashMap<>();
         metadata.put("contentType", "application/json");

--- a/src/test/java/uk/gov/pay/ledger/pact/CaptureSubmittedEventQueueContractTest.java
+++ b/src/test/java/uk/gov/pay/ledger/pact/CaptureSubmittedEventQueueContractTest.java
@@ -51,7 +51,8 @@ public class CaptureSubmittedEventQueueContractTest {
                 .withEventDate(eventDate)
                 .withGatewayAccountId(gatewayAccountId)
                 .withEventType(SalientEventType.CAPTURE_SUBMITTED.toString())
-                .withDefaultEventDataForEventType(SalientEventType.CAPTURE_SUBMITTED.toString());
+                .withDefaultEventDataForEventType(SalientEventType.CAPTURE_SUBMITTED.toString())
+                .withLive(true);
 
         Map<String, String> metadata = new HashMap<>();
         metadata.put("contentType", "application/json");

--- a/src/test/java/uk/gov/pay/ledger/pact/Gateway3dsExemptionResultObtainedEventQueueContractTest.java
+++ b/src/test/java/uk/gov/pay/ledger/pact/Gateway3dsExemptionResultObtainedEventQueueContractTest.java
@@ -48,7 +48,8 @@ public class Gateway3dsExemptionResultObtainedEventQueueContractTest {
                 .withResourceExternalId(externalId)
                 .withEventDate(eventDate)
                 .withEventType(gateway3dsExemptionResultObtainedEvent)
-                .withDefaultEventDataForEventType(gateway3dsExemptionResultObtainedEvent);
+                .withDefaultEventDataForEventType(gateway3dsExemptionResultObtainedEvent)
+                .withLive(true);
 
         Map<String, String> metadata = new HashMap<>();
         metadata.put("contentType", "application/json");

--- a/src/test/java/uk/gov/pay/ledger/pact/Gateway3dsInfoObtainedEventQueueContractTest.java
+++ b/src/test/java/uk/gov/pay/ledger/pact/Gateway3dsInfoObtainedEventQueueContractTest.java
@@ -48,7 +48,8 @@ public class Gateway3dsInfoObtainedEventQueueContractTest {
                 .withResourceExternalId(externalId)
                 .withEventDate(eventDate)
                 .withEventType(gateway3dsInfoObtainedEvent)
-                .withDefaultEventDataForEventType(gateway3dsInfoObtainedEvent);
+                .withDefaultEventDataForEventType(gateway3dsInfoObtainedEvent)
+                .withLive(true);
 
         Map<String, String> metadata = new HashMap<>();
         metadata.put("contentType", "application/json");

--- a/src/test/java/uk/gov/pay/ledger/pact/GatewayRequires3dsAuthorisationEventQueueContractTest.java
+++ b/src/test/java/uk/gov/pay/ledger/pact/GatewayRequires3dsAuthorisationEventQueueContractTest.java
@@ -49,7 +49,8 @@ public class GatewayRequires3dsAuthorisationEventQueueContractTest {
                 .withResourceExternalId(externalId)
                 .withEventDate(eventDate)
                 .withEventType(gatewayRequires3dsAuthorisationEvent)
-                .withDefaultEventDataForEventType(gatewayRequires3dsAuthorisationEvent);
+                .withDefaultEventDataForEventType(gatewayRequires3dsAuthorisationEvent)
+                .withLive(true);
 
         Map<String, String> metadata = new HashMap<>();
         metadata.put("contentType", "application/json");

--- a/src/test/java/uk/gov/pay/ledger/pact/PaymentCreatedEventQueueContractTest.java
+++ b/src/test/java/uk/gov/pay/ledger/pact/PaymentCreatedEventQueueContractTest.java
@@ -50,7 +50,8 @@ public class PaymentCreatedEventQueueContractTest {
                 .withEventDate(eventDate)
                 .withGatewayAccountId(gatewayAccountId)
                 .withCredentialExternalId(credentialExternalId)
-                .withDefaultEventDataForEventType("PAYMENT_CREATED");
+                .withDefaultEventDataForEventType("PAYMENT_CREATED")
+                .withLive(true);
 
         Map<String, String> metadata = new HashMap<>();
         metadata.put("contentType", "application/json");

--- a/src/test/java/uk/gov/pay/ledger/pact/PaymentDetailsEnteredEventQueueContractTest.java
+++ b/src/test/java/uk/gov/pay/ledger/pact/PaymentDetailsEnteredEventQueueContractTest.java
@@ -49,7 +49,8 @@ public class PaymentDetailsEnteredEventQueueContractTest {
                 .withEventDate(eventDate)
                 .withEventType(paymentDetailsEnteredEventName)
                 .withGatewayAccountId("I0YI1")
-                .withDefaultEventDataForEventType(paymentDetailsEnteredEventName);
+                .withDefaultEventDataForEventType(paymentDetailsEnteredEventName)
+                .withLive(true);
 
         Map<String, String> metadata = new HashMap<>();
         metadata.put("contentType", "application/json");

--- a/src/test/java/uk/gov/pay/ledger/pact/PaymentNotificationCreatedEventQueueContractTest.java
+++ b/src/test/java/uk/gov/pay/ledger/pact/PaymentNotificationCreatedEventQueueContractTest.java
@@ -52,7 +52,8 @@ public class PaymentNotificationCreatedEventQueueContractTest {
                 .withGatewayAccountId(gatewayAccountId)
                 .withCredentialExternalId(credentialExternalId)
                 .withEventType(paymentDetailsEnteredEventName)
-                .withDefaultEventDataForEventType(paymentDetailsEnteredEventName);
+                .withDefaultEventDataForEventType(paymentDetailsEnteredEventName)
+                .withLive(true);
 
         Map<String, String> metadata = new HashMap<>();
         metadata.put("contentType", "application/json");

--- a/src/test/java/uk/gov/pay/ledger/pact/UserEmailCollectedEventQueueContractTest.java
+++ b/src/test/java/uk/gov/pay/ledger/pact/UserEmailCollectedEventQueueContractTest.java
@@ -47,7 +47,8 @@ public class UserEmailCollectedEventQueueContractTest {
                 .withResourceExternalId(externalId)
                 .withEventDate(eventDate)
                 .withEventType(userEmailCollectedEvent)
-                .withDefaultEventDataForEventType(userEmailCollectedEvent);
+                .withDefaultEventDataForEventType(userEmailCollectedEvent)
+                .withLive(true);
 
         Map<String, String> metadata = new HashMap<>();
         metadata.put("contentType", "application/json");

--- a/src/test/java/uk/gov/pay/ledger/queue/QueueMessageReceiverIT.java
+++ b/src/test/java/uk/gov/pay/ledger/queue/QueueMessageReceiverIT.java
@@ -307,6 +307,7 @@ public class QueueMessageReceiverIT {
                 .withEventType("CAPTURE_SUBMITTED")
                 .withEventData("{}")
                 .withDefaultEventDataForEventType("DEFAULT")
+                .withLive(true)
                 .insert(rule.getSqsClient());
 
         aQueuePaymentEventFixture()

--- a/src/test/java/uk/gov/pay/ledger/util/fixture/QueuePaymentEventFixture.java
+++ b/src/test/java/uk/gov/pay/ledger/util/fixture/QueuePaymentEventFixture.java
@@ -20,7 +20,7 @@ import static uk.gov.service.payments.commons.model.Source.CARD_API;
 public class QueuePaymentEventFixture implements QueueFixture<QueuePaymentEventFixture, Event> {
     private String sqsMessageId;
     private String serviceId = "a-service-id";
-    private Boolean live = true;
+    private Boolean live;
     private ResourceType resourceType = ResourceType.PAYMENT;
     private String resourceExternalId = "a-resource-external-id";
     private String parentResourceExternalId = StringUtils.EMPTY;
@@ -47,7 +47,7 @@ public class QueuePaymentEventFixture implements QueueFixture<QueuePaymentEventF
         return this;
     }
 
-    public QueuePaymentEventFixture withResourceType(boolean live) {
+    public QueuePaymentEventFixture withLive(Boolean live) {
         this.live = live;
         return this;
     }
@@ -107,10 +107,6 @@ public class QueuePaymentEventFixture implements QueueFixture<QueuePaymentEventF
         return this;
     }
 
-    public QueuePaymentEventFixture withLive(Boolean live) {
-        this.live = live;
-        return this;
-    }
 
     public QueuePaymentEventFixture withIsReprojectDomainObject(boolean reprojectDomainObject) {
         this.reprojectDomainObject = reprojectDomainObject;

--- a/src/test/java/uk/gov/pay/ledger/util/fixture/QueuePayoutEventFixture.java
+++ b/src/test/java/uk/gov/pay/ledger/util/fixture/QueuePayoutEventFixture.java
@@ -15,7 +15,7 @@ import static uk.gov.pay.ledger.event.model.ResourceType.PAYOUT;
 public class QueuePayoutEventFixture implements QueueFixture<QueuePayoutEventFixture, Event> {
     private String sqsMessageId;
     private String serviceId;
-    private boolean live;
+    private Boolean live;
     private ResourceType resourceType = PAYOUT;
     private String resourceExternalId = "resource_external_id";
     private ZonedDateTime eventDate = ZonedDateTime.parse("2020-05-13T18:45:00.000000Z");

--- a/src/test/java/uk/gov/pay/ledger/util/fixture/QueueRefundEventFixture.java
+++ b/src/test/java/uk/gov/pay/ledger/util/fixture/QueueRefundEventFixture.java
@@ -13,7 +13,7 @@ public class QueueRefundEventFixture implements QueueFixture<QueueRefundEventFix
     private String sqsMessageId;
     private ResourceType resourceType = ResourceType.REFUND;
     private String serviceId;
-    private boolean live;
+    private Boolean live;
     private Long amount = 50L;
     private String gatewayAccountId = "123456";
     private String resourceExternalId = "resource_external_id";


### PR DESCRIPTION
Use null-able Boolean `live` on fixture, this is so we can set it correctly to `null` on `PaymentIncludedInPayout` and `RefundIncludedInPayout` events, explicitly default live property to true where expected.