### PR TITLE
PP-9311 Update CSV service to use gateway account metadata table

### DIFF
--- a/src/main/java/uk/gov/pay/ledger/gatewayaccountmetadata/service/GatewayAccountMetadataService.java
+++ b/src/main/java/uk/gov/pay/ledger/gatewayaccountmetadata/service/GatewayAccountMetadataService.java
@@ -3,6 +3,8 @@ package uk.gov.pay.ledger.gatewayaccountmetadata.service;
 import com.google.inject.Inject;
 import uk.gov.pay.ledger.gatewayaccountmetadata.dao.GatewayAccountMetadataDao;
 
+import java.util.List;
+
 
 public class GatewayAccountMetadataService {
 
@@ -15,6 +17,10 @@ public class GatewayAccountMetadataService {
 
     public void upsertMetadataKeyForGatewayAccount(String gatewayAcctId, String metadataKey) {
         gatewayAccountMetadataDao.upsert(gatewayAcctId, metadataKey);
+    }
+
+    public List<String> getKeysForGatewayAccounts(List<String> gatewayAcctIds) {
+        return gatewayAccountMetadataDao.findMetadataKeysForGatewayAccounts(gatewayAcctIds);
     }
 
 }

--- a/src/main/java/uk/gov/pay/ledger/transaction/service/CsvService.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/service/CsvService.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.databind.ObjectWriter;
 import com.fasterxml.jackson.dataformat.csv.CsvMapper;
 import com.fasterxml.jackson.dataformat.csv.CsvSchema;
 import com.google.inject.Inject;
+import uk.gov.pay.ledger.gatewayaccountmetadata.service.GatewayAccountMetadataService;
 import uk.gov.pay.ledger.transaction.entity.TransactionEntity;
 import uk.gov.pay.ledger.transaction.model.CsvTransactionFactory;
 import uk.gov.pay.ledger.transaction.search.common.TransactionSearchParams;
@@ -18,13 +19,14 @@ import java.util.stream.Collectors;
 public class CsvService {
 
     private final CsvTransactionFactory csvTransactionFactory;
-    private final TransactionMetadataService transactionMetadataService;
+    private final GatewayAccountMetadataService gatewayAccountMetadataService;
+
 
     @Inject
     public CsvService(CsvTransactionFactory csvTransactionFactory,
-                      TransactionMetadataService transactionMetadataService) {
+                      GatewayAccountMetadataService gatewayAccountMetadataService) {
         this.csvTransactionFactory = csvTransactionFactory;
-        this.transactionMetadataService = transactionMetadataService;
+        this.gatewayAccountMetadataService = gatewayAccountMetadataService;
     }
 
     public ObjectWriter writerFrom(Map<String, Object> headers) {
@@ -43,7 +45,7 @@ public class CsvService {
                                              boolean includeFeeHeaders,
                                              boolean includeMotoHeader,
                                              boolean includeFeeBreakdownHeaders) {
-        List<String> metadataKeys = transactionMetadataService.findMetadataKeysForTransactions(searchParams);
+        List<String> metadataKeys = gatewayAccountMetadataService.getKeysForGatewayAccounts(searchParams.getAccountIds());
         return csvTransactionFactory.getCsvHeadersWithMedataKeys(metadataKeys, includeFeeHeaders, includeMotoHeader, includeFeeBreakdownHeaders);
     }
 

--- a/src/main/java/uk/gov/pay/ledger/transaction/service/TransactionMetadataService.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/service/TransactionMetadataService.java
@@ -89,17 +89,4 @@ public class TransactionMetadataService {
                             });
                 });
     }
-
-    List<String> findMetadataKeysForTransactions(TransactionSearchParams searchParams) {
-        Stopwatch stopwatch = Stopwatch.createStarted();
-
-        List<String> metadataKeysForTransactions = transactionMetadataDao.findMetadataKeysForTransactions(searchParams);
-
-        long elapsed = stopwatch.stop().elapsed(TimeUnit.MILLISECONDS);
-        LOGGER.info("CSV metadata headers calculated.",
-                kv("time_taken_in_milli_seconds", elapsed),
-                kv("number_of_metadata_keys", metadataKeysForTransactions.size()));
-
-        return metadataKeysForTransactions;
-    }
 }

--- a/src/test/java/uk/gov/pay/ledger/transaction/resource/TransactionResourceCsvIT.java
+++ b/src/test/java/uk/gov/pay/ledger/transaction/resource/TransactionResourceCsvIT.java
@@ -30,6 +30,7 @@ import static org.apache.commons.lang3.RandomStringUtils.randomNumeric;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static uk.gov.pay.ledger.util.DatabaseTestHelper.aDatabaseTestHelper;
+import static uk.gov.pay.ledger.util.fixture.GatewayAccountMetadataFixture.aGatewayAccountMetadataFixture;
 import static uk.gov.pay.ledger.util.fixture.TransactionFixture.aTransactionFixture;
 
 public class TransactionResourceCsvIT {
@@ -91,7 +92,11 @@ public class TransactionResourceCsvIT {
                 .insert(rule.getJdbi());
 
         metadataKeyDao.insertIfNotExist("test-key-1");
-        metadataKeyDao.insertIfNotExist("test-key-2");
+
+        aGatewayAccountMetadataFixture()
+                .withGatewayAccountId(targetGatewayAccountId)
+                .withMetadataKey("test-key-1")
+                .insert(rule.getJdbi());
 
         transactionMetadataDao.upsert(transactionFixture.getId(), "test-key-1", "value1");
 
@@ -337,6 +342,11 @@ public class TransactionResourceCsvIT {
         metadataKeyDao.insertIfNotExist(metadataKey);
         transactionMetadataDao.upsert(transactionFixture.getId(), metadataKey, "value1");
 
+        aGatewayAccountMetadataFixture()
+                .withGatewayAccountId(targetGatewayAccountId)
+                .withMetadataKey("a-metadata-key")
+                .insert(rule.getJdbi());
+
         InputStream csvResponseStream = given().port(port)
                 .accept("text/csv")
                 .get("/v1/transaction?" +
@@ -444,6 +454,15 @@ public class TransactionResourceCsvIT {
                 .withGatewayAccountId(targetGatewayAccountId)
                 .withDefaultTransactionDetails()
                 .insertTransactionAndTransactionMetadata(rule.getJdbi());
+
+        aGatewayAccountMetadataFixture()
+                .withGatewayAccountId(targetGatewayAccountId)
+                .withMetadataKey("a-metadata-key")
+                .insert(rule.getJdbi());
+        aGatewayAccountMetadataFixture()
+                .withGatewayAccountId(targetGatewayAccountId)
+                .withMetadataKey("metadata-key-2")
+                .insert(rule.getJdbi());
 
         InputStream csvResponseStream = given().port(port)
                 .accept("text/csv")

--- a/src/test/java/uk/gov/pay/ledger/util/DatabaseTestHelper.java
+++ b/src/test/java/uk/gov/pay/ledger/util/DatabaseTestHelper.java
@@ -37,7 +37,8 @@ public class DatabaseTestHelper {
     public void truncateAllData() {
         jdbi.withHandle(h -> h.createScript(
                 "TRUNCATE TABLE event CASCADE; " +
-                        "TRUNCATE TABLE transaction CASCADE"
+                        "TRUNCATE TABLE transaction CASCADE;" +
+                        "TRUNCATE TABLE gateway_account_metadata CASCADE;"
         ).execute());
     }
 
@@ -77,7 +78,7 @@ public class DatabaseTestHelper {
     public List<Map<String, Object>> getTransactionMetadata(Long transactionId, String key) {
         return jdbi.withHandle(handle ->
                 handle.createQuery("SELECT * FROM transaction_metadata where transaction_id = :transactionId" +
-                        " and metadata_key_id = (select id from metadata_key where key = :key)")
+                                " and metadata_key_id = (select id from metadata_key where key = :key)")
                         .bind("transactionId", transactionId)
                         .bind("key", key)
                         .mapToMap()
@@ -87,7 +88,7 @@ public class DatabaseTestHelper {
     public List<Map<String, Object>> getGatewayAccountMetadata(String gatewayAccountId, String key) {
         return jdbi.withHandle(handle ->
                 handle.createQuery("SELECT * FROM gateway_account_metadata where gateway_account_id = :gatewayAccountId" +
-                        " and metadata_key_id = (select id from metadata_key where key = :key)")
+                                " and metadata_key_id = (select id from metadata_key where key = :key)")
                         .bind("gatewayAccountId", gatewayAccountId)
                         .bind("key", key)
                         .mapToMap()
@@ -99,12 +100,12 @@ public class DatabaseTestHelper {
                                                            boolean live, boolean moto) {
         return jdbi.withHandle(handle ->
                 handle.createQuery("SELECT * FROM transaction_summary where gateway_account_id = :gatewayAccountId" +
-                        " and transaction_date = :transactionDate" +
-                        " and type = :type" +
-                        " and state = :state" +
-                        " and live = :live" +
-                        " and moto = :moto"
-                )
+                                " and transaction_date = :transactionDate" +
+                                " and type = :type" +
+                                " and state = :state" +
+                                " and live = :live" +
+                                " and moto = :moto"
+                        )
                         .bind("gatewayAccountId", gatewayAccountId)
                         .bind("transactionDate", transactionDate)
                         .bind("state", state.name())


### PR DESCRIPTION
Use the gateway_account_metadata table to get all metadata keys for
gateway accounts included in a CSV download, rather than just the keys
for transactions that are included.

We've changed this behaviour as querying with joins on the transaction
table to get the keys was very expensive and was causing CSV downloads
to take a long time or time out.

Co-authored-by: Stephen Daly <stephen.daly@digital.cabinet-office.gov.uk>