### PR TITLE
PP-9531 Agreements and payment instrument DAO

### DIFF
--- a/src/main/java/uk/gov/pay/ledger/agreement/dao/AgreementDao.java
+++ b/src/main/java/uk/gov/pay/ledger/agreement/dao/AgreementDao.java
@@ -1,0 +1,89 @@
+package uk.gov.pay.ledger.agreement.dao;
+
+import com.google.inject.Inject;
+import org.jdbi.v3.core.Jdbi;
+import uk.gov.pay.ledger.agreement.entity.AgreementEntity;
+import java.util.Optional;
+
+public class AgreementDao {
+    private static final String SELECT_AGREEMENT_WITH_PAYMENT_INSTRUMENT =
+            "SELECT a.*," +
+            "pi.external_id as p_external_id," +
+            "pi.agreement_external_id as p_agreement_external_id," +
+            "pi.email as p_email," +
+            "pi.cardholder_name as p_cardholder_name," +
+            "pi.address_line1 as p_address_line1," +
+            "pi.address_line2 as p_address_line2," +
+            "pi.address_postcode as p_address_postcode," +
+            "pi.address_city as p_address_city," +
+            "pi.address_county as p_address_county," +
+            "pi.address_country as p_address_country," +
+            "pi.last_digits_card_number as p_last_digits_card_number," +
+            "pi.expiry_date as p_expiry_date," +
+            "pi.card_brand as p_card_brand," +
+            "pi.event_count as p_event_count," +
+            "pi.created_date as p_created_date " +
+            "FROM agreement a LEFT JOIN (" +
+            "SELECT DISTINCT ON (agreement_external_id) * FROM payment_instrument ORDER BY agreement_external_id, created_date DESC" +
+            ") pi ON pi.agreement_external_id = a.external_id ";
+
+    private static final String FIND_BY_EXTERNAL_ID =
+            SELECT_AGREEMENT_WITH_PAYMENT_INSTRUMENT +
+            "WHERE a.external_id = :externalId";
+
+    private final String UPSERT_AGREEMENT = "INSERT INTO agreement " +
+            "(" +
+            "external_id," +
+            "gateway_account_id, " +
+            "service_id," +
+            "live," +
+            "reference," +
+            "description," +
+            "status," +
+            "created_date," +
+            "event_count" +
+            ") " +
+            "VALUES (" +
+            ":externalId, " +
+            ":gatewayAccountId, " +
+            ":serviceId, " +
+            ":live, " +
+            ":reference, " +
+            ":description, " +
+            ":status, " +
+            ":createdDate, " +
+            ":eventCount" +
+            ") " +
+            "ON CONFLICT (external_id) DO UPDATE SET " +
+            "external_id = EXCLUDED.external_id, " +
+            "gateway_account_id = EXCLUDED.gateway_account_id, " +
+            "service_id = EXCLUDED.service_id, " +
+            "live = EXCLUDED.live, " +
+            "reference = EXCLUDED.reference, " +
+            "description = EXCLUDED.description, " +
+            "status = EXCLUDED.status, " +
+            "created_date = EXCLUDED.created_date, " +
+            "event_count = EXCLUDED.event_count " +
+            "WHERE EXCLUDED.event_count >= agreement.event_count";
+
+    private Jdbi jdbi;
+
+    @Inject
+    public AgreementDao(Jdbi jdbi) {
+        this.jdbi = jdbi;
+    }
+
+    public Optional<AgreementEntity> findByExternalId(String externalId) {
+        return jdbi.withHandle(handle -> handle.createQuery(FIND_BY_EXTERNAL_ID)
+                .bind("externalId", externalId)
+                .map(new AgreementMapper())
+                .findOne());
+    }
+
+    public void upsert(AgreementEntity agreement) {
+        jdbi.withHandle(handle ->
+                handle.createUpdate(UPSERT_AGREEMENT)
+                        .bindBean(agreement)
+                        .execute());
+    }
+}

--- a/src/main/java/uk/gov/pay/ledger/agreement/dao/AgreementMapper.java
+++ b/src/main/java/uk/gov/pay/ledger/agreement/dao/AgreementMapper.java
@@ -1,0 +1,55 @@
+package uk.gov.pay.ledger.agreement.dao;
+
+import org.jdbi.v3.core.mapper.RowMapper;
+import org.jdbi.v3.core.statement.StatementContext;
+import uk.gov.pay.ledger.agreement.entity.AgreementEntity;
+import uk.gov.pay.ledger.agreement.entity.PaymentInstrumentEntity;
+import uk.gov.pay.ledger.event.model.Event;
+import uk.gov.pay.ledger.event.model.ResourceType;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+
+import static uk.gov.pay.ledger.util.dao.MapperUtils.getBooleanWithNullCheck;
+
+public class AgreementMapper implements RowMapper<AgreementEntity> {
+    @Override
+    public AgreementEntity map(ResultSet resultSet, StatementContext statementContext) throws SQLException {
+        PaymentInstrumentEntity paymentInstrument = null;
+        var paymentInstrumentExternalId = resultSet.getString("p_external_id");
+
+        if (paymentInstrumentExternalId != null) {
+            paymentInstrument = new PaymentInstrumentEntity(
+                    resultSet.getString("p_external_id"),
+                    resultSet.getString("p_agreement_external_id"),
+                    resultSet.getString("p_email"),
+                    resultSet.getString("p_cardholder_name"),
+                    resultSet.getString("p_address_line1"),
+                    resultSet.getString("p_address_line2"),
+                    resultSet.getString("p_address_postcode"),
+                    resultSet.getString("p_address_city"),
+                    resultSet.getString("p_address_county"),
+                    resultSet.getString("p_address_country"),
+                    resultSet.getString("p_last_digits_card_number"),
+                    resultSet.getString("p_expiry_date"),
+                    resultSet.getString("p_card_brand"),
+                    ZonedDateTime.ofInstant(resultSet.getTimestamp("p_created_date").toInstant(), ZoneOffset.UTC),
+                    resultSet.getInt("p_event_count")
+            );
+        }
+        return new AgreementEntity(
+                resultSet.getString("external_id"),
+                resultSet.getString("gateway_account_id"),
+                resultSet.getString("service_id"),
+                resultSet.getString("reference"),
+                resultSet.getString("description"),
+                resultSet.getString("status"),
+                getBooleanWithNullCheck(resultSet,"live"),
+                ZonedDateTime.ofInstant(resultSet.getTimestamp("created_date").toInstant(), ZoneOffset.UTC),
+                resultSet.getInt("event_count"),
+                paymentInstrument
+        );
+    }
+}

--- a/src/main/java/uk/gov/pay/ledger/agreement/dao/PaymentInstrumentDao.java
+++ b/src/main/java/uk/gov/pay/ledger/agreement/dao/PaymentInstrumentDao.java
@@ -1,0 +1,74 @@
+package uk.gov.pay.ledger.agreement.dao;
+
+import com.google.inject.Inject;
+import org.jdbi.v3.core.Jdbi;
+import uk.gov.pay.ledger.agreement.entity.PaymentInstrumentEntity;
+
+public class PaymentInstrumentDao {
+    private Jdbi jdbi;
+
+    private final String UPSERT_PAYMENT_INSTRUMENT = "INSERT INTO payment_instrument " +
+            "(" +
+            "external_id," +
+            "agreement_external_id, " +
+            "email," +
+            "cardholder_name," +
+            "address_line1," +
+            "address_line2," +
+            "address_postcode," +
+            "address_city," +
+            "address_county," +
+            "address_country," +
+            "last_digits_card_number," +
+            "expiry_date," +
+            "card_brand," +
+            "event_count," +
+            "created_date" +
+            ") " +
+            "VALUES (" +
+            ":externalId, " +
+            ":agreementExternalId, " +
+            ":email, " +
+            ":cardholderName, " +
+            ":addressLine1, " +
+            ":addressLine2, " +
+            ":addressPostcode, " +
+            ":addressCity, " +
+            ":addressCounty, " +
+            ":addressCountry, " +
+            ":lastDigitsCardNumber, " +
+            ":expiryDate, " +
+            ":cardBrand, " +
+            ":eventCount, " +
+            ":createdDate" +
+            ") " +
+            "ON CONFLICT (external_id) DO UPDATE SET " +
+            "external_id = EXCLUDED.external_id," +
+            "agreement_external_id = EXCLUDED.agreement_external_id," +
+            "email = EXCLUDED.email," +
+            "cardholder_name = EXCLUDED.cardholder_name," +
+            "address_line1 = EXCLUDED.address_line1," +
+            "address_line2 = EXCLUDED.address_line2," +
+            "address_postcode = EXCLUDED.address_postcode," +
+            "address_city = EXCLUDED.address_city," +
+            "address_county = EXCLUDED.address_county," +
+            "address_country = EXCLUDED.address_country," +
+            "last_digits_card_number = EXCLUDED.last_digits_card_number," +
+            "expiry_date = EXCLUDED.expiry_date," +
+            "card_brand = EXCLUDED.card_brand," +
+            "event_count = EXCLUDED.event_count," +
+            "created_date = EXCLUDED.created_date " +
+            "WHERE EXCLUDED.event_count >= payment_instrument.event_count";
+
+    @Inject
+    public PaymentInstrumentDao(Jdbi jdbi) {
+        this.jdbi = jdbi;
+    }
+
+    public void upsert(PaymentInstrumentEntity paymentInstrument) {
+        jdbi.withHandle(handle ->
+                handle.createUpdate(UPSERT_PAYMENT_INSTRUMENT)
+                        .bindBean(paymentInstrument)
+                        .execute());
+    }
+}

--- a/src/main/java/uk/gov/pay/ledger/agreement/entity/AgreementEntity.java
+++ b/src/main/java/uk/gov/pay/ledger/agreement/entity/AgreementEntity.java
@@ -1,0 +1,119 @@
+package uk.gov.pay.ledger.agreement.entity;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+import java.time.ZonedDateTime;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class AgreementEntity {
+    private String externalId;
+    private String gatewayAccountId;
+    private String serviceId;
+    private String reference;
+    private String description;
+    private String status;
+    private Boolean live;
+    private ZonedDateTime createdDate;
+    private Integer eventCount;
+    private PaymentInstrumentEntity paymentInstrument;
+
+    public AgreementEntity() {
+
+    }
+
+    public AgreementEntity(String externalId, String gatewayAccountId, String serviceId, String reference, String description, String status, Boolean live, ZonedDateTime createdDate, Integer eventCount, PaymentInstrumentEntity paymentInstrument) {
+        this.externalId = externalId;
+        this.gatewayAccountId = gatewayAccountId;
+        this.serviceId = serviceId;
+        this.reference = reference;
+        this.description = description;
+        this.status = status;
+        this.live = live;
+        this.createdDate = createdDate;
+        this.eventCount = eventCount;
+        this.paymentInstrument = paymentInstrument;
+    }
+
+    public String getExternalId() {
+        return externalId;
+    }
+
+    public String getGatewayAccountId() {
+        return gatewayAccountId;
+    }
+
+    public String getServiceId() {
+        return serviceId;
+    }
+
+    public String getReference() {
+        return reference;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public Boolean getLive() {
+        return live;
+    }
+
+    public ZonedDateTime getCreatedDate() {
+        return createdDate;
+    }
+
+    public Integer getEventCount() {
+        return eventCount;
+    }
+
+    public PaymentInstrumentEntity getPaymentInstrument() {
+        return paymentInstrument;
+    }
+
+    public void setServiceId(String serviceId) {
+        this.serviceId = serviceId;
+    }
+
+    public void setLive(Boolean live) {
+        this.live = live;
+    }
+
+    public void setCreatedDate(ZonedDateTime createdDate) {
+        this.createdDate = createdDate;
+    }
+
+    public void setEventCount(Integer eventCount) {
+        this.eventCount = eventCount;
+    }
+
+    public void setExternalId(String externalId) {
+        this.externalId = externalId;
+    }
+
+    public void setGatewayAccountId(String gatewayAccountId) {
+        this.gatewayAccountId = gatewayAccountId;
+    }
+
+    public void setReference(String reference) {
+        this.reference = reference;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public void setStatus(String status) {
+        this.status = status;
+    }
+
+    public void setPaymentInstrument(PaymentInstrumentEntity paymentInstrument) {
+        this.paymentInstrument = paymentInstrument;
+    }
+}

--- a/src/main/java/uk/gov/pay/ledger/agreement/entity/PaymentInstrumentEntity.java
+++ b/src/main/java/uk/gov/pay/ledger/agreement/entity/PaymentInstrumentEntity.java
@@ -1,0 +1,171 @@
+package uk.gov.pay.ledger.agreement.entity;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+import java.time.ZonedDateTime;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class PaymentInstrumentEntity {
+    private String externalId;
+    private String agreementExternalId;
+    private String email;
+    private String cardholderName;
+    private String addressLine1;
+    private String addressLine2;
+    private String addressPostcode;
+    private String addressCity;
+
+    private String addressCounty;
+    private String addressCountry;
+
+    private String lastDigitsCardNumber;
+    private String expiryDate;
+    private String cardBrand;
+
+    private ZonedDateTime createdDate;
+    private Integer eventCount;
+
+    public PaymentInstrumentEntity() {
+
+    }
+
+    public PaymentInstrumentEntity(String externalId, String agreementExternalId, String email, String cardholderName, String addressLine1, String addressLine2, String addressPostcode, String addressCity, String addressCounty, String addressCountry, String lastDigitsCardNumber, String expiryDate, String cardBrand, ZonedDateTime createdDate, Integer eventCount) {
+        this.externalId = externalId;
+        this.agreementExternalId = agreementExternalId;
+        this.email = email;
+        this.cardholderName = cardholderName;
+        this.addressLine1 = addressLine1;
+        this.addressLine2 = addressLine2;
+        this.addressPostcode = addressPostcode;
+        this.addressCity = addressCity;
+        this.addressCounty = addressCounty;
+        this.addressCountry = addressCountry;
+        this.lastDigitsCardNumber = lastDigitsCardNumber;
+        this.expiryDate = expiryDate;
+        this.cardBrand = cardBrand;
+        this.createdDate = createdDate;
+        this.eventCount = eventCount;
+    }
+
+    public void setCreatedDate(ZonedDateTime createdDate) {
+        this.createdDate = createdDate;
+    }
+
+    public void setEventCount(Integer eventCount) {
+        this.eventCount = eventCount;
+    }
+
+    public void setExternalId(String externalId) {
+        this.externalId = externalId;
+    }
+
+    public void setAgreementExternalId(String agreementExternalId) {
+        this.agreementExternalId = agreementExternalId;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    public void setCardholderName(String cardholderName) {
+        this.cardholderName = cardholderName;
+    }
+
+    public void setAddressLine1(String addressLine1) {
+        this.addressLine1 = addressLine1;
+    }
+
+    public void setAddressLine2(String addressLine2) {
+        this.addressLine2 = addressLine2;
+    }
+
+    public void setAddressPostcode(String addressPostcode) {
+        this.addressPostcode = addressPostcode;
+    }
+
+    public void setAddressCity(String addressCity) {
+        this.addressCity = addressCity;
+    }
+
+    public void setAddressCounty(String addressCounty) {
+        this.addressCounty = addressCounty;
+    }
+
+    public void setAddressCountry(String addressCountry) {
+        this.addressCountry = addressCountry;
+    }
+
+    public void setLastDigitsCardNumber(String lastDigitsCardNumber) {
+        this.lastDigitsCardNumber = lastDigitsCardNumber;
+    }
+
+    public void setExpiryDate(String expiryDate) {
+        this.expiryDate = expiryDate;
+    }
+
+    public void setCardBrand(String cardBrand) {
+        this.cardBrand = cardBrand;
+    }
+
+    public String getExternalId() {
+        return externalId;
+    }
+
+    public String getAgreementExternalId() {
+        return agreementExternalId;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public String getCardholderName() {
+        return cardholderName;
+    }
+
+    public String getAddressLine1() {
+        return addressLine1;
+    }
+
+    public String getAddressLine2() {
+        return addressLine2;
+    }
+
+    public String getAddressPostcode() {
+        return addressPostcode;
+    }
+
+    public String getAddressCity() {
+        return addressCity;
+    }
+
+    public String getAddressCountry() {
+        return addressCountry;
+    }
+
+    public String getLastDigitsCardNumber() {
+        return lastDigitsCardNumber;
+    }
+
+    public String getExpiryDate() {
+        return expiryDate;
+    }
+
+    public String getCardBrand() {
+        return cardBrand;
+    }
+
+    public ZonedDateTime getCreatedDate() {
+        return createdDate;
+    }
+
+    public Integer getEventCount() {
+        return eventCount;
+    }
+    public String getAddressCounty() {
+        return addressCounty;
+    }
+}

--- a/src/test/java/uk/gov/pay/ledger/agreement/AgreementDaoIT.java
+++ b/src/test/java/uk/gov/pay/ledger/agreement/AgreementDaoIT.java
@@ -1,0 +1,87 @@
+package uk.gov.pay.ledger.agreement;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import uk.gov.pay.ledger.agreement.dao.AgreementDao;
+import uk.gov.pay.ledger.agreement.dao.PaymentInstrumentDao;
+import uk.gov.pay.ledger.agreement.entity.AgreementEntity;
+import uk.gov.pay.ledger.extension.AppWithPostgresAndSqsExtension;
+import uk.gov.pay.ledger.util.fixture.AgreementFixture;
+import uk.gov.pay.ledger.util.fixture.PaymentInstrumentFixture;
+
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+class AgreementDaoIT {
+
+    @RegisterExtension
+    public static AppWithPostgresAndSqsExtension rule = new AppWithPostgresAndSqsExtension();
+
+    private final AgreementDao agreementDao = new AgreementDao(rule.getJdbi());
+    private final PaymentInstrumentDao paymentInstrumentDao = new PaymentInstrumentDao(rule.getJdbi());
+
+    @Test
+    void shouldInsertAgreement() {
+        AgreementFixture fixture = AgreementFixture.anAgreementFixture();
+        agreementDao.upsert(fixture.toEntity());
+
+        AgreementEntity fetchedEntity = agreementDao.findByExternalId(fixture.getExternalId()).get();
+
+        assertThat(fetchedEntity, is(notNullValue()));
+        assertThat(fetchedEntity.getExternalId(), is(fixture.getExternalId()));
+    }
+
+    @Test
+    void shouldFindAgreementByExternalId() {
+        AgreementFixture fixture = AgreementFixture.anAgreementFixture();
+        agreementDao.upsert(fixture.toEntity());
+
+        AgreementEntity fetchedEntity = agreementDao.findByExternalId(fixture.getExternalId()).get();
+
+        // assert fields are appropriately set, re-constructed and correctly typed by the agreement mapper
+        assertThat(fetchedEntity.getExternalId(), is(fixture.getExternalId()));
+        assertThat(fetchedEntity.getDescription(), is(fixture.getDescription()));
+        assertThat(fetchedEntity.getCreatedDate(), is(fixture.getCreatedDate()));
+    }
+
+    @Test
+    void shouldCorrectlyMapAndFindAgreementWithPaymentInstrumentByExternalId() {
+        var paymentInstrumentExternalId = "pi-external-id";
+        AgreementFixture agreementFixture = AgreementFixture.anAgreementFixture();
+        var paymentInstrumentFixture = PaymentInstrumentFixture.aPaymentInstrumentFixture(
+                paymentInstrumentExternalId,
+                agreementFixture.getExternalId(),
+                ZonedDateTime.now(ZoneOffset.UTC)
+        );
+        agreementDao.upsert(agreementFixture.toEntity());
+        paymentInstrumentDao.upsert(paymentInstrumentFixture.toEntity());
+
+        AgreementEntity fetchedEntity = agreementDao.findByExternalId(agreementFixture.getExternalId()).get();
+
+        assertThat(fetchedEntity.getExternalId(), is(agreementFixture.getExternalId()));
+
+        // assert payment instrument fields are appropriately joined and typed by the agreement mapper
+        assertThat(fetchedEntity.getPaymentInstrument().getExternalId(), is(paymentInstrumentExternalId));
+        assertThat(fetchedEntity.getPaymentInstrument().getCreatedDate(), is(paymentInstrumentFixture.getCreatedDate()));
+        assertThat(fetchedEntity.getPaymentInstrument().getAgreementExternalId(), is(agreementFixture.getExternalId()));
+    }
+
+    @Test
+    void shouldFindAndGuaranteeMostRecentlyCreatedPaymentInstrumentByExternalId() {
+        AgreementFixture agreementFixture = AgreementFixture.anAgreementFixture();
+        var paymentInstrumentFixtureOne = PaymentInstrumentFixture.aPaymentInstrumentFixture("aaa", agreementFixture.getExternalId(), ZonedDateTime.now(ZoneOffset.UTC).minusDays(10));
+        var paymentInstrumentFixtureTwo = PaymentInstrumentFixture.aPaymentInstrumentFixture("aab", agreementFixture.getExternalId(), ZonedDateTime.now(ZoneOffset.UTC));
+        var paymentInstrumentFixtureThree= PaymentInstrumentFixture.aPaymentInstrumentFixture("aac", agreementFixture.getExternalId(), ZonedDateTime.now(ZoneOffset.UTC).minusDays(5));
+        agreementDao.upsert(agreementFixture.toEntity());
+        paymentInstrumentDao.upsert(paymentInstrumentFixtureOne.toEntity());
+        paymentInstrumentDao.upsert(paymentInstrumentFixtureTwo.toEntity());
+        paymentInstrumentDao.upsert(paymentInstrumentFixtureThree.toEntity());
+
+        AgreementEntity fetchedEntity = agreementDao.findByExternalId(agreementFixture.getExternalId()).get();
+        assertThat(fetchedEntity.getPaymentInstrument().getExternalId(), is(paymentInstrumentFixtureTwo.getExternalId()));
+    }
+}

--- a/src/test/java/uk/gov/pay/ledger/agreement/PaymentInstrumentDaoIT.java
+++ b/src/test/java/uk/gov/pay/ledger/agreement/PaymentInstrumentDaoIT.java
@@ -1,0 +1,42 @@
+package uk.gov.pay.ledger.agreement;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import uk.gov.pay.ledger.agreement.dao.AgreementDao;
+import uk.gov.pay.ledger.agreement.dao.PaymentInstrumentDao;
+import uk.gov.pay.ledger.agreement.entity.PaymentInstrumentEntity;
+import uk.gov.pay.ledger.extension.AppWithPostgresAndSqsExtension;
+import uk.gov.pay.ledger.util.fixture.AgreementFixture;
+import uk.gov.pay.ledger.util.fixture.PaymentInstrumentFixture;
+
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+class PaymentInstrumentDaoIT {
+
+    @RegisterExtension
+    public static AppWithPostgresAndSqsExtension rule = new AppWithPostgresAndSqsExtension();
+
+    private final AgreementDao agreementDao = new AgreementDao(rule.getJdbi());
+    private final PaymentInstrumentDao paymentInstrumentDao = new PaymentInstrumentDao(rule.getJdbi());
+
+    @Test
+    void shouldInsertPaymentInstrument() {
+        var paymentInstrumentExternalId = "pi-external-id";
+        AgreementFixture agreementFixture = AgreementFixture.anAgreementFixture();
+        var paymentInstrumentFixture = PaymentInstrumentFixture.aPaymentInstrumentFixture(
+                paymentInstrumentExternalId,
+                agreementFixture.getExternalId(),
+                ZonedDateTime.now(ZoneOffset.UTC)
+        );
+        agreementDao.upsert(agreementFixture.toEntity());
+        paymentInstrumentDao.upsert(paymentInstrumentFixture.toEntity());
+
+        PaymentInstrumentEntity fetchedEntity = agreementDao.findByExternalId(agreementFixture.getExternalId()).get().getPaymentInstrument();
+
+        assertThat(fetchedEntity.getExternalId(), is(paymentInstrumentExternalId));
+    }
+}

--- a/src/test/java/uk/gov/pay/ledger/util/fixture/AgreementFixture.java
+++ b/src/test/java/uk/gov/pay/ledger/util/fixture/AgreementFixture.java
@@ -1,0 +1,102 @@
+package uk.gov.pay.ledger.util.fixture;
+
+import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.commons.lang3.RandomUtils;
+import org.jdbi.v3.core.Jdbi;
+import uk.gov.pay.ledger.agreement.entity.AgreementEntity;
+
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+
+public class AgreementFixture implements DbFixture<AgreementFixture, AgreementEntity> {
+
+    private Long id = RandomUtils.nextLong(1, 99999);
+    private String serviceId = RandomStringUtils.randomAlphanumeric(26);
+    private String gatewayAccountId = RandomStringUtils.randomAlphanumeric(10);
+    private String externalId = RandomStringUtils.randomAlphanumeric(20);
+    private String reference = RandomStringUtils.randomAlphanumeric(10);
+    private String description = RandomStringUtils.randomAlphanumeric(20);
+    private String status = "ACTIVE";
+    private boolean live = false;
+    private ZonedDateTime createdDate = ZonedDateTime.now(ZoneOffset.UTC);
+    private Integer eventCount = 1;
+
+    private AgreementFixture() {
+    }
+
+    public static AgreementFixture anAgreementFixture(String externalId, String serviceId) {
+        var fixture = new AgreementFixture();
+        fixture.setExternalId(externalId);
+        fixture.setServiceId(serviceId);
+        return fixture;
+    }
+
+    public static AgreementFixture anAgreementFixture() {
+        return new AgreementFixture();
+    }
+
+    @Override
+    public AgreementFixture insert(Jdbi jdbi) {
+        var sql = "INSERT INTO agreement" +
+                "(id, external_id, gateway_account_id, service_id, reference, description, status, live, created_date, event_count) " +
+                "VALUES " +
+                "(?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
+
+        jdbi.withHandle(h ->
+                h.execute(
+                        sql,
+                        id,
+                        externalId,
+                        gatewayAccountId,
+                        serviceId,
+                        reference,
+                        description,
+                        status,
+                        live,
+                        createdDate,
+                        eventCount
+                )
+        );
+        return this;
+    }
+
+    @Override
+    public AgreementEntity toEntity() {
+        return new AgreementEntity(
+                externalId,
+                gatewayAccountId,
+                serviceId,
+                reference,
+                description,
+                status,
+                live,
+                createdDate,
+                eventCount,
+                null
+        );
+    }
+
+    public String getExternalId() {
+        return externalId;
+    }
+
+    public String getServiceId() {
+        return serviceId;
+    }
+
+    public void setServiceId(String serviceId) {
+        this.serviceId = serviceId;
+    }
+
+    public void setExternalId(String externalId) {
+        this.externalId = externalId;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public ZonedDateTime getCreatedDate() {
+        return createdDate;
+    }
+}

--- a/src/test/java/uk/gov/pay/ledger/util/fixture/PaymentInstrumentFixture.java
+++ b/src/test/java/uk/gov/pay/ledger/util/fixture/PaymentInstrumentFixture.java
@@ -1,0 +1,121 @@
+package uk.gov.pay.ledger.util.fixture;
+
+import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.commons.lang3.RandomUtils;
+import org.jdbi.v3.core.Jdbi;
+import uk.gov.pay.ledger.agreement.entity.PaymentInstrumentEntity;
+
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+
+public class PaymentInstrumentFixture implements DbFixture<PaymentInstrumentFixture, PaymentInstrumentEntity> {
+
+    private Long id = RandomUtils.nextLong(1, 99999);
+    private String externalId = RandomStringUtils.randomAlphanumeric(26);
+    private String agreementExternalId = RandomStringUtils.randomAlphanumeric(26);
+    private String email = "jdoe@email.com";
+    private String cardholderName = "J Doe";
+    private String addressLine1 = "Address line 1";
+    private String addressLine2 = "Address line 2";
+    private String addressPostcode = "EC3R8BT";
+    private String addressCity = "London";
+    private String addressCounty;
+    private String addressCountry = "UK";
+    private String lastDigitsCardNumber = "4242";
+    private String expiryDate = "10/21";
+    private String cardBrand = "visa";
+
+    private Integer eventCount = 1;
+    private ZonedDateTime createdDate = ZonedDateTime.now(ZoneOffset.UTC);
+
+    private PaymentInstrumentFixture() {
+    }
+
+    public static PaymentInstrumentFixture aPaymentInstrumentFixture(String externalId, String agreementExternalId, ZonedDateTime createdDate) {
+        var fixture = new PaymentInstrumentFixture();
+        fixture.setExternalId(externalId);
+        fixture.setAgreementExternalId(agreementExternalId);
+        fixture.setCreatedDate(createdDate);
+        return fixture;
+    }
+
+    public static PaymentInstrumentFixture aPaymentInstrumentFixture() {
+        return new PaymentInstrumentFixture();
+    }
+
+    @Override
+    public PaymentInstrumentFixture insert(Jdbi jdbi) {
+        var sql = "INSERT INTO payment_instrument" +
+                "(id, external_id, agreement_external_id, email, cardholder_name, address_line1, address_line2, address_postcode, address_city, address_county, address_country, last_digits_card_number, expiry_date, card_brand, event_count, created_date) " +
+                "VALUES " +
+                "(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
+
+        jdbi.withHandle(h ->
+                h.execute(
+                        sql,
+                        id,
+                        externalId,
+                        agreementExternalId,
+                        email,
+                        cardholderName,
+                        addressLine1,
+                        addressLine2,
+                        addressPostcode,
+                        addressCity,
+                        addressCounty,
+                        addressCountry,
+                        lastDigitsCardNumber,
+                        expiryDate,
+                        cardBrand,
+                        eventCount,
+                        createdDate
+                )
+        );
+        return this;
+    }
+
+    @Override
+    public PaymentInstrumentEntity toEntity() {
+        return new PaymentInstrumentEntity(
+                externalId,
+                agreementExternalId,
+                email,
+                cardholderName,
+                addressLine1,
+                addressLine2,
+                addressPostcode,
+                addressCity,
+                addressCounty,
+                addressCountry,
+                lastDigitsCardNumber,
+                expiryDate,
+                cardBrand,
+                createdDate,
+                eventCount
+        );
+    }
+
+    public String getExternalId() {
+        return externalId;
+    }
+
+    public void setExternalId(String externalId) {
+        this.externalId = externalId;
+    }
+
+    public void setAgreementExternalId(String agreementExternalId) {
+        this.agreementExternalId = agreementExternalId;
+    }
+
+    public String getAgreementExternalId() {
+        return agreementExternalId;
+    }
+
+    public ZonedDateTime getCreatedDate() {
+        return createdDate;
+    }
+
+    public void setCreatedDate(ZonedDateTime createdDate) {
+        this.createdDate = createdDate;
+    }
+}


### PR DESCRIPTION
Entities to be mapped to agreement and payment instrument table rows.

DAO and JDBI row mappers for agreements and payment instruments.

Fetch agreements with their latest payment instrument using Postgres
`SELECT DISTINCT ON`.

Test coverage to assert that row mappers are correctly mapping and
casting fields.

Test coverage to assert that the latest payment instrument (by created
date) is associated with an agreement when pulled out of the database
and mapped to an agreement entity.