### PR TITLE
PP-9533 Agreement resource

### DIFF
--- a/src/main/java/uk/gov/pay/ledger/agreement/dao/AgreementDao.java
+++ b/src/main/java/uk/gov/pay/ledger/agreement/dao/AgreementDao.java
@@ -81,7 +81,7 @@ public class AgreementDao {
             "FROM agreement a " +
             ":searchExtraFields";
 
-    private Jdbi jdbi;
+    private final Jdbi jdbi;
 
     @Inject
     public AgreementDao(Jdbi jdbi) {

--- a/src/main/java/uk/gov/pay/ledger/agreement/dao/AgreementDao.java
+++ b/src/main/java/uk/gov/pay/ledger/agreement/dao/AgreementDao.java
@@ -1,9 +1,15 @@
 package uk.gov.pay.ledger.agreement.dao;
 
 import com.google.inject.Inject;
+import org.apache.commons.lang3.StringUtils;
 import org.jdbi.v3.core.Jdbi;
+import org.jdbi.v3.core.statement.Query;
 import uk.gov.pay.ledger.agreement.entity.AgreementEntity;
+import uk.gov.pay.ledger.agreement.resource.AgreementSearchParams;
+
+import java.util.List;
 import java.util.Optional;
+import java.util.function.BiConsumer;
 
 public class AgreementDao {
     private static final String SELECT_AGREEMENT_WITH_PAYMENT_INSTRUMENT =
@@ -66,6 +72,15 @@ public class AgreementDao {
             "event_count = EXCLUDED.event_count " +
             "WHERE EXCLUDED.event_count >= agreement.event_count";
 
+    private static final String SEARCH_AGREEMENT =
+            SELECT_AGREEMENT_WITH_PAYMENT_INSTRUMENT +
+                    ":searchExtraFields " +
+                    "ORDER BY a.created_date DESC OFFSET :offset LIMIT :limit";
+
+    private static final String COUNT_AGREEEMENT = "SELECT count(1) " +
+            "FROM agreement a " +
+            ":searchExtraFields";
+
     private Jdbi jdbi;
 
     @Inject
@@ -85,5 +100,48 @@ public class AgreementDao {
                 handle.createUpdate(UPSERT_AGREEMENT)
                         .bindBean(agreement)
                         .execute());
+    }
+
+    public List<AgreementEntity> searchAgreements(AgreementSearchParams searchParams) {
+        return jdbi.withHandle(handle -> {
+            Query query = handle.createQuery(createSearchTemplate(searchParams.getFilterTemplates(), SEARCH_AGREEMENT));
+            searchParams.getQueryMap().forEach(bindSearchParameter(query));
+            query.bind("offset", searchParams.getOffset());
+            query.bind("limit", searchParams.getDisplaySize());
+            return query
+                    .map(new AgreementMapper())
+                    .list();
+        });
+    }
+
+    public Long getTotalForSearch(AgreementSearchParams searchParams) {
+        return jdbi.withHandle(handle -> {
+            Query query = handle.createQuery(createSearchTemplate(searchParams.getFilterTemplates(), COUNT_AGREEEMENT));
+            searchParams.getQueryMap().forEach(bindSearchParameter(query));
+            return query
+                    .mapTo(Long.class)
+                    .one();
+        });
+    }
+
+    private String createSearchTemplate(List<String> filterTemplates, String baseQueryString) {
+        String searchClauseTemplate = String.join(" AND ", filterTemplates);
+        searchClauseTemplate = StringUtils.isNotBlank(searchClauseTemplate) ?
+                "WHERE " + searchClauseTemplate :
+                "";
+
+        return baseQueryString.replace(
+                ":searchExtraFields",
+                searchClauseTemplate);
+    }
+
+    private BiConsumer<String, Object> bindSearchParameter(Query query) {
+        return (searchKey, searchValue) -> {
+            if (searchValue instanceof List<?>) {
+                query.bindList(searchKey, ((List<?>) searchValue));
+            } else {
+                query.bind(searchKey, searchValue);
+            }
+        };
     }
 }

--- a/src/main/java/uk/gov/pay/ledger/agreement/model/Agreement.java
+++ b/src/main/java/uk/gov/pay/ledger/agreement/model/Agreement.java
@@ -1,0 +1,79 @@
+package uk.gov.pay.ledger.agreement.model;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import uk.gov.pay.ledger.agreement.entity.AgreementEntity;
+import uk.gov.service.payments.commons.api.json.ApiResponseDateTimeSerializer;
+
+import java.time.ZonedDateTime;
+import java.util.Optional;
+
+@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+public class Agreement {
+    private String externalId;
+    private String serviceId;
+    private String reference;
+    private String description;
+    private String status;
+    private Boolean live;
+    @JsonSerialize(using = ApiResponseDateTimeSerializer.class)
+    private ZonedDateTime createdDate;
+    private PaymentInstrument paymentInstrument;
+
+    public Agreement(String externalId, String serviceId, String reference, String description, String status, Boolean live, ZonedDateTime createdDate, PaymentInstrument paymentInstrument) {
+        this.externalId = externalId;
+        this.serviceId = serviceId;
+        this.reference = reference;
+        this.description = description;
+        this.status = status;
+        this.live = live;
+        this.createdDate = createdDate;
+        this.paymentInstrument = paymentInstrument;
+    }
+
+    public static Agreement from(AgreementEntity entity) {
+        return new Agreement(
+                entity.getExternalId(),
+                entity.getServiceId(),
+                entity.getReference(),
+                entity.getDescription(),
+                entity.getStatus(),
+                entity.getLive(),
+                entity.getCreatedDate(),
+                Optional.ofNullable(entity.getPaymentInstrument()).map(PaymentInstrument::from).orElse(null)
+        );
+    }
+
+    public String getExternalId() {
+        return externalId;
+    }
+
+    public String getServiceId() {
+        return serviceId;
+    }
+
+    public String getReference() {
+        return reference;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public Boolean getLive() {
+        return live;
+    }
+
+    public ZonedDateTime getCreatedDate() {
+        return createdDate;
+    }
+
+    public PaymentInstrument getPaymentInstrument() {
+        return paymentInstrument;
+    }
+}

--- a/src/main/java/uk/gov/pay/ledger/agreement/model/Agreement.java
+++ b/src/main/java/uk/gov/pay/ledger/agreement/model/Agreement.java
@@ -1,6 +1,6 @@
 package uk.gov.pay.ledger.agreement.model;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import uk.gov.pay.ledger.agreement.entity.AgreementEntity;
@@ -9,7 +9,7 @@ import uk.gov.service.payments.commons.api.json.ApiResponseDateTimeSerializer;
 import java.time.ZonedDateTime;
 import java.util.Optional;
 
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class Agreement {
     private String externalId;
     private String serviceId;

--- a/src/main/java/uk/gov/pay/ledger/agreement/model/AgreementSearchResponse.java
+++ b/src/main/java/uk/gov/pay/ledger/agreement/model/AgreementSearchResponse.java
@@ -1,0 +1,53 @@
+package uk.gov.pay.ledger.agreement.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import uk.gov.pay.ledger.util.pagination.PaginationBuilder;
+
+import java.util.List;
+
+public class AgreementSearchResponse {
+
+    @JsonProperty("total")
+    private Long total;
+    @JsonProperty("count")
+    private long count;
+    @JsonProperty("page")
+    private long page;
+    @JsonProperty("results")
+    List<Agreement> results;
+    @JsonProperty("_links")
+    private PaginationBuilder paginationBuilder;
+
+    public AgreementSearchResponse(Long total, long count, long page,
+                                   List<Agreement> results) {
+        this.total = total;
+        this.count = count;
+        this.page = page;
+        this.results = results;
+    }
+
+    public AgreementSearchResponse withPaginationBuilder(PaginationBuilder paginationBuilder) {
+        this.paginationBuilder = paginationBuilder;
+        return this;
+    }
+
+    public Long getTotal() {
+        return total;
+    }
+
+    public long getCount() {
+        return count;
+    }
+
+    public long getPage() {
+        return page;
+    }
+
+    public List<Agreement> getResults() {
+        return results;
+    }
+
+    public PaginationBuilder getPaginationBuilder() {
+        return paginationBuilder;
+    }
+}

--- a/src/main/java/uk/gov/pay/ledger/agreement/model/PaymentInstrument.java
+++ b/src/main/java/uk/gov/pay/ledger/agreement/model/PaymentInstrument.java
@@ -1,0 +1,69 @@
+package uk.gov.pay.ledger.agreement.model;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import uk.gov.pay.ledger.agreement.entity.PaymentInstrumentEntity;
+import uk.gov.pay.ledger.transaction.model.Address;
+import uk.gov.pay.ledger.transaction.model.CardDetails;
+import uk.gov.service.payments.commons.api.json.ApiResponseDateTimeSerializer;
+
+import java.time.ZonedDateTime;
+
+@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+public class PaymentInstrument {
+    private String externalId;
+    private String agreementExternalId;
+    private CardDetails cardDetails;
+    @JsonSerialize(using = ApiResponseDateTimeSerializer.class)
+    private ZonedDateTime createdDate;
+
+    public PaymentInstrument(String externalId, String agreementExternalId, CardDetails cardDetails, ZonedDateTime createdDate) {
+        this.externalId = externalId;
+        this.agreementExternalId = agreementExternalId;
+        this.cardDetails = cardDetails;
+        this.createdDate = createdDate;
+    }
+
+    public static PaymentInstrument from(PaymentInstrumentEntity entity) {
+        var billingAddress = Address.from(
+                entity.getAddressLine1(),
+                entity.getAddressLine2(),
+                entity.getAddressPostcode(),
+                entity.getAddressCity(),
+                entity.getAddressCounty(),
+                entity.getAddressCountry()
+        );
+        var cardDetails = CardDetails.from(
+                entity.getCardholderName(),
+                billingAddress,
+                entity.getCardBrand(),
+                entity.getLastDigitsCardNumber(),
+                null,
+                entity.getExpiryDate(),
+                null
+        );
+        return new PaymentInstrument(
+                entity.getExternalId(),
+                entity.getAgreementExternalId(),
+                cardDetails,
+                entity.getCreatedDate()
+        );
+    }
+
+    public String getExternalId() {
+        return externalId;
+    }
+
+    public String getAgreementExternalId() {
+        return agreementExternalId;
+    }
+
+    public CardDetails getCardDetails() {
+        return cardDetails;
+    }
+
+    public ZonedDateTime getCreatedDate() {
+        return createdDate;
+    }
+}

--- a/src/main/java/uk/gov/pay/ledger/agreement/resource/AgreementResource.java
+++ b/src/main/java/uk/gov/pay/ledger/agreement/resource/AgreementResource.java
@@ -1,0 +1,51 @@
+package uk.gov.pay.ledger.agreement.resource;
+
+import com.codahale.metrics.annotation.Timed;
+import com.google.inject.Inject;
+import uk.gov.pay.ledger.agreement.model.Agreement;
+import uk.gov.pay.ledger.agreement.model.AgreementSearchResponse;
+import uk.gov.pay.ledger.agreement.service.AgreementService;
+
+import javax.validation.Valid;
+import javax.validation.ValidationException;
+import javax.ws.rs.BeanParam;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriInfo;
+import java.util.Optional;
+
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+
+@Path("/v1/agreement")
+@Produces(APPLICATION_JSON)
+public class AgreementResource {
+    private final AgreementService agreementService;
+
+    @Inject
+    public AgreementResource(AgreementService agreementService) {
+        this.agreementService = agreementService;
+    }
+
+    @Path("/")
+    @GET
+    @Timed
+    public AgreementSearchResponse search(@Valid @BeanParam AgreementSearchParams querySearchParams,
+                                          @Context UriInfo uriInfo) {
+        var searchParams = Optional.ofNullable(querySearchParams).orElse(new AgreementSearchParams());
+        return agreementService.searchAgreements(searchParams, uriInfo);
+    }
+
+    @Path("/{agreementExternalId}")
+    @GET
+    @Timed
+    public Agreement get(@PathParam("agreementExternalId") String agreementExternalId,
+                         @Context UriInfo uriInfo) {
+        return agreementService.findAgreement(agreementExternalId)
+                .orElseThrow(() -> new WebApplicationException(Response.Status.NOT_FOUND));
+    }
+}

--- a/src/main/java/uk/gov/pay/ledger/agreement/resource/AgreementSearchParams.java
+++ b/src/main/java/uk/gov/pay/ledger/agreement/resource/AgreementSearchParams.java
@@ -24,7 +24,7 @@ public class AgreementSearchParams extends SearchParams {
     private static final String REFERENCE_FIELD = "reference";
     private static final long DEFAULT_PAGE_NUMBER = 1L;
     private static final long DEFAULT_MAX_DISPLAY_SIZE = 20L;
-    private static final long DEFAULT_DISPLAY_SIZE = 20L;
+    public static final long DEFAULT_DISPLAY_SIZE = 20L;
 
     private long maxDisplaySize = DEFAULT_MAX_DISPLAY_SIZE;
 
@@ -133,7 +133,7 @@ public class AgreementSearchParams extends SearchParams {
                 queryMap.put(LIVE_FIELD, live);
             }
         }
-        return queryMap;
+        return Map.copyOf(queryMap);
     }
 
     public List<String> getGatewayAccountIds() {

--- a/src/main/java/uk/gov/pay/ledger/agreement/resource/AgreementSearchParams.java
+++ b/src/main/java/uk/gov/pay/ledger/agreement/resource/AgreementSearchParams.java
@@ -1,0 +1,208 @@
+package uk.gov.pay.ledger.agreement.resource;
+
+import uk.gov.pay.ledger.common.search.SearchParams;
+
+import javax.validation.constraints.AssertTrue;
+import javax.validation.constraints.NotNull;
+import javax.ws.rs.DefaultValue;
+import javax.ws.rs.QueryParam;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
+
+public class AgreementSearchParams extends SearchParams {
+
+    private static final String SERVICE_ID_FIELD = "service_id";
+    private static final String GATEWAY_ACCOUNT_ID_FIELD = "gateway_account_id";
+    private static final String LIVE_FIELD = "live";
+    private static final String STATUS_FIELD = "status";
+    private static final String REFERENCE_FIELD = "reference";
+    private static final long DEFAULT_PAGE_NUMBER = 1L;
+    private static final long DEFAULT_MAX_DISPLAY_SIZE = 20L;
+    private static final long DEFAULT_DISPLAY_SIZE = 20L;
+
+    private long maxDisplaySize = DEFAULT_MAX_DISPLAY_SIZE;
+
+    @NotNull
+    @QueryParam("service_id")
+    private List<String> serviceIds;
+    @QueryParam("live")
+    private Boolean live;
+    @QueryParam("gateway_account_id")
+    private List<String> gatewayAccountIds;
+    @QueryParam("status")
+    private String status;
+    @QueryParam("exact_reference_match")
+    private Boolean exactReferenceMatch;
+    @QueryParam("reference")
+    private String reference;
+    @DefaultValue("true")
+    private Long pageNumber = 1L;
+    private Long displaySize = DEFAULT_DISPLAY_SIZE;
+    private Map<String, Object> queryMap;
+
+    @AssertTrue(message = "One of field [" + SERVICE_ID_FIELD + "] or field [" + GATEWAY_ACCOUNT_ID_FIELD + "] are required")
+    private boolean isServiceIdsOrGatewayAccountIds() {
+        return !(getServiceIds().isEmpty() && getGatewayAccountIds().isEmpty());
+    }
+
+    public void setServiceIds(List<String> serviceIds) {
+        this.serviceIds = List.copyOf(serviceIds);
+    }
+
+    public void setGatewayAccountIds(List<String> gatewayAccountIds) {
+        this.gatewayAccountIds = List.copyOf(gatewayAccountIds);
+    }
+
+    public void setStatus(String status) {
+        this.status = status;
+    }
+
+    @QueryParam("page")
+    public void setPageNumber(Long pageNumber) {
+        this.pageNumber = Objects.requireNonNullElse(pageNumber, DEFAULT_PAGE_NUMBER);
+    }
+
+    public void setExactReferenceMatch(Boolean exactReferenceMatch) {
+        this.exactReferenceMatch = exactReferenceMatch;
+    }
+
+    public void setReference(String reference) {
+        this.reference = reference;
+    }
+
+    public List<String> getFilterTemplates() {
+        List<String> filters = new ArrayList<>();
+
+        if (serviceIds != null && !serviceIds.isEmpty()) {
+            filters.add(" a.service_id IN (<" + SERVICE_ID_FIELD + ">)");
+        }
+
+        if (gatewayAccountIds != null && !gatewayAccountIds.isEmpty()) {
+            filters.add(" a.gateway_account_id IN (<" + GATEWAY_ACCOUNT_ID_FIELD + ">)");
+        }
+
+        if (isNotBlank(status)) {
+            filters.add(" a.status = :" + STATUS_FIELD);
+        }
+
+        if (isNotBlank(reference)) {
+            if (exactReferenceMatch != null && exactReferenceMatch) {
+                filters.add(" lower(a.reference) = lower(:" + REFERENCE_FIELD + ")");
+            } else {
+                filters.add(" lower(a.reference) LIKE lower(:" + REFERENCE_FIELD + ")");
+            }
+        }
+
+        if (live != null) {
+            filters.add(" a.live = :" + LIVE_FIELD);
+        }
+        return List.copyOf(filters);
+    }
+
+    public Map<String, Object> getQueryMap() {
+        if (queryMap == null) {
+            queryMap = new HashMap<>();
+
+            if (serviceIds != null && !serviceIds.isEmpty()) {
+                queryMap.put(SERVICE_ID_FIELD, serviceIds);
+            }
+
+            if (gatewayAccountIds != null && !gatewayAccountIds.isEmpty()) {
+                queryMap.put(GATEWAY_ACCOUNT_ID_FIELD, gatewayAccountIds);
+            }
+
+            if (isNotBlank(status)) {
+                queryMap.put(STATUS_FIELD, status);
+            }
+
+            if (isNotBlank(reference)) {
+                if (exactReferenceMatch != null && exactReferenceMatch) {
+                    queryMap.put(REFERENCE_FIELD, reference);
+                } else {
+                    queryMap.put(REFERENCE_FIELD, likeClause(reference));
+                }
+            }
+
+            if (live != null) {
+                queryMap.put(LIVE_FIELD, live);
+            }
+        }
+        return queryMap;
+    }
+
+    public List<String> getGatewayAccountIds() {
+        return gatewayAccountIds;
+    }
+
+    public List<String> getServiceIds() {
+        return serviceIds;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    @Override
+    public Long getPageNumber() {
+        return pageNumber;
+    }
+
+    @Override
+    public Long getDisplaySize() {
+        if (this.displaySize > this.maxDisplaySize) {
+            return this.maxDisplaySize;
+        } else {
+            return this.displaySize;
+        }
+    }
+
+    public Long getOffset() {
+        long offset = 0L;
+
+        if (pageNumber != null) {
+            offset = (pageNumber - 1) * getDisplaySize();
+        }
+
+        return offset;
+    }
+
+    @Override
+    public String buildQueryParamString(Long forPage) {
+        List<String> queries = new ArrayList<>();
+
+        if (serviceIds != null && !serviceIds.isEmpty()) {
+            queries.add(SERVICE_ID_FIELD + "=" + String.join(",", serviceIds));
+        }
+
+        if (gatewayAccountIds != null && !gatewayAccountIds.isEmpty()) {
+            queries.add(GATEWAY_ACCOUNT_ID_FIELD + "=" + String.join(",", gatewayAccountIds));
+        }
+
+        if (isNotBlank(status)) {
+            queries.add(STATUS_FIELD + "=" + status);
+        }
+
+        if (isNotBlank(reference)) {
+            queries.add(REFERENCE_FIELD + "=" + reference);
+        }
+
+        if (live != null) {
+            queries.add(LIVE_FIELD + "=" + live);
+        }
+
+        queries.add("page=" + forPage);
+        queries.add("display_size=" + getDisplaySize());
+
+        return String.join("&", queries);
+    }
+
+    private String likeClause(String rawUserInputText) {
+        return "%" + rawUserInputText + "%";
+    }
+}

--- a/src/main/java/uk/gov/pay/ledger/agreement/service/AgreementService.java
+++ b/src/main/java/uk/gov/pay/ledger/agreement/service/AgreementService.java
@@ -1,0 +1,54 @@
+package uk.gov.pay.ledger.agreement.service;
+
+import com.google.inject.Inject;
+import uk.gov.pay.ledger.agreement.dao.AgreementDao;
+import uk.gov.pay.ledger.agreement.entity.AgreementEntity;
+import uk.gov.pay.ledger.agreement.model.Agreement;
+import uk.gov.pay.ledger.agreement.model.AgreementSearchResponse;
+import uk.gov.pay.ledger.agreement.resource.AgreementSearchParams;
+import uk.gov.pay.ledger.util.pagination.PaginationBuilder;
+
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriInfo;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+public class AgreementService {
+    private final AgreementDao agreementDao;
+
+    @Inject
+    public AgreementService(AgreementDao agreementDao) {
+        this.agreementDao = agreementDao;
+    }
+
+    public Optional<Agreement> findAgreement(String externalId) {
+        return agreementDao.findByExternalId(externalId)
+                .map(Agreement::from);
+    }
+
+    public AgreementSearchResponse searchAgreements(AgreementSearchParams searchParams, UriInfo uriInfo) {
+        var agreements = agreementDao.searchAgreements(searchParams)
+                .stream()
+                .map(Agreement::from)
+                .collect(Collectors.toList());
+        var total = agreementDao.getTotalForSearch(searchParams);
+
+        long size = searchParams.getDisplaySize();
+        if (total > 0 && searchParams.getDisplaySize() > 0) {
+            long lastPage = (total + size - 1) / size;
+            if (searchParams.getPageNumber() > lastPage || searchParams.getPageNumber() < 1) {
+                throw new WebApplicationException("The requested page was not found",
+                        Response.Status.NOT_FOUND);
+            }
+        }
+
+        PaginationBuilder paginationBuilder = new PaginationBuilder(searchParams, uriInfo)
+                .withTotalCount(total)
+                .buildResponse();
+
+        return new AgreementSearchResponse(total, agreements.size(),
+                searchParams.getPageNumber(), agreements)
+                .withPaginationBuilder(paginationBuilder);
+    }
+}

--- a/src/main/java/uk/gov/pay/ledger/agreement/service/AgreementService.java
+++ b/src/main/java/uk/gov/pay/ledger/agreement/service/AgreementService.java
@@ -2,7 +2,6 @@ package uk.gov.pay.ledger.agreement.service;
 
 import com.google.inject.Inject;
 import uk.gov.pay.ledger.agreement.dao.AgreementDao;
-import uk.gov.pay.ledger.agreement.entity.AgreementEntity;
 import uk.gov.pay.ledger.agreement.model.Agreement;
 import uk.gov.pay.ledger.agreement.model.AgreementSearchResponse;
 import uk.gov.pay.ledger.agreement.resource.AgreementSearchParams;
@@ -31,7 +30,7 @@ public class AgreementService {
         var agreements = agreementDao.searchAgreements(searchParams)
                 .stream()
                 .map(Agreement::from)
-                .collect(Collectors.toList());
+                .collect(Collectors.toUnmodifiableList());
         var total = agreementDao.getTotalForSearch(searchParams);
 
         long size = searchParams.getDisplaySize();

--- a/src/main/java/uk/gov/pay/ledger/app/LedgerApp.java
+++ b/src/main/java/uk/gov/pay/ledger/app/LedgerApp.java
@@ -12,6 +12,8 @@ import io.dropwizard.migrations.MigrationsBundle;
 import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
 import org.jdbi.v3.core.Jdbi;
+import uk.gov.pay.ledger.agreement.model.Agreement;
+import uk.gov.pay.ledger.agreement.resource.AgreementResource;
 import uk.gov.pay.ledger.event.resource.EventResource;
 import uk.gov.pay.ledger.exception.BadRequestExceptionMapper;
 import uk.gov.pay.ledger.exception.JerseyViolationExceptionMapper;
@@ -69,6 +71,7 @@ public class LedgerApp extends Application<LedgerConfig> {
         environment.jersey().register(injector.getInstance(TransactionResource.class));
         environment.jersey().register(injector.getInstance(ReportResource.class));
         environment.jersey().register(injector.getInstance(PerformanceReportResource.class));
+        environment.jersey().register(injector.getInstance(AgreementResource.class));
         environment.jersey().register(injector.getInstance(HealthCheckResource.class));
 
         environment.servlets().addFilter("LoggingFilter", new LoggingFilter())

--- a/src/main/java/uk/gov/pay/ledger/app/LedgerModule.java
+++ b/src/main/java/uk/gov/pay/ledger/app/LedgerModule.java
@@ -13,6 +13,7 @@ import io.dropwizard.setup.Environment;
 import org.jdbi.v3.core.Jdbi;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.sns.SnsClient;
+import uk.gov.pay.ledger.agreement.dao.AgreementDao;
 import uk.gov.pay.ledger.event.dao.EventDao;
 import uk.gov.pay.ledger.event.dao.ResourceTypeDao;
 import uk.gov.pay.ledger.gatewayaccountmetadata.dao.GatewayAccountMetadataDao;
@@ -113,6 +114,12 @@ public class LedgerModule extends AbstractModule {
     @Singleton
     public TransactionSummaryDao provideTransactionSummaryDao() {
         return new TransactionSummaryDao(jdbi);
+    }
+
+    @Provides
+    @Singleton
+    public AgreementDao provideAgreementDao() {
+        return new AgreementDao(jdbi);
     }
 
     @Provides

--- a/src/test/java/uk/gov/pay/ledger/agreement/resource/AgreementResourceIT.java
+++ b/src/test/java/uk/gov/pay/ledger/agreement/resource/AgreementResourceIT.java
@@ -1,0 +1,117 @@
+package uk.gov.pay.ledger.agreement.resource;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import uk.gov.pay.ledger.extension.AppWithPostgresAndSqsExtension;
+import uk.gov.pay.ledger.util.fixture.AgreementFixture;
+import uk.gov.pay.ledger.util.fixture.PaymentInstrumentFixture;
+
+import javax.ws.rs.core.Response;
+
+import java.time.ZonedDateTime;
+
+import static io.restassured.RestAssured.given;
+import static io.restassured.http.ContentType.JSON;
+import static org.hamcrest.CoreMatchers.is;
+import static uk.gov.pay.ledger.util.DatabaseTestHelper.aDatabaseTestHelper;
+
+public class AgreementResourceIT {
+    @RegisterExtension
+    public static AppWithPostgresAndSqsExtension rule = new AppWithPostgresAndSqsExtension();
+
+    private Integer port = rule.getAppRule().getLocalPort();
+
+    @BeforeEach
+    public void setUp() {
+        aDatabaseTestHelper(rule.getJdbi()).truncateAllData();
+    }
+
+    @Test
+    public void shouldGetAgreement() {
+        var fixture = AgreementFixture.anAgreementFixture("a-valid-agreement-id", "a-valid-service-id")
+            .insert(rule.getJdbi());
+
+        given().port(port)
+                .contentType(JSON)
+                .get("/v1/agreement/a-valid-agreement-id")
+                .then()
+                .statusCode(Response.Status.OK.getStatusCode())
+                .contentType(JSON)
+                .body("external_id", is(fixture.getExternalId()));
+    }
+
+    @Test
+    public void shouldGetAgreementWithPaymentInstrument() {
+        var agreementFixture = AgreementFixture.anAgreementFixture("a-valid-agreement-id", "a-valid-service-id")
+                .insert(rule.getJdbi());
+        var paymentInstrumentFixture = PaymentInstrumentFixture.aPaymentInstrumentFixture("a-payment-instrument-id", "a-valid-agreement-id", ZonedDateTime.now())
+                .insert(rule.getJdbi());
+
+        given().port(port)
+                .contentType(JSON)
+                .get("/v1/agreement/a-valid-agreement-id")
+                .then()
+                .statusCode(Response.Status.OK.getStatusCode())
+                .contentType(JSON)
+                .body("external_id", is(agreementFixture.getExternalId()))
+                .body("payment_instrument.external_id", is(paymentInstrumentFixture.getExternalId()));
+    }
+
+    @Test
+    public void shouldSearchEmptyWithNoAgreements() {
+        given().port(port)
+                .contentType(JSON)
+                .queryParam("service_id", "a-valid-service-id")
+                .get("/v1/agreement")
+                .then()
+                .statusCode(Response.Status.OK.getStatusCode())
+                .contentType(JSON)
+                .body("total", is(0))
+                .body("count", is(0))
+                .body("page", is(1))
+                .body("results.size()", is(0));
+    }
+
+    @Test
+    public void shouldSearchWithPaginationForAgreements() {
+        AgreementFixture.anAgreementFixture("a-valid-agreement-id", "a-valid-service-id")
+                .insert(rule.getJdbi());
+        given().port(port)
+                .contentType(JSON)
+                .queryParam("service_id", "a-valid-service-id")
+                .get("/v1/agreement")
+                .then()
+                .statusCode(Response.Status.OK.getStatusCode())
+                .contentType(JSON)
+                .body("total", is(1))
+                .body("count", is(1))
+                .body("page", is(1))
+                .body("results.size()", is(1))
+                .body("results[0].external_id", is("a-valid-agreement-id"));
+    }
+
+    @Test
+    public void shouldSearchWithFilterParams() {
+        AgreementFixture.anAgreementFixture("a-one-agreement-id", "a-one-service-id", "CREATED", "partial-ref-1").insert(rule.getJdbi());
+        AgreementFixture.anAgreementFixture("a-two-agreement-id", "a-one-service-id", "CREATED", "notmatchingref").insert(rule.getJdbi());
+        AgreementFixture.anAgreementFixture("a-three-agreement-id", "a-one-service-id", "ACTIVE", "anotherref").insert(rule.getJdbi());
+        AgreementFixture.anAgreementFixture("a-four-agreement-id", "a-two-service-id", "CREATED", "reference").insert(rule.getJdbi());
+        AgreementFixture.anAgreementFixture("a-five-agreement-id", "a-one-service-id", "CREATED", "avalid-partial-ref").insert(rule.getJdbi());
+        given().port(port)
+                .contentType(JSON)
+                .queryParam("service_id", "a-one-service-id")
+                .queryParam("status", "CREATED")
+                .queryParam("reference", "partial-ref")
+                .get("/v1/agreement")
+                .then()
+                .statusCode(Response.Status.OK.getStatusCode())
+                .contentType(JSON)
+                .body("total", is(2))
+                .body("count", is(2))
+                .body("page", is(1))
+                .body("results.size()", is(2))
+                .body("results[0].external_id", is("a-five-agreement-id"))
+                .body("results[1].external_id", is("a-one-agreement-id"));
+    }
+}

--- a/src/test/java/uk/gov/pay/ledger/agreement/resource/AgreementResourceTest.java
+++ b/src/test/java/uk/gov/pay/ledger/agreement/resource/AgreementResourceTest.java
@@ -1,0 +1,66 @@
+package uk.gov.pay.ledger.agreement.resource;
+
+import io.dropwizard.testing.junit5.DropwizardExtensionsSupport;
+import io.dropwizard.testing.junit5.ResourceExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.pay.ledger.agreement.model.AgreementSearchResponse;
+import uk.gov.pay.ledger.agreement.service.AgreementService;
+import uk.gov.pay.ledger.exception.BadRequestExceptionMapper;
+import uk.gov.pay.ledger.exception.JerseyViolationExceptionMapper;
+
+import javax.ws.rs.core.Response;
+
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(DropwizardExtensionsSupport.class)
+@ExtendWith(MockitoExtension.class)
+class AgreementResourceTest {
+
+    private static final AgreementService agreementService = mock(AgreementService.class);
+
+    public static final ResourceExtension resources = ResourceExtension.builder()
+            .addResource(new AgreementResource(agreementService))
+            .addProvider(BadRequestExceptionMapper.class)
+            .addProvider(JerseyViolationExceptionMapper.class)
+            .build();
+
+    @Test
+    public void searchShouldReturn422_WithMissingBothServiceIdAndGatewayAccountId() {
+        Response response = resources
+                .target("/v1/agreement")
+                .request()
+                .get();
+
+        assertThat(response.getStatus(), is(422));
+    }
+
+    @Test
+    public void searchShouldReturn200_WithValidParams() {
+        when(agreementService.searchAgreements(any(), any())).thenReturn(new AgreementSearchResponse(0L, 0L, 0L, List.of()));
+        Response response = resources
+                .target("/v1/agreement")
+                .queryParam("service_id", "a-valid-service-id")
+                .request()
+                .get();
+
+        assertThat(response.getStatus(), is(200));
+    }
+
+    @Test
+    public void findShouldReturn404_IfMissing() {
+        Response response = resources
+                .target("/v1/agreement/missing-agreement-id")
+                .request()
+                .get();
+
+        assertThat(response.getStatus(), is(404));
+    }
+}

--- a/src/test/java/uk/gov/pay/ledger/util/DatabaseTestHelper.java
+++ b/src/test/java/uk/gov/pay/ledger/util/DatabaseTestHelper.java
@@ -38,7 +38,9 @@ public class DatabaseTestHelper {
         jdbi.withHandle(h -> h.createScript(
                 "TRUNCATE TABLE event CASCADE; " +
                         "TRUNCATE TABLE transaction CASCADE;" +
-                        "TRUNCATE TABLE gateway_account_metadata CASCADE;"
+                        "TRUNCATE TABLE gateway_account_metadata CASCADE;" +
+                        "TRUNCATE TABLE agreement CASCADE;" +
+                        "TRUNCATE TABLE payment_instrument CASCADE;"
         ).execute());
     }
 

--- a/src/test/java/uk/gov/pay/ledger/util/fixture/AgreementFixture.java
+++ b/src/test/java/uk/gov/pay/ledger/util/fixture/AgreementFixture.java
@@ -31,6 +31,15 @@ public class AgreementFixture implements DbFixture<AgreementFixture, AgreementEn
         return fixture;
     }
 
+    public static AgreementFixture anAgreementFixture(String externalId, String serviceId, String status, String reference) {
+        var fixture = new AgreementFixture();
+        fixture.setExternalId(externalId);
+        fixture.setServiceId(serviceId);
+        fixture.setStatus(status);
+        fixture.setReference(reference);
+        return fixture;
+    }
+
     public static AgreementFixture anAgreementFixture() {
         return new AgreementFixture();
     }
@@ -90,6 +99,14 @@ public class AgreementFixture implements DbFixture<AgreementFixture, AgreementEn
 
     public void setExternalId(String externalId) {
         this.externalId = externalId;
+    }
+
+    public void setStatus(String status) {
+        this.status = status;
+    }
+
+    public void setReference(String reference) {
+        this.reference = reference;
     }
 
     public String getDescription() {

--- a/src/test/java/uk/gov/pay/ledger/util/fixture/PaymentInstrumentFixture.java
+++ b/src/test/java/uk/gov/pay/ledger/util/fixture/PaymentInstrumentFixture.java
@@ -48,7 +48,7 @@ public class PaymentInstrumentFixture implements DbFixture<PaymentInstrumentFixt
         var sql = "INSERT INTO payment_instrument" +
                 "(id, external_id, agreement_external_id, email, cardholder_name, address_line1, address_line2, address_postcode, address_city, address_county, address_country, last_digits_card_number, expiry_date, card_brand, event_count, created_date) " +
                 "VALUES " +
-                "(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
+                "(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
 
         jdbi.withHandle(h ->
                 h.execute(


### PR DESCRIPTION
Add endpoints to
* get one agreement
* search for agreements

Agreement search supports standard Pay result response
* pagination
* filtering on `status` and `reference`

Lifts core pagination and search string templating methodology directly from transaction search.

Either `gateway_account_id` or `service_id` is required to access the
search endpoint. This should guard against consumers accidentally
requesting data across services.

Adds agreement service to manage search functionality.

HTTP endpoints generally follow a pattern of serialising an external
facing model rather than using the database entities. Add agreement and
payment instrument shaped models.