### PR TITLE
PP-9456 OpenAPI specs for events and payouts resources

### DIFF
--- a/openapi/ledger_spec.yaml
+++ b/openapi/ledger_spec.yaml
@@ -1,0 +1,301 @@
+openapi: 3.0.1
+info:
+  description: Ledger API
+  title: Ledger API
+  version: v1.0.0
+servers:
+- url: http://ledger_url
+paths:
+  /v1/event/ticker:
+    get:
+      operationId: listEvents
+      parameters:
+      - description: from date of events to be searched (this date is inclusive).
+        example: 2015-08-14T12:35:00Z
+        in: query
+        name: from_date
+        required: true
+        schema:
+          type: string
+      - description: to date of events to be searched (this date is exclusive)
+        example: 2015-08-14T12:35:00Z
+        in: query
+        name: to_date
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/EventTicker'
+          description: OK
+        "422":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Missing query parameters
+        "500":
+          description: Invalid parameters or Downstream system error
+      summary: Get list of events between a date/time range
+      tags:
+      - Events
+  /v1/event/{eventId}:
+    get:
+      operationId: getEvent
+      parameters:
+      - in: path
+        name: eventId
+        required: true
+        schema:
+          type: integer
+          format: int64
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Event'
+          description: OK
+        "404":
+          description: Not found
+      summary: Find event by ID (id of event table)
+      tags:
+      - Events
+  /v1/payout:
+    get:
+      operationId: search
+      parameters:
+      - description: "State of payout. allowed values are intransit, paidout, failed"
+        in: query
+        name: state
+        schema:
+          type: string
+      - description: "Page number requested for the search, should be a positive integer\
+          \ (optional, defaults to 1)"
+        in: query
+        name: page
+        schema:
+          type: integer
+          format: int64
+      - description: "Number of results to be shown per page, should be a positive\
+          \ integer (optional, defaults to 500, max 500)"
+        in: query
+        name: display_size
+        schema:
+          type: integer
+          format: int64
+      - description: Set to true to list all payouts.
+        in: query
+        name: override_account_id_restriction
+        schema:
+          type: boolean
+      - description: Comma separate gateway account IDs. Required except when override_account_id_restriction=true
+        example: "1,2"
+        in: query
+        name: gateway_account_id
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PayoutSearchResponse'
+          description: OK
+        "404":
+          description: Not found
+      summary: Search payouts by gateway_account_id and state
+      tags:
+      - Payouts
+components:
+  schemas:
+    ErrorResponse:
+      type: object
+      properties:
+        error_identifier:
+          type: string
+          enum:
+          - GENERIC
+          - REFUND_NOT_AVAILABLE
+          - REFUND_AMOUNT_AVAILABLE_MISMATCH
+          - ZERO_AMOUNT_NOT_ALLOWED
+          - MOTO_NOT_ALLOWED
+          - CANCEL_CHARGE_FAILURE_DUE_TO_CONFLICTING_TERMINAL_STATE_AT_GATEWAY_CHARGE_STATE_FORCIBLY_TRANSITIONED
+          - CANCEL_CHARGE_FAILURE_DUE_TO_CONFLICTING_TERMINAL_STATE_AT_GATEWAY_INVALID_STATE_TRANSITION
+          - AUTH_TOKEN_INVALID
+          - AUTH_TOKEN_REVOKED
+          - ACCOUNT_NOT_LINKED_WITH_PSP
+          - TELEPHONE_PAYMENT_NOTIFICATIONS_NOT_ALLOWED
+          - AGREEMENT_NOT_FOUND
+        message:
+          type: array
+          items:
+            type: string
+    Event:
+      type: object
+      properties:
+        event_data:
+          type: string
+          example: "{\"live\": false, \"moto\": false, \"amount\": 1000, \"source\"\
+            : \"CARD_API\", \"language\": \"en\", \"reference\": \"my payment reference\"\
+            , \"return_url\": \"https://www.payments.service.gov.uk\", \"description\"\
+            : \"my payment\", \"delayed_capture\": false, \"payment_provider\": \"\
+            sandbox\", \"gateway_account_id\": \"3\", \"credential_external_id\":\
+            \ \"ddb294481de146c09598c8cce0461af9\", \"save_payment_instrument_to_agreement\"\
+            : false}\""
+        event_date:
+          type: string
+          format: date-time
+        event_type:
+          type: string
+          example: PAYMENT_CREATED
+        live:
+          type: boolean
+          example: true
+        parent_resource_external_id:
+          type: string
+          default: "null"
+          example: l40ajdf0923uojlkfjsldkjfl2
+        reproject_domain_object:
+          type: boolean
+          default: false
+          example: true
+        resource_external_id:
+          type: string
+          example: 58na2dr7rv7h6h53bef1l0soep
+        resource_type:
+          type: string
+          enum:
+          - agreement
+          - payment
+          - refund
+          - service
+          - card_payment
+          - payout
+          - dispute
+          example: payment
+        service_id:
+          type: string
+          example: ea2d6673b23d4ff7ad88a1fd3c7ab0f6
+        sqs_message_id:
+          type: string
+          example: fe689579-63af-40bf-a783-23de97134b5f
+    EventTicker:
+      type: object
+      properties:
+        amount:
+          type: integer
+          format: int64
+          example: 100
+        card_brand:
+          type: string
+          example: visa
+        event_date:
+          type: string
+          format: date-time
+        event_type:
+          type: string
+          example: PAYMENT_CREATED
+        gateway_account_id:
+          type: string
+          example: "1"
+        payment_provider:
+          type: string
+          example: sandbox
+        resource_external_id:
+          type: string
+          example: 9np5pocnotgkpp029d5kdfau5f
+        resource_type:
+          type: string
+          enum:
+          - agreement
+          - payment
+          - refund
+          - service
+          - card_payment
+          - payout
+          - dispute
+          example: payment
+        transaction_type:
+          type: string
+          example: PAYMENT
+    PaginationBuilder:
+      type: object
+      properties:
+        first_page:
+          $ref: '#/components/schemas/PaginationLink'
+        last_page:
+          $ref: '#/components/schemas/PaginationLink'
+        next_page:
+          $ref: '#/components/schemas/PaginationLink'
+        prev_page:
+          $ref: '#/components/schemas/PaginationLink'
+        self:
+          $ref: '#/components/schemas/PaginationLink'
+    PaginationLink:
+      type: object
+      properties:
+        href:
+          type: string
+          example: https://an.example.link
+    PayoutSearchResponse:
+      type: object
+      properties:
+        _links:
+          $ref: '#/components/schemas/PaginationBuilder'
+        count:
+          type: integer
+          format: int64
+          example: 100
+        page:
+          type: integer
+          format: int64
+          example: 1
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/PayoutView'
+        total:
+          type: integer
+          format: int64
+          example: 1000
+    PayoutView:
+      type: object
+      properties:
+        amount:
+          type: integer
+          format: int64
+          description: amount in pence
+          example: 1000
+        created_date:
+          type: string
+          format: date-time
+        gateway_account_id:
+          type: string
+          example: "1"
+        gateway_payout_id:
+          type: string
+          example: po_sd0fkpam0dlwe10dmlsl3mf
+        live:
+          type: boolean
+          example: true
+        paid_out_date:
+          type: string
+          format: date-time
+        service_id:
+          type: string
+          example: dlsd0dkad20sk0adne9fjd
+        state:
+          type: string
+          enum:
+          - UNDEFINED
+          - IN_TRANSIT
+          - PAID_OUT
+          - FAILED
+          example: "{\"status\":\"paidout\",\"finished\":true}"

--- a/pom.xml
+++ b/pom.xml
@@ -19,6 +19,7 @@
         <surefire.version>3.0.0-M5</surefire.version>
         <guice.version>5.1.0</guice.version>
         <rest-assured.version>5.0.0</rest-assured.version>
+        <swaggger-version>2.1.13</swaggger-version>
         <PACT_BROKER_URL/>
         <PACT_BROKER_USERNAME/>
         <PACT_BROKER_PASSWORD/>
@@ -255,6 +256,12 @@
             <version>1.9.0</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.swagger.core.v3</groupId>
+            <artifactId>swagger-annotations</artifactId>
+            <version>${swaggger-version}</version>
+            <scope>compile</scope>
+        </dependency>
     </dependencies>
 
     <build>
@@ -404,6 +411,25 @@
                         <argument>src/main/resources/config/config.yaml</argument>
                     </arguments>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>io.swagger.core.v3</groupId>
+                <artifactId>swagger-maven-plugin</artifactId>
+                <version>${swaggger-version}</version>
+                <configuration>
+                    <outputPath>openapi</outputPath>
+                    <outputFileName>ledger_spec</outputFileName>
+                    <outputFormat>YAML</outputFormat>
+                    <configurationFilePath>${basedir}/src/main/resources/openapi-config.yaml</configurationFilePath>
+                </configuration>
+                <executions>
+                    <execution>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>resolve</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/src/main/java/uk/gov/pay/ledger/event/model/Event.java
+++ b/src/main/java/uk/gov/pay/ledger/event/model/Event.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import io.swagger.v3.oas.annotations.media.Schema;
 import uk.gov.service.payments.commons.api.json.MicrosecondPrecisionDateTimeSerializer;
 
 import java.time.ZonedDateTime;
@@ -14,16 +15,26 @@ public class Event {
 
     @JsonIgnore
     private Long id;
+    @Schema(example = "fe689579-63af-40bf-a783-23de97134b5f")
     private String sqsMessageId;
+    @Schema(example = "ea2d6673b23d4ff7ad88a1fd3c7ab0f6")
     private String serviceId;
+    @Schema(example = "true")
     private Boolean live;
+    @Schema(example = "payment")
     private ResourceType resourceType;
+    @Schema(example = "58na2dr7rv7h6h53bef1l0soep")
     private String resourceExternalId;
+    @Schema(example = "l40ajdf0923uojlkfjsldkjfl2", defaultValue = "null")
     private String parentResourceExternalId;
     @JsonSerialize(using = MicrosecondPrecisionDateTimeSerializer.class)
+    @Schema(implementation = ZonedDateTime.class, example = "\"2022-03-30T15:09:20.241Z\"")
     private ZonedDateTime eventDate;
+    @Schema(example = "PAYMENT_CREATED")
     private String eventType;
+    @Schema(example = "{\"live\": false, \"moto\": false, \"amount\": 1000, \"source\": \"CARD_API\", \"language\": \"en\", \"reference\": \"my payment reference\", \"return_url\": \"https://www.payments.service.gov.uk\", \"description\": \"my payment\", \"delayed_capture\": false, \"payment_provider\": \"sandbox\", \"gateway_account_id\": \"3\", \"credential_external_id\": \"ddb294481de146c09598c8cce0461af9\", \"save_payment_instrument_to_agreement\": false}\"")
     private String eventData;
+    @Schema(example = "true", defaultValue = "false")
     private boolean reprojectDomainObject;
 
     public Event() {
@@ -63,7 +74,7 @@ public class Event {
                  String eventType,
                  String eventData,
                  boolean reprojectDomainObject) {
-        this(null, sqsMessageId, serviceId, live,  resourceType, resourceExternalId, parentResourceExternalId, eventDate, eventType,
+        this(null, sqsMessageId, serviceId, live, resourceType, resourceExternalId, parentResourceExternalId, eventDate, eventType,
                 eventData, reprojectDomainObject);
     }
 

--- a/src/main/java/uk/gov/pay/ledger/event/model/EventTicker.java
+++ b/src/main/java/uk/gov/pay/ledger/event/model/EventTicker.java
@@ -1,28 +1,38 @@
 package uk.gov.pay.ledger.event.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import io.swagger.v3.oas.annotations.media.Schema;
 import uk.gov.service.payments.commons.api.json.MicrosecondPrecisionDateTimeSerializer;
 
 import java.time.ZonedDateTime;
 import java.util.Objects;
 
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class EventTicker {
 
     @JsonIgnore
     private Long id;
-    private ResourceType resourceType;
+    @Schema(example = "9np5pocnotgkpp029d5kdfau5f")
     private String resourceExternalId;
+    @Schema(example = "payment")
+    private ResourceType resourceType;
     @JsonSerialize(using = MicrosecondPrecisionDateTimeSerializer.class)
+    @Schema(implementation = ZonedDateTime.class, example = "\"2022-03-30T15:09:20.241Z\"")
     private ZonedDateTime eventDate;
+    @Schema(example = "PAYMENT_CREATED")
     private String eventType;
+    @Schema(example = "visa")
     private String cardBrand;
+    @Schema(example = "PAYMENT")
     private String transactionType;
+    @Schema(example = "sandbox")
     private String paymentProvider;
+    @Schema(example = "1")
     private String gatewayAccountId;
+    @Schema(example = "100")
     private Long amount;
 
     public EventTicker() { }

--- a/src/main/java/uk/gov/pay/ledger/event/resource/EventResource.java
+++ b/src/main/java/uk/gov/pay/ledger/event/resource/EventResource.java
@@ -2,31 +2,36 @@ package uk.gov.pay.ledger.event.resource;
 
 import com.codahale.metrics.annotation.Timed;
 import com.google.inject.Inject;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.pay.ledger.event.dao.EventDao;
 import uk.gov.pay.ledger.event.model.Event;
 import uk.gov.pay.ledger.event.model.EventTicker;
-import uk.gov.pay.ledger.exception.ValidationException;
-import static org.apache.commons.lang3.StringUtils.isBlank;
+import uk.gov.pay.ledger.exception.ErrorResponse;
 
 import javax.validation.constraints.NotEmpty;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
-import javax.ws.rs.QueryParam;
 import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Response;
-
 import java.time.ZonedDateTime;
 import java.util.List;
 
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 
-
 @Path("/v1/event")
 @Produces(APPLICATION_JSON)
+@Tag(name = "Events")
 public class EventResource {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(EventResource.class);
@@ -40,6 +45,13 @@ public class EventResource {
     @Path("/{eventId}")
     @GET
     @Timed
+    @Operation(
+            summary = "Find event by ID (id of event table)",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = Event.class))),
+                    @ApiResponse(responseCode = "404", description = "Not found")
+            }
+    )
     public Event getEvent(@PathParam("eventId") Long eventId) {
         LOGGER.info("Get event request: {}", eventId);
         return eventDao.getById(eventId)
@@ -49,7 +61,19 @@ public class EventResource {
     @Path("/ticker")
     @GET
     @Timed
-    public List<EventTicker> eventTickerList(@NotEmpty @QueryParam("from_date") String fromDate, @NotEmpty @QueryParam("to_date") String toDate) {
+    @Operation(
+            operationId = "listEvents",
+            summary = "Get list of events between a date/time range",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "OK", content = @Content(array = @ArraySchema(schema = @Schema(implementation = EventTicker.class)))),
+                    @ApiResponse(responseCode = "422", description = "Missing query parameters", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+                    @ApiResponse(responseCode = "500", description = "Invalid parameters or Downstream system error")
+            }
+    )
+    public List<EventTicker> eventTickerList(@NotEmpty @Parameter(description = "from date of events to be searched (this date is inclusive).", required = true, example = "\"2015-08-14T12:35:00Z\"")
+                                             @QueryParam("from_date") String fromDate,
+                                             @NotEmpty @Parameter(description = "to date of events to be searched (this date is exclusive)", required = true, example = "\"2015-08-14T12:35:00Z\"")
+                                             @QueryParam("to_date") String toDate) {
         return eventDao.findEventsTickerFromDate(ZonedDateTime.parse(fromDate), ZonedDateTime.parse(toDate));
     }
 }

--- a/src/main/java/uk/gov/pay/ledger/payout/model/PayoutSearchResponse.java
+++ b/src/main/java/uk/gov/pay/ledger/payout/model/PayoutSearchResponse.java
@@ -1,6 +1,8 @@
 package uk.gov.pay.ledger.payout.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Schema;
 import uk.gov.pay.ledger.util.pagination.PaginationBuilder;
 
 import java.util.List;
@@ -8,12 +10,16 @@ import java.util.List;
 public class PayoutSearchResponse {
 
     @JsonProperty("total")
+    @Schema(example = "1000")
     private Long total;
     @JsonProperty("count")
+    @Schema(example = "100")
     private long count;
     @JsonProperty("page")
+    @Schema(example = "1")
     private long page;
     @JsonProperty("results")
+    @ArraySchema(schema = @Schema(implementation = PayoutView.class))
     List<PayoutView> payoutViewList;
     @JsonProperty("_links")
     private PaginationBuilder paginationBuilder;

--- a/src/main/java/uk/gov/pay/ledger/payout/model/PayoutView.java
+++ b/src/main/java/uk/gov/pay/ledger/payout/model/PayoutView.java
@@ -1,26 +1,34 @@
 package uk.gov.pay.ledger.payout.model;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import io.swagger.v3.oas.annotations.media.Schema;
 import uk.gov.pay.ledger.payout.entity.PayoutEntity;
 import uk.gov.pay.ledger.payout.state.PayoutState;
 import uk.gov.service.payments.commons.api.json.ApiResponseDateTimeSerializer;
 
 import java.time.ZonedDateTime;
 
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class PayoutView {
 
+    @Schema(description = "amount in pence", example = "1000")
     private Long amount;
     @JsonSerialize(using = ApiResponseDateTimeSerializer.class)
+    @Schema(implementation = ZonedDateTime.class, example = "\"2022-03-30T15:09:20.241Z\"")
     private ZonedDateTime createdDate;
+    @Schema(example = "po_sd0fkpam0dlwe10dmlsl3mf")
     private String gatewayPayoutId;
+    @Schema(example = "1")
     private String gatewayAccountId;
+    @Schema(example = "dlsd0dkad20sk0adne9fjd")
     private String serviceId;
+    @Schema(example = "true")
     private Boolean live;
     @JsonSerialize(using = ApiResponseDateTimeSerializer.class)
     private ZonedDateTime paidOutDate;
+    @Schema(implementation = PayoutState.class, type="object", example = "{\"status\": \"paidout\",\"finished\": true }")
     private PayoutState state;
 
     private PayoutView(Long amount, ZonedDateTime createdDate, String gatewayPayoutId,

--- a/src/main/java/uk/gov/pay/ledger/payout/resource/PayoutResource.java
+++ b/src/main/java/uk/gov/pay/ledger/payout/resource/PayoutResource.java
@@ -2,8 +2,12 @@ package uk.gov.pay.ledger.payout.resource;
 
 import com.codahale.metrics.annotation.Timed;
 import com.google.inject.Inject;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import uk.gov.pay.ledger.payout.model.PayoutSearchResponse;
 import uk.gov.pay.ledger.payout.search.PayoutSearchParams;
 import uk.gov.pay.ledger.payout.service.PayoutService;
@@ -24,6 +28,7 @@ import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 
 @Path("/v1/payout")
 @Produces(APPLICATION_JSON)
+@Tag(name = "Payouts")
 public class PayoutResource {
 
     private static final String ACCOUNT_MANAGER_FIELD_NAME = "gateway_account_id";
@@ -37,9 +42,18 @@ public class PayoutResource {
     @Path("/")
     @GET
     @Timed
+    @Operation(
+            summary = "Search payouts by gateway_account_id and state",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = PayoutSearchResponse.class))),
+                    @ApiResponse(responseCode = "404", description = "Not found")
+            }
+    )
     public PayoutSearchResponse search(@BeanParam PayoutSearchParams searchParams,
-                                       @QueryParam("override_account_id_restriction") Boolean overrideAccountRestriction,
-                                       @QueryParam("gateway_account_id") CommaDelimitedSetParameter gatewayAccountIds,
+                                       @QueryParam("override_account_id_restriction") @Parameter(description = "Set to true to list all payouts.")
+                                               Boolean overrideAccountRestriction,
+                                       @QueryParam("gateway_account_id") @Parameter(description = "Comma separate gateway account IDs. Required except when override_account_id_restriction=true", required = true, example = "1,2", schema = @Schema(type = "string", implementation = String.class))
+                                               CommaDelimitedSetParameter gatewayAccountIds,
                                        @Context UriInfo uriInfo) {
 
         return searchForPayouts(searchParams, overrideAccountRestriction, gatewayAccountIds, uriInfo);

--- a/src/main/java/uk/gov/pay/ledger/payout/search/PayoutSearchParams.java
+++ b/src/main/java/uk/gov/pay/ledger/payout/search/PayoutSearchParams.java
@@ -1,8 +1,8 @@
 package uk.gov.pay.ledger.payout.search;
 
+import io.swagger.v3.oas.annotations.Parameter;
 import uk.gov.pay.ledger.common.search.SearchParams;
 import uk.gov.pay.ledger.payout.state.PayoutState;
-import uk.gov.pay.ledger.util.CommaDelimitedSetParameter;
 
 import javax.ws.rs.DefaultValue;
 import javax.ws.rs.QueryParam;
@@ -11,10 +11,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.stream.Collectors;
 
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
-import static uk.gov.pay.ledger.payout.state.PayoutState.from;
 
 public class PayoutSearchParams extends SearchParams {
 
@@ -28,6 +26,7 @@ public class PayoutSearchParams extends SearchParams {
 
     private List<String> gatewayAccountIds;
     @QueryParam("state")
+    @Parameter(description = "State of payout. allowed values are intransit, paidout, failed")
     private String state;
     @DefaultValue("true")
     private Long pageNumber = 1L;
@@ -43,11 +42,13 @@ public class PayoutSearchParams extends SearchParams {
     }
 
     @QueryParam("page")
+    @Parameter(description = "Page number requested for the search, should be a positive integer (optional, defaults to 1)")
     public void setPageNumber(Long pageNumber) {
         this.pageNumber = Objects.requireNonNullElse(pageNumber, DEFAULT_PAGE_NUMBER);
     }
 
     @QueryParam("display_size")
+    @Parameter(description = "Number of results to be shown per page, should be a positive integer (optional, defaults to 500, max 500)")
     public PayoutSearchParams setDisplaySize(Long displaySize) {
         this.displaySize = Objects.requireNonNullElse(displaySize, DEFAULT_DISPLAY_SIZE);
         return this;

--- a/src/main/java/uk/gov/pay/ledger/util/pagination/PaginationLink.java
+++ b/src/main/java/uk/gov/pay/ledger/util/pagination/PaginationLink.java
@@ -1,12 +1,14 @@
 package uk.gov.pay.ledger.util.pagination;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.util.Objects;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class PaginationLink {
 
+    @Schema(example = "https://an.example.link")
     private String href;
 
     private PaginationLink(String href) {

--- a/src/main/resources/openapi-config.yaml
+++ b/src/main/resources/openapi-config.yaml
@@ -1,0 +1,14 @@
+resourceClasses:
+  - uk.gov.pay.ledger.event.resource.EventResource
+  - uk.gov.pay.ledger.payout.resource.PayoutResource
+readAllResources: true
+sortOutput: true
+prettyPrint: true
+
+openAPI:
+  info:
+    description: 'Ledger API'
+    title: 'Ledger API'
+    version: 'v1.0.0'
+  servers:
+    - url: 'http://ledger_url'


### PR DESCRIPTION
## WHAT
- Added swagger library to generate openAPI specs for ledger endpoints
- Initial config to generate openAPI specs
- Annotated event & payout resources and generated openAPI specs for these endpoints
- Preview (using https://editor.swagger.io/)
<img width="587" alt="image" src="https://user-images.githubusercontent.com/40598480/161283306-e27159d3-4613-4ac6-92f0-abede7dad0f4.png">

