### PR TITLE
PP-9142 Return authorisation_mode in payment responses

### DIFF
--- a/openapi/ledger_spec.yaml
+++ b/openapi/ledger_spec.yaml
@@ -888,6 +888,8 @@ components:
           - ACCOUNT_NOT_LINKED_WITH_PSP
           - TELEPHONE_PAYMENT_NOTIFICATIONS_NOT_ALLOWED
           - AGREEMENT_NOT_FOUND
+          - ONE_TIME_TOKEN_INVALID
+          - ONE_TIME_TOKEN_ALREADY_USED
           example: GENERIC
         message:
           type: array
@@ -1243,6 +1245,13 @@ components:
           type: integer
           format: int64
           example: 1000
+        authorisation_mode:
+          type: string
+          enum:
+          - web
+          - moto_api
+          - external
+          example: web
         authorisation_summary:
           $ref: '#/components/schemas/AuthorisationSummary'
         card_details:

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
         <jackson.version>2.13.2</jackson.version>
         <testcontainers.version>1.17.0</testcontainers.version>
         <postgresql.version>42.3.3</postgresql.version>
-        <pay-java-commons.version>1.0.20220411103640</pay-java-commons.version>
+        <pay-java-commons.version>1.0.20220414105607</pay-java-commons.version>
         <junit5.version>5.8.2</junit5.version>
         <surefire.version>3.0.0-M6</surefire.version>
         <guice.version>5.1.0</guice.version>

--- a/src/main/java/uk/gov/pay/ledger/transaction/model/Payment.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/model/Payment.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
 import uk.gov.service.payments.commons.api.json.ApiResponseDateTimeSerializer;
+import uk.gov.service.payments.commons.model.AuthorisationMode;
 import uk.gov.service.payments.commons.model.Source;
 import uk.gov.pay.ledger.transaction.search.model.PaymentSettlementSummary;
 import uk.gov.pay.ledger.transaction.search.model.RefundSummary;
@@ -46,6 +47,7 @@ public class Payment extends Transaction {
     private Boolean live;
     private Source source;
     private String walletType;
+    private AuthorisationMode authorisationMode;
 
     public Payment() {
 
@@ -79,6 +81,7 @@ public class Payment extends Transaction {
         this.source = builder.source;
         this.walletType = builder.walletType;
         this.eventCount = builder.eventCount;
+        this.authorisationMode = builder.authorisationMode;
     }
 
     @Override
@@ -192,6 +195,10 @@ public class Payment extends Transaction {
         return walletType;
     }
 
+    public AuthorisationMode getAuthorisationMode() {
+        return authorisationMode;
+    }
+
     public static class Builder {
         public String serviceId;
         private Long id;
@@ -224,6 +231,7 @@ public class Payment extends Transaction {
         private String externalId;
         private String gatewayPayoutId;
         private String credentialExternalId;
+        private AuthorisationMode authorisationMode;
 
         public Builder() {
         }
@@ -384,6 +392,11 @@ public class Payment extends Transaction {
 
         public Builder withServiceId(String serviceId) {
             this.serviceId = serviceId;
+            return this;
+        }
+
+        public Builder withAuthorisationMode(AuthorisationMode authorisationMode) {
+            this.authorisationMode = authorisationMode;
             return this;
         }
     }

--- a/src/main/java/uk/gov/pay/ledger/transaction/model/TransactionFactory.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/model/TransactionFactory.java
@@ -10,6 +10,7 @@ import uk.gov.pay.ledger.transaction.entity.TransactionEntity;
 import uk.gov.pay.ledger.transaction.search.model.PaymentSettlementSummary;
 import uk.gov.pay.ledger.transaction.search.model.RefundSummary;
 import uk.gov.pay.ledger.transaction.search.model.SettlementSummary;
+import uk.gov.service.payments.commons.model.AuthorisationMode;
 
 import java.io.IOException;
 import java.util.Map;
@@ -82,6 +83,10 @@ public class TransactionFactory {
 
             String credentialExternalId = safeGetAsString(transactionDetails, "credential_external_id");
 
+            AuthorisationMode authorisationMode = transactionDetails.has("authorisation_mode") ?
+                    AuthorisationMode.of(safeGetAsString(transactionDetails, "authorisation_mode")) :
+                    AuthorisationMode.WEB;
+
             return new Payment.Builder()
                     .withGatewayAccountId(entity.getGatewayAccountId())
                     .withServiceId(entity.getServiceId())
@@ -113,6 +118,7 @@ public class TransactionFactory {
                     .withSource(entity.getSource())
                     .withWalletType(safeGetAsString(transactionDetails, "wallet"))
                     .withGatewayPayoutId(entity.getGatewayPayoutId())
+                    .withAuthorisationMode(authorisationMode)
                     .build();
         } catch (IOException e) {
             LOGGER.error("Error during the parsing transaction entity data [{}] [errorMessage={}]", entity.getExternalId(), e.getMessage());

--- a/src/main/java/uk/gov/pay/ledger/transaction/search/model/TransactionView.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/search/model/TransactionView.java
@@ -15,6 +15,7 @@ import uk.gov.pay.ledger.transaction.model.Transaction;
 import uk.gov.pay.ledger.transaction.model.TransactionType;
 import uk.gov.pay.ledger.transaction.state.ExternalTransactionState;
 import uk.gov.service.payments.commons.api.json.ApiResponseDateTimeSerializer;
+import uk.gov.service.payments.commons.model.AuthorisationMode;
 import uk.gov.service.payments.commons.model.Source;
 
 import java.time.ZonedDateTime;
@@ -85,6 +86,8 @@ public class TransactionView {
     private String walletType;
     @Schema(example = "po_mdoiu23jkdj1kj23sd")
     private String gatewayPayoutId;
+    @Schema(example = "web")
+    private AuthorisationMode authorisationMode;
     private TransactionView paymentDetails;
 
     public TransactionView(Builder builder) {
@@ -122,6 +125,7 @@ public class TransactionView {
         this.source = builder.source;
         this.walletType = builder.walletType;
         this.gatewayPayoutId = builder.gatewayPayoutId;
+        this.authorisationMode = builder.authorisationMode;
         this.paymentDetails = builder.paymentDetails;
     }
 
@@ -163,7 +167,8 @@ public class TransactionView {
                     .withLive(payment.isLive())
                     .withSource(payment.getSource())
                     .withWalletType(payment.getWalletType())
-                    .withGatewayPayoutId(payment.getGatewayPayoutId());
+                    .withGatewayPayoutId(payment.getGatewayPayoutId())
+                    .withAuthorisationMode(payment.getAuthorisationMode());
             if (payment.getState() != null) {
                 paymentBuilder = paymentBuilder
                         .withState(ExternalTransactionState.from(payment.getState(), statusVersion));
@@ -279,6 +284,10 @@ public class TransactionView {
         return refundedByUserEmail;
     }
 
+    public AuthorisationMode getAuthorisationMode() {
+        return authorisationMode;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
@@ -389,6 +398,7 @@ public class TransactionView {
         private TransactionView paymentDetails;
         private String credentialExternalId;
         private String serviceId;
+        private AuthorisationMode authorisationMode;
 
         public Builder() {
         }
@@ -569,6 +579,11 @@ public class TransactionView {
 
         public Builder withServiceId(String serviceId) {
             this.serviceId = serviceId;
+            return this;
+        }
+
+        public Builder withAuthorisationMode(AuthorisationMode authorisationMode) {
+            this.authorisationMode = authorisationMode;
             return this;
         }
     }

--- a/src/test/java/uk/gov/pay/ledger/transaction/model/TransactionFactoryTest.java
+++ b/src/test/java/uk/gov/pay/ledger/transaction/model/TransactionFactoryTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.Test;
 import org.testcontainers.shaded.com.google.common.collect.ImmutableMap;
 import uk.gov.pay.ledger.transaction.entity.TransactionEntity;
 import uk.gov.pay.ledger.transaction.state.TransactionState;
+import uk.gov.service.payments.commons.model.AuthorisationMode;
 
 import java.time.ZonedDateTime;
 import java.util.Optional;
@@ -78,6 +79,7 @@ public class TransactionFactoryTest {
         fullTransactionDetails.add("external_metadata", metadata);
         fullTransactionDetails.addProperty("expiry_date", cardExpiryDate);
         fullTransactionDetails.addProperty("wallet", walletType);
+        fullTransactionDetails.addProperty("authorisation_mode", "moto_api");
 
         var payoutObject = aPayoutEntity()
                 .withPaidOutDate(paidOutDate)
@@ -183,6 +185,7 @@ public class TransactionFactoryTest {
         assertThat(payment.getSettlementSummary().getCapturedDate(), is(Optional.empty()));
         assertThat(payment.getSettlementSummary().getSettlementSubmittedTime(), is(Optional.empty()));
         assertThat(payment.getSettlementSummary().getSettledDate(), is(Optional.empty()));
+        assertThat(payment.getAuthorisationMode(), is(AuthorisationMode.WEB));
     }
 
     @Test
@@ -326,5 +329,6 @@ public class TransactionFactoryTest {
         assertThat(payment.getSettlementSummary().getSettlementSubmittedTime(), is(Optional.of("2017-09-09T08:35:45.695Z")));
         assertThat(payment.getSettlementSummary().getSettledDate(), is(Optional.of("2017-09-19")));
         assertThat(payment.getWalletType(), is(walletType));
+        assertThat(payment.getAuthorisationMode(), is(AuthorisationMode.MOTO_API));
     }
 }

--- a/src/test/java/uk/gov/pay/ledger/transaction/resource/TransactionResourceIT.java
+++ b/src/test/java/uk/gov/pay/ledger/transaction/resource/TransactionResourceIT.java
@@ -71,7 +71,8 @@ public class TransactionResourceIT {
                 .body("live", is(Boolean.TRUE))
                 .body("wallet_type", is("APPLE_PAY"))
                 .body("source", is(String.valueOf(Source.CARD_API)))
-                .body("gateway_payout_id", is(gatewayPayoutId));
+                .body("gateway_payout_id", is(gatewayPayoutId))
+                .body("authorisation_mode", is("web"));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/ledger/util/fixture/QueuePaymentEventFixture.java
+++ b/src/test/java/uk/gov/pay/ledger/util/fixture/QueuePaymentEventFixture.java
@@ -139,6 +139,7 @@ public class QueuePaymentEventFixture implements QueueFixture<QueuePaymentEventF
                                 .put("address_city", "London")
                                 .put("source", CARD_API)
                                 .put("address_country", "GB")
+                                .put("authorisation_mode", "web")
                                 .build());
                 break;
             case "PAYMENT_DETAILS_ENTERED":


### PR DESCRIPTION
Return authorisation_mode field in all payment responses. Read this from the transaction details for the payment if it exists, else default to "web" for historic transactions.

Modify the queue message contract test for the PAYMENT_CREATED event to expect this field in the event from connector.