### PR TITLE
PP-9281 Derive service_id from events

### DIFF
--- a/src/main/java/uk/gov/pay/ledger/event/model/EventDigest.java
+++ b/src/main/java/uk/gov/pay/ledger/event/model/EventDigest.java
@@ -69,6 +69,7 @@ public class EventDigest {
                 .orElseThrow();
 
         String parentResourceExternalId = deriveParentResourceExternalId(events);
+        String serviceId = deriveServiceId(events);
 
         Boolean isLive = events.stream()
                 .filter(event -> event.getLive() != null)
@@ -77,7 +78,7 @@ public class EventDigest {
                 .orElse(null);
 
         return new EventDigest(
-                latestEvent.getServiceId(),
+                serviceId,
                 isLive,
                 latestEvent.getEventDate(),
                 latestSalientEventType,
@@ -88,6 +89,14 @@ public class EventDigest {
                 eventPayload,
                 earliestDate
         );
+    }
+
+    private static String deriveServiceId(List<Event> events) {
+        return events.stream()
+                .filter(event -> isNotEmpty(event.getServiceId()))
+                .map(Event::getServiceId)
+                .findFirst()
+                .orElse(null);
     }
 
     private static String deriveParentResourceExternalId(List<Event> events) {

--- a/src/test/java/uk/gov/pay/ledger/event/model/EventDigestTest.java
+++ b/src/test/java/uk/gov/pay/ledger/event/model/EventDigestTest.java
@@ -56,6 +56,48 @@ public class EventDigestTest {
     }
 
     @Test
+    public void shouldDeriveNonNullServiceIdCorrectlyFromEventDigest() {
+        Event eventWithServiceId = anEventFixture()
+                .withEventDate(ZonedDateTime.now().minusHours(2L))
+                .withServiceId("service-id")
+                .toEntity();
+
+        Event eventWithOutServiceId = anEventFixture()
+                .withEventDate(ZonedDateTime.now())
+                .toEntity();
+
+        Event latestEventWithOutServiceId = anEventFixture()
+                .withEventDate(ZonedDateTime.now().plusDays(2))
+                .withServiceId(null)
+                .toEntity();
+
+        EventDigest eventDigest = EventDigest.fromEventList(
+                List.of(eventWithServiceId, eventWithOutServiceId, latestEventWithOutServiceId));
+
+        assertThat(eventDigest.getServiceId(), is("service-id"));
+    }
+
+    @Test
+    public void shouldDeriveServiceIdToNullIfNoEventsHasServiceId() {
+        Event eventWithoutServiceId = anEventFixture()
+                .withParentResourceExternalId(null)
+                .toEntity();
+
+        Event event2WithoutServiceId = anEventFixture()
+                .withParentResourceExternalId(null)
+                .toEntity();
+
+        Event event3WithoutServiceId = anEventFixture()
+                .withParentResourceExternalId(null)
+                .toEntity();
+
+        EventDigest eventDigest = EventDigest.fromEventList(
+                List.of(eventWithoutServiceId, event2WithoutServiceId, event3WithoutServiceId));
+
+        assertThat(eventDigest.getParentResourceExternalId(), is(nullValue()));
+    }
+
+    @Test
     public void shouldBeLiveTrueIfContainsTrueEvent() {
         Event eventWithNullLiveValue = anEventFixture().withLive(null).toEntity();
         Event eventWithTrueLiveValue = anEventFixture().withLive(true).toEntity();

--- a/src/test/java/uk/gov/pay/ledger/util/fixture/EventFixture.java
+++ b/src/test/java/uk/gov/pay/ledger/util/fixture/EventFixture.java
@@ -65,6 +65,11 @@ public class EventFixture implements DbFixture<EventFixture, Event> {
         return this;
     }
 
+    public EventFixture withServiceId(String serviceId) {
+        this.serviceId = serviceId;
+        return this;
+    }
+
     public EventFixture withEventType(String eventType) {
         this.eventType = eventType;
         return this;


### PR DESCRIPTION
## WHAT

- Derived service_id if any one event in the given list has service_id.
- This is because some events from connector doesn't have service_id set and service_id on the transaction could be null if taken from latest event.