### PR TITLE
PP-9038 Add fee breakdown to CSV

### DIFF
--- a/src/main/java/uk/gov/pay/ledger/transaction/resource/TransactionResource.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/resource/TransactionResource.java
@@ -117,6 +117,7 @@ public class TransactionResource {
     public Response streamCsv(@Valid @BeanParam TransactionSearchParams searchParams,
                               @QueryParam("account_id") CommaDelimitedSetParameter gatewayAccountIds,
                               @QueryParam("fee_headers") boolean includeFeeHeaders,
+                              @QueryParam("fee_breakdown_headers") boolean includeFeeBreakdownHeaders,
                               @QueryParam("moto_header") boolean includeMotoHeader,
                               @Context UriInfo uriInfo) {
         StreamingOutput stream = outputStream -> {
@@ -132,7 +133,8 @@ public class TransactionResource {
             Long startingAfterId = null;
             int count = 0;
 
-            Map<String, Object> headers = csvService.csvHeaderFrom(csvSearchParams, includeFeeHeaders, includeMotoHeader);
+            Map<String, Object> headers = csvService.csvHeaderFrom(csvSearchParams, includeFeeHeaders, includeMotoHeader,
+                    includeFeeBreakdownHeaders);
             ObjectWriter writer = csvService.writerFrom(headers);
             Stopwatch stopwatch = Stopwatch.createStarted();
             outputStream.write(csvService.csvStringFrom(headers, writer).getBytes());

--- a/src/main/java/uk/gov/pay/ledger/transaction/service/CsvService.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/service/CsvService.java
@@ -41,9 +41,10 @@ public class CsvService {
 
     public Map<String, Object> csvHeaderFrom(TransactionSearchParams searchParams,
                                              boolean includeFeeHeaders,
-                                             boolean includeMotoHeader) {
+                                             boolean includeMotoHeader,
+                                             boolean includeFeeBreakdownHeaders) {
         List<String> metadataKeys = transactionMetadataService.findMetadataKeysForTransactions(searchParams);
-        return csvTransactionFactory.getCsvHeadersWithMedataKeys(metadataKeys, includeFeeHeaders, includeMotoHeader);
+        return csvTransactionFactory.getCsvHeadersWithMedataKeys(metadataKeys, includeFeeHeaders, includeMotoHeader, includeFeeBreakdownHeaders);
     }
 
     public String csvStringFrom(Map<String, Object> headers, ObjectWriter writer) throws JsonProcessingException {


### PR DESCRIPTION
## WHAT
- Adds fee breakdown fields to CSV download if the query param `fee_breakdown_headers` is set.
- Fields appear as below in CSV
![image](https://user-images.githubusercontent.com/40598480/149136381-e855fff8-db15-4367-a7f1-14c37da91a86.png)
