### PR TITLE
BAU Serialise event date using standard pay format

### DIFF
--- a/src/main/java/uk/gov/pay/ledger/queue/EventMessage.java
+++ b/src/main/java/uk/gov/pay/ledger/queue/EventMessage.java
@@ -28,7 +28,7 @@ public class EventMessage {
                 eventDto.getResourceType(),
                 eventDto.getExternalId(),
                 eventDto.getParentExternalId(),
-                eventDto.getEventDate(),
+                eventDto.getTimestamp(),
                 eventDto.getEventType(),
                 eventDto.getEventData(),
                 eventDto.isReprojectDomainObject()

--- a/src/main/java/uk/gov/pay/ledger/queue/EventMessageDto.java
+++ b/src/main/java/uk/gov/pay/ledger/queue/EventMessageDto.java
@@ -6,8 +6,10 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import uk.gov.pay.ledger.event.model.ResourceType;
 import uk.gov.service.payments.commons.api.json.MicrosecondPrecisionDateTimeDeserializer;
+import uk.gov.service.payments.commons.api.json.MicrosecondPrecisionDateTimeSerializer;
 
 import java.time.ZonedDateTime;
 
@@ -49,7 +51,8 @@ public class EventMessageDto {
         return resourceType;
     }
 
-    public ZonedDateTime getEventDate() {
+    @JsonSerialize(using = MicrosecondPrecisionDateTimeSerializer.class)
+    public ZonedDateTime getTimestamp() {
         return timestamp;
     }
 


### PR DESCRIPTION
Rename `event_date` to `timestamp` match the original event spec (from producer
Connector). The event store shouldn't be doing any renaming on event
fields before publishing.

Downstream services receiving events parse event metadata. Now that this
is the publishing DTO, make sure a standard format is used for time.