### PR TITLE
Pp 9236 run consumer contract tests profile

### DIFF
--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -38,8 +38,10 @@ jobs:
       - name: Publish and tag ledger consumer pact
         run: |
           mvn pact:publish -DPACT_BROKER_URL=https://pact-broker-test.cloudapps.digital \
+          -DrunConsumerContractTests \
           -DPACT_BROKER_USERNAME=${{ secrets.pact_broker_username }} \
-          -DPACT_BROKER_PASSWORD=${{ secrets.pact_broker_password }} -DPACT_CONSUMER_TAG=master \
+          -DPACT_BROKER_PASSWORD=${{ secrets.pact_broker_password }} \
+          -DPACT_CONSUMER_TAG=master \
           -DPACT_CONSUMER_VERSION=${{ github.sha }}
 
   provider-contract-tests:


### PR DESCRIPTION
Looking at the Jenkinsfile, we want to run maven with `-DrunConsumerContractTests` when running a ledger-as-consumer build.

Example [successful run](https://github.com/alphagov/pay-ledger/runs/5585002629?check_suite_focus=true).