### PR TITLE
BAU Update images used by testscontainers for M1 compatibility

### DIFF
--- a/src/test/java/uk/gov/pay/ledger/rule/SqsTestDocker.java
+++ b/src/test/java/uk/gov/pay/ledger/rule/SqsTestDocker.java
@@ -29,7 +29,7 @@ public class SqsTestDocker {
         if (sqsContainer == null) {
             logger.info("Creating SQS Container");
 
-            sqsContainer = new GenericContainer("roribio16/alpine-sqs")
+            sqsContainer = new GenericContainer("mvisonneau/alpine-sqs:1.2.0")
                     .withExposedPorts(9324)
                     .waitingFor(Wait.forHttp("/?Action=GetQueueUrl&QueueName=default"));
 

--- a/src/test/resources/testcontainers.properties
+++ b/src/test/resources/testcontainers.properties
@@ -1,2 +1,2 @@
-# Digest of image testcontainersofficial/ryuk:latest for linux/amd64 from tags list on https://hub.docker.com/r/testcontainersofficial/ryuk
-ryuk.container.image=testcontainersofficial/ryuk@sha256:8fdd715bf34975d088273bcea497fe048f9b768ba4c7fc690ab6e4ddc995e317
+# arm64/amd64 friendly ryuk image
+ryuk.container.image=testcontainers/ryuk:0.3.3


### PR DESCRIPTION
Updated the following images used by `testcontainers`:
-   `testcontainersofficial/ryuk` -> `testcontainers/ryuk:0.3.3`
-  `oribio16/alpine-sqs` -> `mvisonneau/alpine-sqs:1.2.0`