### PR TITLE
PP-8608 remove deprecated stripe contract fee handling

### DIFF
--- a/src/main/java/uk/gov/pay/ledger/transaction/model/CsvTransactionFactory.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/model/CsvTransactionFactory.java
@@ -206,8 +206,7 @@ public class CsvTransactionFactory {
 
     public Map<String, Object> getCsvHeadersWithMedataKeys(List<String> metadataKeys,
                                                            boolean includeFeeHeaders,
-                                                           boolean includeMotoHeader,
-                                                           boolean includeFeeBreakdownHeaders) {
+                                                           boolean includeMotoHeader) {
         LinkedHashMap<String, Object> headers = new LinkedHashMap<>();
 
         headers.put(FIELD_REFERENCE, FIELD_REFERENCE);
@@ -234,9 +233,6 @@ public class CsvTransactionFactory {
         if (includeFeeHeaders) {
             headers.put(FIELD_FEE, FIELD_FEE);
             headers.put(FIELD_NET, FIELD_NET);
-        }
-
-        if (includeFeeBreakdownHeaders) {
             headers.put(FIELD_FEE_BREAKDOWN_TRANSACTION, FIELD_FEE_BREAKDOWN_TRANSACTION);
             headers.put(FIELD_FEE_BREAKDOWN_3DS, FIELD_FEE_BREAKDOWN_3DS);
             headers.put(FIELD_FEE_BREAKDOWN_RADAR, FIELD_FEE_BREAKDOWN_RADAR);

--- a/src/main/java/uk/gov/pay/ledger/transaction/resource/TransactionResource.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/resource/TransactionResource.java
@@ -148,7 +148,6 @@ public class TransactionResource {
     public Response streamCsv(@Valid @BeanParam TransactionSearchParams searchParams,
                               @QueryParam("account_id") CommaDelimitedSetParameter gatewayAccountIds,
                               @QueryParam("fee_headers") boolean includeFeeHeaders,
-                              @QueryParam("fee_breakdown_headers") boolean includeFeeBreakdownHeaders,
                               @QueryParam("moto_header") boolean includeMotoHeader,
                               @Context UriInfo uriInfo) {
         StreamingOutput stream = outputStream -> {
@@ -164,8 +163,7 @@ public class TransactionResource {
             Long startingAfterId = null;
             int count = 0;
 
-            Map<String, Object> headers = csvService.csvHeaderFrom(csvSearchParams, includeFeeHeaders, includeMotoHeader,
-                    includeFeeBreakdownHeaders);
+            Map<String, Object> headers = csvService.csvHeaderFrom(csvSearchParams, includeFeeHeaders, includeMotoHeader);
             ObjectWriter writer = csvService.writerFrom(headers);
             Stopwatch stopwatch = Stopwatch.createStarted();
             outputStream.write(csvService.csvStringFrom(headers, writer).getBytes());

--- a/src/main/java/uk/gov/pay/ledger/transaction/service/CsvService.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/service/CsvService.java
@@ -43,10 +43,9 @@ public class CsvService {
 
     public Map<String, Object> csvHeaderFrom(TransactionSearchParams searchParams,
                                              boolean includeFeeHeaders,
-                                             boolean includeMotoHeader,
-                                             boolean includeFeeBreakdownHeaders) {
+                                             boolean includeMotoHeader) {
         List<String> metadataKeys = gatewayAccountMetadataService.getKeysForGatewayAccounts(searchParams.getAccountIds());
-        return csvTransactionFactory.getCsvHeadersWithMedataKeys(metadataKeys, includeFeeHeaders, includeMotoHeader, includeFeeBreakdownHeaders);
+        return csvTransactionFactory.getCsvHeadersWithMedataKeys(metadataKeys, includeFeeHeaders, includeMotoHeader);
     }
 
     public String csvStringFrom(Map<String, Object> headers, ObjectWriter writer) throws JsonProcessingException {

--- a/src/test/java/uk/gov/pay/ledger/transaction/model/CsvTransactionFactoryTest.java
+++ b/src/test/java/uk/gov/pay/ledger/transaction/model/CsvTransactionFactoryTest.java
@@ -227,7 +227,7 @@ class CsvTransactionFactoryTest {
     void getCsvHeadersWithMedataKeysShouldReturnMapWithCorrectCsvHeaders_WithoutOptionalColumns() {
         var keys = List.of("test-key-1", "test-key-2");
 
-        Map<String, Object> csvHeaders = csvTransactionFactory.getCsvHeadersWithMedataKeys(keys, false, false, false);
+        Map<String, Object> csvHeaders = csvTransactionFactory.getCsvHeadersWithMedataKeys(keys, false, false);
 
         assertThat(csvHeaders.get("Reference"), is(notNullValue()));
         assertThat(csvHeaders.get("Description"), is(notNullValue()));
@@ -257,25 +257,20 @@ class CsvTransactionFactoryTest {
 
         assertThat(csvHeaders.get("Net"), is(nullValue()));
         assertThat(csvHeaders.get("Fee"), is(nullValue()));
+        assertThat(csvHeaders.get("Fee (transaction)"), is(nullValue()));
+        assertThat(csvHeaders.get("Fee (fraud protection)"), is(nullValue()));
+        assertThat(csvHeaders.get("Fee (3DS)"), is(nullValue()));
         assertThat(csvHeaders.get("MOTO"), is(nullValue()));
-    }
-
-    @Test
-    void getCsvHeadersWithMedataKeysShouldReturnMapWithCorrectCsvHeaders_WithFeeColumns() {
-        var keys = List.of("test-key-1", "test-key-2");
-
-        Map<String, Object> csvHeaders = csvTransactionFactory.getCsvHeadersWithMedataKeys(keys, true, false, false);
-
-        assertThat(csvHeaders.get("Net"), is(notNullValue()));
-        assertThat(csvHeaders.get("Fee"), is(notNullValue()));
     }
 
     @Test
     void getCsvHeadersWithMedataKeysShouldReturnMapWithCorrectCsvHeaders_WithFeeBreakdownColumns() {
         var keys = List.of("test-key-1", "test-key-2");
 
-        Map<String, Object> csvHeaders = csvTransactionFactory.getCsvHeadersWithMedataKeys(keys, false, false, true);
+        Map<String, Object> csvHeaders = csvTransactionFactory.getCsvHeadersWithMedataKeys(keys, true, false);
 
+        assertThat(csvHeaders.get("Net"), is(notNullValue()));
+        assertThat(csvHeaders.get("Fee"), is(notNullValue()));
         assertThat(csvHeaders.get("Fee (transaction)"), is(notNullValue()));
         assertThat(csvHeaders.get("Fee (fraud protection)"), is(notNullValue()));
         assertThat(csvHeaders.get("Fee (3DS)"), is(notNullValue()));
@@ -285,7 +280,7 @@ class CsvTransactionFactoryTest {
     void getCsvHeadersWithMedataKeysShouldReturnMapWithCorrectCsvHeaders_WithMotoColumn() {
         var keys = List.of("test-key-1", "test-key-2");
 
-        Map<String, Object> csvHeaders = csvTransactionFactory.getCsvHeadersWithMedataKeys(keys, false, true, false);
+        Map<String, Object> csvHeaders = csvTransactionFactory.getCsvHeadersWithMedataKeys(keys, false, true);
 
         assertThat(csvHeaders.get("MOTO"), is(notNullValue()));
     }


### PR DESCRIPTION
- Stripe contract fee V2 is applicable to all services which use Stripe thus we no longer need `includeFeeBreakdownHeaders`. All Stripe csv downloads will contain the fee break down. Remove all traces of separate fee  break down.
- Update tests accordingly.