### PR TITLE
bau: Use 'test-fargate' when running provider contract test

### DIFF
--- a/src/test/java/uk/gov/pay/ledger/pact/ConnectorContractTest.java
+++ b/src/test/java/uk/gov/pay/ledger/pact/ConnectorContractTest.java
@@ -8,7 +8,7 @@ import org.junit.runner.RunWith;
 
 @RunWith(PactRunner.class)
 @Provider("ledger")
-@PactBroker(scheme = "https", host = "${PACT_BROKER_HOST:pact-broker-test.cloudapps.digital}", tags = {"${PACT_CONSUMER_TAG}", "test"},
+@PactBroker(scheme = "https", host = "${PACT_BROKER_HOST:pact-broker-test.cloudapps.digital}", tags = {"${PACT_CONSUMER_TAG}", "test-fargate"},
         authentication = @PactBrokerAuth(username = "${PACT_BROKER_USERNAME}", password = "${PACT_BROKER_PASSWORD}"),
         consumers = {"connector"})
 public class ConnectorContractTest extends ContractTest {

--- a/src/test/java/uk/gov/pay/ledger/pact/PublicApiContractTest.java
+++ b/src/test/java/uk/gov/pay/ledger/pact/PublicApiContractTest.java
@@ -8,7 +8,7 @@ import org.junit.runner.RunWith;
 
 @RunWith(PactRunner.class)
 @Provider("ledger")
-@PactBroker(scheme = "https", host = "${PACT_BROKER_HOST:pact-broker-test.cloudapps.digital}", tags = {"${PACT_CONSUMER_TAG}", "test"},
+@PactBroker(scheme = "https", host = "${PACT_BROKER_HOST:pact-broker-test.cloudapps.digital}", tags = {"${PACT_CONSUMER_TAG}", "test-fargate"},
         authentication = @PactBrokerAuth(username = "${PACT_BROKER_USERNAME}", password = "${PACT_BROKER_PASSWORD}"),
         consumers = {"publicapi"})
 public class PublicApiContractTest extends ContractTest {

--- a/src/test/java/uk/gov/pay/ledger/pact/SelfServiceContractTest.java
+++ b/src/test/java/uk/gov/pay/ledger/pact/SelfServiceContractTest.java
@@ -8,7 +8,7 @@ import org.junit.runner.RunWith;
 
 @RunWith(PactRunner.class)
 @Provider("ledger")
-@PactBroker(scheme = "https", host = "${PACT_BROKER_HOST:pact-broker-test.cloudapps.digital}", tags = {"${PACT_CONSUMER_TAG}", "test"},
+@PactBroker(scheme = "https", host = "${PACT_BROKER_HOST:pact-broker-test.cloudapps.digital}", tags = {"${PACT_CONSUMER_TAG}", "test-fargate"},
         authentication = @PactBrokerAuth(username = "${PACT_BROKER_USERNAME}", password = "${PACT_BROKER_PASSWORD}"),
         consumers = {"selfservice"})
 public class SelfServiceContractTest extends ContractTest {


### PR DESCRIPTION
The purpose of running the provider contract test is to ensure the app can be
deployed to the test environment without breaking its contractual obligations
with other apps. Pacts are tagged with 'test-fargate' in the concourse deploy
pipeline for app deployments so this tag needs to be updated.