### PR TITLE
pp-7475 fix errors in config, add labels to GH actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,8 +25,8 @@ updates:
   schedule:
     interval: daily
     time: "03:00"
-- package-ecosystem: "github-actions"
-  directory: "/"
-  schedule:
-    interval: "daily"
-    time: "03:00"
+  open-pull-requests-limit: 10  
+  labels:
+  - dependencies
+  - govuk-pay
+  - github_actions


### PR DESCRIPTION
### WHAT
Fixed a duplication error in the configuration that was causing a parsing issue and added missing labels to GHA