### PR TITLE
PP-9278 Fix serialisation of SNS message

### DIFF
--- a/src/main/java/uk/gov/pay/ledger/queue/EventMessage.java
+++ b/src/main/java/uk/gov/pay/ledger/queue/EventMessage.java
@@ -38,4 +38,8 @@ public class EventMessage {
     public String getQueueMessageReceiptHandle() {
         return queueMessage.getReceiptHandle();
     }
+
+    public EventMessageDto getEventDto() {
+        return eventDto;
+    }
 }

--- a/src/main/java/uk/gov/pay/ledger/queue/EventMessageHandler.java
+++ b/src/main/java/uk/gov/pay/ledger/queue/EventMessageHandler.java
@@ -90,14 +90,14 @@ public class EventMessageHandler {
                 if (message.getEvent().getResourceType() == ResourceType.DISPUTE) {
                     if (ledgerConfig.getSnsConfig().isPublishCardPaymentDisputeEventsToSns()) {
                         eventPublisher.publishMessageToTopic(
-                                objectMapper.writeValueAsString(message.getEvent()),
+                                objectMapper.writeValueAsString(message.getEventDto()),
                                 TopicName.CARD_PAYMENT_DISPUTE_EVENTS
                         );
                     }
                 } else {
                     if (ledgerConfig.getSnsConfig().isPublishCardPaymentEventsToSns()) {
                         eventPublisher.publishMessageToTopic(
-                                objectMapper.writeValueAsString(message.getEvent()),
+                                objectMapper.writeValueAsString(message.getEventDto()),
                                 TopicName.CARD_PAYMENT_EVENTS
                         );
                     }

--- a/src/test/java/uk/gov/pay/ledger/queue/EventMessageHandlerTest.java
+++ b/src/test/java/uk/gov/pay/ledger/queue/EventMessageHandlerTest.java
@@ -147,10 +147,12 @@ class EventMessageHandlerTest {
         var deserializedEvent = "deserialized event";
         Event event = aQueuePaymentEventFixture().toEntity();
         when(eventMessage.getEvent()).thenReturn(event);
+        var eventDto = new EventMessageDto();
+        when(eventMessage.getEventDto()).thenReturn(eventDto);
         when(ledgerConfig.getSnsConfig()).thenReturn(snsConfig);
         when(snsConfig.isSnsEnabled()).thenReturn(true);
         when(snsConfig.isPublishCardPaymentEventsToSns()).thenReturn(true);
-        when(objectMapper.writeValueAsString(event)).thenReturn(deserializedEvent);
+        when(objectMapper.writeValueAsString(eventDto)).thenReturn(deserializedEvent);
 
         eventMessageHandler.handle();
 
@@ -162,10 +164,12 @@ class EventMessageHandlerTest {
         var deserializedEvent = "deserialized event";
         Event event = aQueuePaymentEventFixture().withResourceType(ResourceType.DISPUTE).toEntity();
         when(eventMessage.getEvent()).thenReturn(event);
+        var eventDto = new EventMessageDto();
+        when(eventMessage.getEventDto()).thenReturn(eventDto);
         when(ledgerConfig.getSnsConfig()).thenReturn(snsConfig);
         when(snsConfig.isSnsEnabled()).thenReturn(true);
         when(snsConfig.isPublishCardPaymentDisputeEventsToSns()).thenReturn(true);
-        when(objectMapper.writeValueAsString(event)).thenReturn(deserializedEvent);
+        when(objectMapper.writeValueAsString(eventDto)).thenReturn(deserializedEvent);
 
         eventMessageHandler.handle();
 


### PR DESCRIPTION
When serialising the event to send to SNS, use the EventMessageDto,
rather then the internal Event model. This ensures that the field names
are unchanged from the event received from connector. In particular,
the "event_details" fields is renamed to "event_data" in the internal
ledger Event model.

This field isn't deserialised by webhooks, so we won't break anything
by changing it.