### PR TITLE
PP-9526 Sync event write endpoint

### DIFF
--- a/src/main/java/uk/gov/pay/ledger/app/LedgerModule.java
+++ b/src/main/java/uk/gov/pay/ledger/app/LedgerModule.java
@@ -44,6 +44,7 @@ public class LedgerModule extends AbstractModule {
     protected void configure() {
         bind(LedgerConfig.class).toInstance(configuration);
         bind(Environment.class).toInstance(environment);
+        bind(Jdbi.class).toInstance(jdbi);
     }
 
     @Provides

--- a/src/main/java/uk/gov/pay/ledger/event/resource/EventResource.java
+++ b/src/main/java/uk/gov/pay/ledger/event/resource/EventResource.java
@@ -15,9 +15,14 @@ import uk.gov.pay.ledger.event.dao.EventDao;
 import uk.gov.pay.ledger.event.model.Event;
 import uk.gov.pay.ledger.event.model.EventTicker;
 import uk.gov.pay.ledger.exception.ErrorResponse;
+import uk.gov.pay.ledger.queue.EventMessage;
+import uk.gov.pay.ledger.queue.EventMessageDto;
+import uk.gov.pay.ledger.queue.EventMessageHandler;
+import uk.gov.service.payments.commons.queue.exception.QueueException;
 
 import javax.validation.constraints.NotEmpty;
 import javax.ws.rs.GET;
+import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
@@ -26,6 +31,7 @@ import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Response;
 import java.time.ZonedDateTime;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 
@@ -36,10 +42,12 @@ public class EventResource {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(EventResource.class);
     private final EventDao eventDao;
+    private final EventMessageHandler eventMessageHandler;
 
     @Inject
-    public EventResource(EventDao eventDao) {
+    public EventResource(EventDao eventDao, EventMessageHandler eventMessageHandler) {
         this.eventDao = eventDao;
+        this.eventMessageHandler = eventMessageHandler;
     }
 
     @Path("/{eventId}")
@@ -56,6 +64,22 @@ public class EventResource {
         LOGGER.info("Get event request: {}", eventId);
         return eventDao.getById(eventId)
                 .orElseThrow(() -> new WebApplicationException(Response.Status.NOT_FOUND));
+    }
+
+    @POST
+    @Timed
+    public Response writeEvent(List<EventMessageDto> events) throws QueueException {
+        try {
+            eventMessageHandler.processEventBatch(events
+                    .stream()
+                    .map(eventMessageDto -> EventMessage.of(eventMessageDto, null))
+                    .collect(Collectors.toList())
+            );
+        } catch (Exception ignored) {
+            LOGGER.warn("Failed to process batch of events");
+            throw ignored;
+        }
+        return Response.accepted().build();
     }
 
     @Path("/ticker")

--- a/src/main/java/uk/gov/pay/ledger/queue/EventMessage.java
+++ b/src/main/java/uk/gov/pay/ledger/queue/EventMessage.java
@@ -18,15 +18,13 @@ public class EventMessage {
         return new EventMessage(eventDto, queueMessage);
     }
 
-    public String getQueueMessageId() {
-        return Optional.ofNullable(queueMessage)
-                .map(QueueMessage::getMessageId)
-                .orElse(null);
+    public Optional<String> getQueueMessageId() {
+        return Optional.ofNullable(queueMessage).map(QueueMessage::getMessageId);
     }
 
     public Event getEvent() {
         return new Event(
-                getQueueMessageId(),
+                getQueueMessageId().orElse(null),
                 eventDto.getServiceId(),
                 eventDto.isLive(),
                 eventDto.getResourceType(),
@@ -39,10 +37,8 @@ public class EventMessage {
         );
     }
 
-    public String getQueueMessageReceiptHandle() {
-        return Optional.ofNullable(queueMessage)
-                .map(QueueMessage::getReceiptHandle)
-                .orElse(null);
+    public Optional<String> getQueueMessageReceiptHandle() {
+        return Optional.ofNullable(queueMessage).map(QueueMessage::getReceiptHandle);
     }
 
     public EventMessageDto getEventDto() {

--- a/src/main/java/uk/gov/pay/ledger/queue/EventMessage.java
+++ b/src/main/java/uk/gov/pay/ledger/queue/EventMessage.java
@@ -3,6 +3,8 @@ package uk.gov.pay.ledger.queue;
 import uk.gov.pay.ledger.event.model.Event;
 import uk.gov.service.payments.commons.queue.model.QueueMessage;
 
+import java.util.Optional;
+
 public class EventMessage {
     private EventMessageDto eventDto;
     private QueueMessage queueMessage;
@@ -17,7 +19,9 @@ public class EventMessage {
     }
 
     public String getQueueMessageId() {
-        return queueMessage.getMessageId();
+        return Optional.ofNullable(queueMessage)
+                .map(QueueMessage::getMessageId)
+                .orElse(null);
     }
 
     public Event getEvent() {
@@ -36,7 +40,9 @@ public class EventMessage {
     }
 
     public String getQueueMessageReceiptHandle() {
-        return queueMessage.getReceiptHandle();
+        return Optional.of(queueMessage)
+                .map(QueueMessage::getReceiptHandle)
+                .orElse(null);
     }
 
     public EventMessageDto getEventDto() {

--- a/src/main/java/uk/gov/pay/ledger/queue/EventMessage.java
+++ b/src/main/java/uk/gov/pay/ledger/queue/EventMessage.java
@@ -40,7 +40,7 @@ public class EventMessage {
     }
 
     public String getQueueMessageReceiptHandle() {
-        return Optional.of(queueMessage)
+        return Optional.ofNullable(queueMessage)
                 .map(QueueMessage::getReceiptHandle)
                 .orElse(null);
     }

--- a/src/main/java/uk/gov/pay/ledger/queue/EventMessageHandler.java
+++ b/src/main/java/uk/gov/pay/ledger/queue/EventMessageHandler.java
@@ -130,12 +130,19 @@ public class EventMessageHandler {
 
             LOGGER.info("The event message has been processed.", loggingArgs.toArray());
         } else {
-            eventQueue.scheduleMessageForRetry(message);
-            LOGGER.warn("The event message has been scheduled for retry.",
-                    kv("sqs_message_id", message.getQueueMessageId()),
-                    kv("resource_external_id", message.getEvent().getResourceExternalId()),
-                    kv("state", response.getState()),
-                    kv("error", response.getErrorMessage()));
+            if (message.getQueueMessageId() != null) {
+                eventQueue.scheduleMessageForRetry(message);
+                LOGGER.warn("The event message has been scheduled for retry.",
+                        kv("sqs_message_id", message.getQueueMessageId()),
+                        kv("resource_external_id", message.getEvent().getResourceExternalId()),
+                        kv("state", response.getState()),
+                        kv("error", response.getErrorMessage()));
+            } else {
+                LOGGER.warn("Create event response was unsuccessful.",
+                        kv("resource_external_id", message.getEvent().getResourceExternalId()),
+                        kv("state", response.getState()),
+                        kv("error", response.getErrorMessage()));
+            }
         }
     }
 }

--- a/src/main/java/uk/gov/pay/ledger/queue/EventMessageHandler.java
+++ b/src/main/java/uk/gov/pay/ledger/queue/EventMessageHandler.java
@@ -4,6 +4,7 @@ import com.codahale.metrics.MetricRegistry;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.inject.Inject;
 import io.sentry.Sentry;
+import org.jdbi.v3.core.Jdbi;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.pay.ledger.app.LedgerConfig;
@@ -19,7 +20,6 @@ import java.time.ZonedDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 
 import static net.logstash.logback.argument.StructuredArguments.kv;
 import static uk.gov.pay.ledger.event.model.response.CreateEventResponse.CreateEventState.INSERTED;
@@ -36,6 +36,7 @@ public class EventMessageHandler {
     private final MetricRegistry metricRegistry;
     private final LedgerConfig ledgerConfig;
     private final ObjectMapper objectMapper;
+    private final Jdbi jdbi;
 
     @Inject
     public EventMessageHandler(EventQueue eventQueue,
@@ -44,7 +45,8 @@ public class EventMessageHandler {
                                EventPublisher eventPublisher,
                                MetricRegistry metricRegistry,
                                LedgerConfig ledgerConfig,
-                               ObjectMapper objectMapper) {
+                               ObjectMapper objectMapper,
+                               Jdbi jdbi) {
         this.eventQueue = eventQueue;
         this.eventService = eventService;
         this.eventDigestHandler = eventDigestHandler;
@@ -52,6 +54,7 @@ public class EventMessageHandler {
         this.metricRegistry = metricRegistry;
         this.ledgerConfig = ledgerConfig;
         this.objectMapper = objectMapper;
+        this.jdbi = jdbi;
     }
 
     public void handle() throws QueueException {
@@ -71,10 +74,13 @@ public class EventMessageHandler {
         }
     }
 
+    // provides a transactional guarantee, if any of the events fail to process, none of the events will be persisted
     public void processEventBatch(List<EventMessage> messages) throws QueueException {
-        for (EventMessage message : messages) {
-            processSingleMessage(message);
-        }
+       jdbi.useTransaction(handle -> {
+            for (EventMessage message : messages) {
+                processSingleMessage(message);
+            }
+        });
     }
 
     private void processSingleMessage(EventMessage message) throws QueueException {
@@ -122,7 +128,7 @@ public class EventMessageHandler {
 
         if (response.isSuccessful()) {
             eventDigestHandler.processEvent(event, response.getState() == INSERTED);
-            if (message.getQueueMessageReceiptHandle() != null) {
+            if (message.getQueueMessageReceiptHandle().isPresent()) {
                 eventQueue.markMessageAsProcessed(message);
             }
             metricRegistry.histogram("event-message-handler.ingest-lag-microseconds").update(ingestLag);
@@ -139,7 +145,7 @@ public class EventMessageHandler {
 
             LOGGER.info("The event message has been processed.", loggingArgs.toArray());
         } else {
-            if (message.getQueueMessageId() != null) {
+            if (message.getQueueMessageId().isPresent()) {
                 eventQueue.scheduleMessageForRetry(message);
                 LOGGER.warn("The event message has been scheduled for retry.",
                         kv("sqs_message_id", message.getQueueMessageId()),

--- a/src/main/java/uk/gov/pay/ledger/queue/EventQueue.java
+++ b/src/main/java/uk/gov/pay/ledger/queue/EventQueue.java
@@ -44,11 +44,11 @@ public class EventQueue {
     }
 
     public void markMessageAsProcessed(EventMessage message) throws QueueException {
-        sqsQueueService.deleteMessage(this.eventQueueUrl, message.getQueueMessageReceiptHandle());
+        sqsQueueService.deleteMessage(this.eventQueueUrl, message.getQueueMessageReceiptHandle().orElse(null));
     }
 
     public void scheduleMessageForRetry(EventMessage message) throws QueueException {
-        sqsQueueService.deferMessage(this.eventQueueUrl, message.getQueueMessageReceiptHandle(), retryDelayInSeconds);
+        sqsQueueService.deferMessage(this.eventQueueUrl, message.getQueueMessageReceiptHandle().orElse(null), retryDelayInSeconds);
     }
 
     private EventMessage getMessage(QueueMessage queueMessage) {

--- a/src/test/java/uk/gov/pay/ledger/event/resource/EventResourceIT.java
+++ b/src/test/java/uk/gov/pay/ledger/event/resource/EventResourceIT.java
@@ -1,9 +1,13 @@
 package uk.gov.pay.ledger.event.resource;
 
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import uk.gov.pay.ledger.event.model.Event;
 import uk.gov.pay.ledger.extension.AppWithPostgresAndSqsExtension;
+import uk.gov.pay.ledger.util.DatabaseTestHelper;
 
 import javax.ws.rs.core.Response;
 
@@ -12,6 +16,7 @@ import static io.restassured.http.ContentType.JSON;
 import static org.hamcrest.CoreMatchers.is;
 import static uk.gov.pay.ledger.util.fixture.EventFixture.anEventFixture;
 import static uk.gov.pay.ledger.util.fixture.TransactionFixture.aTransactionFixture;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class EventResourceIT {
 
@@ -19,6 +24,14 @@ public class EventResourceIT {
     public static AppWithPostgresAndSqsExtension rule = new AppWithPostgresAndSqsExtension();
 
     private Integer port = rule.getAppRule().getLocalPort();
+
+    private DatabaseTestHelper databaseTestHelper;
+
+    @BeforeEach
+    public void setUp() {
+        databaseTestHelper = DatabaseTestHelper.aDatabaseTestHelper(rule.getJdbi());
+        databaseTestHelper.truncateAllData();
+    }
 
     @Test
     public void shouldGetEventFromDB() {
@@ -37,6 +50,31 @@ public class EventResourceIT {
                 .body("sqs_message_id", is(event.getSqsMessageId()))
                 .body("event_type", is(event.getEventType()))
                 .body("event_data", is(event.getEventData()));
+    }
+
+    @Test
+    public void shouldWriteEvent() {
+        var params = new JSONArray();
+
+        var event = new JSONObject()
+                .put("event_type", "PAYMENT_CREATED")
+                .put("service_id", "a-service-id")
+                .put("resource_type", "payment")
+                .put("live", false)
+                .put("timestamp", "2022-03-23T22:08:02.123456Z")
+                .put("event_details", new JSONObject())
+                .put("resource_external_id", "a-valid-external-id");
+        params.put(event);
+
+        given().port(port)
+                .contentType(JSON)
+                .body(params.toString())
+                .post("/v1/event")
+                .then()
+                .statusCode(Response.Status.ACCEPTED.getStatusCode());
+
+        var results = databaseTestHelper.getEventsByExternalId("a-valid-external-id");
+        assertThat(results.size(), is(1));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/ledger/event/resource/EventResourceTest.java
+++ b/src/test/java/uk/gov/pay/ledger/event/resource/EventResourceTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.pay.ledger.event.dao.EventDao;
 import uk.gov.pay.ledger.event.model.Event;
+import uk.gov.pay.ledger.queue.EventMessageHandler;
 import uk.gov.pay.ledger.util.fixture.EventFixture;
 
 import javax.ws.rs.core.Response;
@@ -22,6 +23,7 @@ import static org.mockito.Mockito.when;
 @ExtendWith(DropwizardExtensionsSupport.class)
 public class EventResourceTest {
     private static final EventDao dao = mock(EventDao.class);
+    private static final EventMessageHandler eventMessageHandler = mock(EventMessageHandler.class);
     private static final Long eventId = 1L;
     private static final String nonExistentId = "I'm not really here";
     private final Event event = EventFixture.anEventFixture()
@@ -29,7 +31,7 @@ public class EventResourceTest {
             .toEntity();
 
     public static final ResourceExtension resources = ResourceExtension.builder()
-            .addResource(new EventResource(dao))
+            .addResource(new EventResource(dao, eventMessageHandler))
             .build();
 
     @BeforeEach

--- a/src/test/java/uk/gov/pay/ledger/queue/EventMessageHandlerTest.java
+++ b/src/test/java/uk/gov/pay/ledger/queue/EventMessageHandlerTest.java
@@ -27,6 +27,7 @@ import uk.gov.pay.ledger.eventpublisher.TopicName;
 import uk.gov.service.payments.commons.queue.exception.QueueException;
 
 import java.util.List;
+import java.util.Optional;
 
 import static ch.qos.logback.classic.Level.INFO;
 import static net.logstash.logback.argument.StructuredArguments.kv;
@@ -97,6 +98,7 @@ class EventMessageHandlerTest {
     void shouldMarkMessageAsProcessed_WhenEventIsProcessedSuccessfully() throws QueueException {
         Event event = aQueuePaymentEventFixture().toEntity();
         when(eventMessage.getEvent()).thenReturn(event);
+        when(eventMessage.getQueueMessageReceiptHandle()).thenReturn(Optional.of("a-valid-recipient-handle"));
         when(eventService.createIfDoesNotExist(any())).thenReturn(createEventResponse);
         when(createEventResponse.isSuccessful()).thenReturn(true);
         when(metricRegistry.histogram((any()))).thenReturn(histogram);
@@ -119,6 +121,7 @@ class EventMessageHandlerTest {
                 .withEventType(eventType)
                 .toEntity();
         when(eventMessage.getEvent()).thenReturn(event);
+        when(eventMessage.getQueueMessageReceiptHandle()).thenReturn(Optional.of("a-valid-recipient-handle"));
         when(metricRegistry.histogram((any()))).thenReturn(histogram);
 
         eventMessageHandler.handle();
@@ -135,7 +138,7 @@ class EventMessageHandlerTest {
     void shouldScheduleMessageForRetry_WhenEventIsNotProcessedSuccessfully() throws QueueException {
         Event event = aQueuePaymentEventFixture().toEntity();
         when(eventMessage.getEvent()).thenReturn(event);
-        when(eventMessage.getQueueMessageId()).thenReturn("a-valid-queue-message-id");
+        when(eventMessage.getQueueMessageId()).thenReturn(Optional.of("a-valid-queue-message-id"));
         when(eventService.createIfDoesNotExist(any())).thenReturn(createEventResponse);
         when(createEventResponse.isSuccessful()).thenReturn(false);
 


### PR DESCRIPTION
Depends on https://github.com/alphagov/pay-ledger/pull/1857

---

Sync write event endpoint. Accepts an array of standard Pay event JSON.

This interface directly matches events that are consumed from SQS.

Add coverage to assert events passed into this list (POST body) are
written to the database.

Ensure that any interactions with `jdbi` are rolled back if
any
individual event fails to process, this includes:
* writing events
* domain object projection

Add coverage with an incomplete event (missing resource external ID) --
this will fail a nullable column constraint and cause the batch to rollback.