### PR TITLE
PP-9278 Publish dispute events to SNS

### DIFF
--- a/src/main/java/uk/gov/pay/ledger/app/config/SnsConfig.java
+++ b/src/main/java/uk/gov/pay/ledger/app/config/SnsConfig.java
@@ -11,16 +11,33 @@ public class SnsConfig extends Configuration {
     @NotNull
     private String region;
     private String cardPaymentEventsTopicArn;
+    private String cardPaymentDisputeEventsTopicArn;
+    @NotNull
+    private boolean publishCardPaymentEventsToSns;
+    @NotNull
+    private boolean publishCardPaymentDisputeEventsToSns;
 
     public boolean isSnsEnabled() {
         return snsEnabled;
+    }
+
+    public String getRegion() {
+        return region;
     }
 
     public String getCardPaymentEventsTopicArn() {
         return cardPaymentEventsTopicArn;
     }
 
-    public String getRegion() {
-        return region;
+    public String getCardPaymentDisputeEventsTopicArn() {
+        return cardPaymentDisputeEventsTopicArn;
+    }
+
+    public boolean isPublishCardPaymentEventsToSns() {
+        return publishCardPaymentEventsToSns;
+    }
+
+    public boolean isPublishCardPaymentDisputeEventsToSns() {
+        return publishCardPaymentDisputeEventsToSns;
     }
 }

--- a/src/main/java/uk/gov/pay/ledger/eventpublisher/TopicName.java
+++ b/src/main/java/uk/gov/pay/ledger/eventpublisher/TopicName.java
@@ -1,5 +1,6 @@
 package uk.gov.pay.ledger.eventpublisher;
 
 public enum TopicName {
-    CARD_PAYMENT_EVENTS
+    CARD_PAYMENT_EVENTS,
+    CARD_PAYMENT_DISPUTE_EVENTS
 }

--- a/src/main/java/uk/gov/pay/ledger/eventpublisher/TopicNameArnMapper.java
+++ b/src/main/java/uk/gov/pay/ledger/eventpublisher/TopicNameArnMapper.java
@@ -11,10 +11,13 @@ class TopicNameArnMapper {
 
     @Inject
     TopicNameArnMapper(LedgerConfig ledgerConfig) {
-        this.snsConfig  = ledgerConfig.getSnsConfig();
+        this.snsConfig = ledgerConfig.getSnsConfig();
     }
+
     public String getArnForTopicName(TopicName topicName) {
-        return Map.of(TopicName.CARD_PAYMENT_EVENTS, snsConfig.getCardPaymentEventsTopicArn())
+        return Map.of(
+                        TopicName.CARD_PAYMENT_EVENTS, snsConfig.getCardPaymentEventsTopicArn(),
+                        TopicName.CARD_PAYMENT_DISPUTE_EVENTS, snsConfig.getCardPaymentDisputeEventsTopicArn())
                 .get(topicName);
     }
 }

--- a/src/main/java/uk/gov/pay/ledger/queue/EventMessageHandler.java
+++ b/src/main/java/uk/gov/pay/ledger/queue/EventMessageHandler.java
@@ -8,6 +8,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.pay.ledger.app.LedgerConfig;
 import uk.gov.pay.ledger.event.model.Event;
+import uk.gov.pay.ledger.event.model.ResourceType;
 import uk.gov.pay.ledger.event.model.response.CreateEventResponse;
 import uk.gov.pay.ledger.event.service.EventService;
 import uk.gov.pay.ledger.eventpublisher.EventPublisher;
@@ -86,10 +87,21 @@ public class EventMessageHandler {
 
         if (ledgerConfig.getSnsConfig().isSnsEnabled()) {
             try {
-                eventPublisher.publishMessageToTopic(
-                        objectMapper.writeValueAsString(message.getEvent()),
-                        TopicName.CARD_PAYMENT_EVENTS
-                );
+                if (message.getEvent().getResourceType() == ResourceType.DISPUTE) {
+                    if (ledgerConfig.getSnsConfig().isPublishCardPaymentDisputeEventsToSns()) {
+                        eventPublisher.publishMessageToTopic(
+                                objectMapper.writeValueAsString(message.getEvent()),
+                                TopicName.CARD_PAYMENT_DISPUTE_EVENTS
+                        );
+                    }
+                } else {
+                    if (ledgerConfig.getSnsConfig().isPublishCardPaymentEventsToSns()) {
+                        eventPublisher.publishMessageToTopic(
+                                objectMapper.writeValueAsString(message.getEvent()),
+                                TopicName.CARD_PAYMENT_EVENTS
+                        );
+                    }
+                }
             } catch (Exception e) {
                 LOGGER.warn("Failed to publish event for message",
                         kv("sqs_message_id", message.getQueueMessageId()),

--- a/src/main/resources/config/config.yaml
+++ b/src/main/resources/config/config.yaml
@@ -73,6 +73,9 @@ snsConfig:
   snsEnabled: ${SNS_ENABLED:-false}
   region: ${AWS_SNS_REGION:-eu-west-1}
   cardPaymentEventsTopicArn: ${SNS_TOPIC_CARD_PAYMENT_EVENTS_ARN}
+  cardPaymentDisputeEventsTopicArn: ${SNS_TOPIC_CARD_PAYMENT_DISPUTE_EVENTS_ARN}
+  publishCardPaymentEventsToSns: ${PUBLISH_CARD_PAYMENT_EVENTS_TO_SNS:-false}
+  publishCardPaymentDisputeEventsToSns: ${PUBLISH_CARD_PAYMENT_DISPUTE_EVENTS_TO_SNS:-false}
 
 queueMessageReceiverConfig:
   backgroundProcessingEnabled: ${BACKGROUND_PROCESSING_ENABLED:-true}

--- a/src/test/java/uk/gov/pay/ledger/eventpublisher/EventPublisherTest.java
+++ b/src/test/java/uk/gov/pay/ledger/eventpublisher/EventPublisherTest.java
@@ -27,21 +27,24 @@ public class EventPublisherTest {
 
     private TopicNameArnMapper topicNameArnMapper;
 
-    private String cardPaymentEventTopicArn = "sns_arn";
+    private String cardPaymentEventsTopicArn = "card_payment_events_arn";
+
+    private String cardPaymentDisputeEventsTopicArn = "card_payment_dispute_events_arn";
 
     private EventPublisher eventPublisher;
 
     @Test
     public void shouldPublishMessageToSpecifiedTopic() throws Exception {
         when(ledgerConfig.getSnsConfig()).thenReturn(snsConfig);
-        when(snsConfig.getCardPaymentEventsTopicArn()).thenReturn(cardPaymentEventTopicArn);
+        when(snsConfig.getCardPaymentEventsTopicArn()).thenReturn(cardPaymentEventsTopicArn);
+        when(snsConfig.getCardPaymentDisputeEventsTopicArn()).thenReturn(cardPaymentDisputeEventsTopicArn);
         topicNameArnMapper = new TopicNameArnMapper(ledgerConfig);
         eventPublisher = new EventPublisher(snsClient, topicNameArnMapper);
         var message = "Hooray, I've been published";
         var expectedPublishRequest = PublishRequest
                 .builder()
                 .message(message)
-                .topicArn(cardPaymentEventTopicArn)
+                .topicArn(cardPaymentEventsTopicArn)
                 .build();
 
         eventPublisher.publishMessageToTopic(message, TopicName.CARD_PAYMENT_EVENTS);
@@ -53,6 +56,7 @@ public class EventPublisherTest {
     public void shouldNotErrorWhenTopicArnNotSet() {
         when(ledgerConfig.getSnsConfig()).thenReturn(snsConfig);
         lenient().when(snsConfig.getCardPaymentEventsTopicArn()).thenReturn(null);
+        lenient().when(snsConfig.getCardPaymentDisputeEventsTopicArn()).thenReturn(null);
         topicNameArnMapper = new TopicNameArnMapper(ledgerConfig);
 
         assertDoesNotThrow(() -> new EventPublisher(snsClient, topicNameArnMapper));


### PR DESCRIPTION
Publish dispute events to the SNS topic card_payment_dispute_events.

Add feature flags to separately enable sending events to the
card_payment_events topic and the card_payment_dispute_events topic.