### PR TITLE
PP-8951 update the CSV transaction factory to zero `net` when appropriate

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -7,32 +7,32 @@ This is a bare bones Dropwizard App for the Pay Ledger microservice.
 There are several environment variables used for the app configuration. They're grouped in categories: database, SQS
 and background processing.
 
-| Variable | Default | Purpose |
-|----------|---------|---------|
-| `PORT` | - | Port on which application listens |
+| Variable | Default | Purpose                           |
+|----------|---------|-----------------------------------|
+| `PORT`   | -       | Port on which application listens |
 
 ### Database configuration
 
-| Variable | Default | Purpose |
-|----------|---------|---------|
-| `DB_USER` | - | Name of the user used to connect to the database |
-| `DB_PASSWORD` | - | Password of the user used to connect to the database |
-| `DB_HOST` | - | Database host name |
-| `DB_NAME` | `ledger` | Name of the database |
-| `DB_SSL_OPTION`| - | Indicates whether the connection to the database should be secured with SSL (eg. `ssl=true`) |
+| Variable        | Default  | Purpose                                                                                      |
+|-----------------|----------|----------------------------------------------------------------------------------------------|
+| `DB_USER`       | -        | Name of the user used to connect to the database                                             |
+| `DB_PASSWORD`   | -        | Password of the user used to connect to the database                                         |
+| `DB_HOST`       | -        | Database host name                                                                           |
+| `DB_NAME`       | `ledger` | Name of the database                                                                         |
+| `DB_SSL_OPTION` | -        | Indicates whether the connection to the database should be secured with SSL (eg. `ssl=true`) |
 
 ### SQS configuration
 
-| Variable | Default | Purpose |
-|----------|---------|---------|
-| `AWS_SQS_REGION` | - | SQS region |
-| `AWS_SQS_PAYMENT_EVENT_QUEUE_URL` | - | SQS payment event queue URL |
-| `AWS_SQS_MESSAGE_MAXIMUM_WAIT_TIME_IN_SECONDS` | `20` | Maximum wait time for long poll message requests to queue |
-| `AWS_SQS_MESSAGE_MAXIMUM_BATCH_SIZE` | `10` | Maximum number of messages that should be received in an individual message batch |
-| `AWS_SQS_NON_STANDARD_SERVICE_ENDPOINT` | `false` | Set to true to use a non standard (eg: `http://my-own-sqs-endpoint`) SQS endpoint |
-| `AWS_SQS_ENDPOINT` | - | URL that is the entry point for SQS. Only required when `AWS_SQS_NON_STANDARD_SERVICE_ENDPOINT` is `true` |
-| `AWS_SECRET_KEY` | - | Secret key. Only required when `AWS_SQS_NON_STANDARD_SERVICE_ENDPOINT` is `true`
-| `AWS_ACCESS_KEY` | - | Access key. Only required when `AWS_SQS_NON_STANDARD_SERVICE_ENDPOINT` is `true` |
+| Variable                                       | Default | Purpose                                                                                                   |
+|------------------------------------------------|---------|-----------------------------------------------------------------------------------------------------------|
+| `AWS_SQS_REGION`                               | -       | SQS region                                                                                                |
+| `AWS_SQS_PAYMENT_EVENT_QUEUE_URL`              | -       | SQS payment event queue URL                                                                               |
+| `AWS_SQS_MESSAGE_MAXIMUM_WAIT_TIME_IN_SECONDS` | `20`    | Maximum wait time for long poll message requests to queue                                                 |
+| `AWS_SQS_MESSAGE_MAXIMUM_BATCH_SIZE`           | `10`    | Maximum number of messages that should be received in an individual message batch                         |
+| `AWS_SQS_NON_STANDARD_SERVICE_ENDPOINT`        | `false` | Set to true to use a non standard (eg: `http://my-own-sqs-endpoint`) SQS endpoint                         |
+| `AWS_SQS_ENDPOINT`                             | -       | URL that is the entry point for SQS. Only required when `AWS_SQS_NON_STANDARD_SERVICE_ENDPOINT` is `true` |
+| `AWS_SECRET_KEY`                               | -       | Secret key. Only required when `AWS_SQS_NON_STANDARD_SERVICE_ENDPOINT` is `true`                          |
+| `AWS_ACCESS_KEY`                               | -       | Access key. Only required when `AWS_SQS_NON_STANDARD_SERVICE_ENDPOINT` is `true`                          |
 
 ### Background processing configuration
 
@@ -51,11 +51,11 @@ More information of how the visibility timeout works can be found [here](https:/
 
 The following variables control the background process:
 
-| Variable | Default | Purpose |
-|----------|---------|---------|
-| `QUEUE_MESSAGE_RECEIVER_THREAD_DELAY_IN_MILLISECONDS` | `1` | Duration in seconds that the queue message receiver should wait between running threads|
-| `QUEUE_MESSAGE_RECEIVER_NUMBER_OF_THREADS` | `1` | The number of polling threads started by the queue message scheduler |
-| `QUEUE_MESSAGE_RETRY_DELAY_IN_SECONDS` | `900` | The duration in seconds that a message should be deferred before it should be retried |
+| Variable                                              | Default | Purpose                                                                                 |
+|-------------------------------------------------------|---------|-----------------------------------------------------------------------------------------|
+| `QUEUE_MESSAGE_RECEIVER_THREAD_DELAY_IN_MILLISECONDS` | `1`     | Duration in seconds that the queue message receiver should wait between running threads |
+| `QUEUE_MESSAGE_RECEIVER_NUMBER_OF_THREADS`            | `1`     | The number of polling threads started by the queue message scheduler                    |
+| `QUEUE_MESSAGE_RETRY_DELAY_IN_SECONDS`                | `900`   | The duration in seconds that a message should be deferred before it should be retried   |
 
 ## Licence
 

--- a/src/test/java/uk/gov/pay/ledger/transaction/resource/TransactionResourceCsvIT.java
+++ b/src/test/java/uk/gov/pay/ledger/transaction/resource/TransactionResourceCsvIT.java
@@ -466,10 +466,10 @@ public class TransactionResourceCsvIT {
     private void assertCommonPaymentFields(CSVRecord csvRecord, TransactionFixture transactionFixture) {
         assertThat(csvRecord.get("Reference"), is(transactionFixture.getReference()));
         assertThat(csvRecord.get("Description"), is(transactionFixture.getDescription()));
-        assertThat(csvRecord.get("Email"), is("someone@example.org"));
+        assertThat(csvRecord.get("Email"), is(transactionFixture.getEmail()));
         assertThat(csvRecord.get("Card Brand"), is(transactionFixture.getCardBrandLabel()));
         assertThat(csvRecord.get("Cardholder Name"), is(transactionFixture.getCardholderName()));
-        assertThat(csvRecord.get("Card Expiry Date"), is("10/21"));
+        assertThat(csvRecord.get("Card Expiry Date"), is(transactionFixture.getCardExpiryDate()));
         assertThat(csvRecord.get("Card Number"), is("1234"));
         assertThat(csvRecord.get("Card Type"), is("credit"));
     }

--- a/src/test/java/uk/gov/pay/ledger/util/fixture/TransactionFixture.java
+++ b/src/test/java/uk/gov/pay/ledger/util/fixture/TransactionFixture.java
@@ -33,22 +33,22 @@ import static uk.gov.pay.ledger.util.fixture.TransactionMetadataFixture.aTransac
 public class TransactionFixture implements DbFixture<TransactionFixture, TransactionEntity> {
 
     private Long id = RandomUtils.nextLong(1, 99999);
-    private String serviceId = RandomStringUtils.randomAlphanumeric(26);
+    private final String serviceId = RandomStringUtils.randomAlphanumeric(26);
     private String gatewayAccountId = RandomStringUtils.randomAlphanumeric(10);
-    private String credentialExternalId = "credential-external-id";
+    private final String credentialExternalId = "credential-external-id";
     private String externalId = RandomStringUtils.randomAlphanumeric(20);
     private Long amount = RandomUtils.nextLong(1, 99999);
     private String reference = RandomStringUtils.randomAlphanumeric(10);
     private String description = RandomStringUtils.randomAlphanumeric(20);
     private TransactionState state = TransactionState.SUBMITTED;
-    private String email = "someone@example.org";
-    private String cardholderName = "j.doe@example.org";
+    private String email = "j.doe@example.org";
+    private String cardholderName = "J Doe";
     private JsonElement externalMetadata = null;
     private ZonedDateTime createdDate = ZonedDateTime.now(ZoneOffset.UTC);
     private String transactionDetails = "{}";
     private Integer eventCount = 1;
     private String cardBrand = "visa";
-    private String cardExpiryDate = "10/21";
+    private final String cardExpiryDate = "10/21";
     private String language = "en";
     private String lastDigitsCardNumber;
     private String firstDigitsCardNumber;


### PR DESCRIPTION
### WHAT
When downloading transaction details in CSV format, Ledger now returns a `0.00` net value for a failed payment that has no `net_amount`. Refund behaviour is unchanged.

README tables reformatted with correct width.