### PR TITLE
PP-9526 Remove sqs message id null constraint

### DIFF
--- a/src/main/resources/migrations/00072_remove_event_sqs_message_id_null_constraint.sql
+++ b/src/main/resources/migrations/00072_remove_event_sqs_message_id_null_constraint.sql
@@ -1,0 +1,4 @@
+--liquibase formatted sql
+
+--changeset uk.gov.pay:remove_event_sqs_message_id_not_null_constraint
+ALTER TABLE event ALTER COLUMN sqs_message_id DROP NOT NULL;


### PR DESCRIPTION
The SQS message ID is never used outside of interacting with an
in-flight recieved SQS message. The identifier is then stored in the
database only for developer auditing.

Allow this column to be null to allow events to be produced by other
non-SQS message sources (HTTP endpoint).