### PR TITLE
PP-9252 Add index on gateway_account_id and created_date columns

### DIFF
--- a/src/main/resources/migrations/00067_index_transaction_gateway_account_id_created_date.sql
+++ b/src/main/resources/migrations/00067_index_transaction_gateway_account_id_created_date.sql
@@ -1,0 +1,4 @@
+--liquibase formatted sql
+
+--changeset uk.gov.pay:add_index_on_transaction_gateway_account_id_and_created_date runInTransaction:false
+CREATE INDEX CONCURRENTLY IF NOT EXISTS transaction_gateway_account_id_and_created_date_idx ON transaction USING btree(gateway_account_id,created_date);


### PR DESCRIPTION
## WHAT
- Adds a multicolumn index on ‘gateway_account and created_date’ columns of transaction table which could address slow query issues (which also fixed scheduled performance job for search https://build.ci.pymnt.uk/view/HUD/job/run-scheduled-performance-test-for-search/208/ that has been failing for a long time) when services load all services transactions page.
- This may not address the slow queries issue fully because of the different combination of search params allowed on the transaction table. Need to look into different indexes and remove any not required separately.