### PR TITLE
PP-9577 add dispute lost event pact test

### DIFF
--- a/src/test/java/uk/gov/pay/ledger/pact/ConsumerContractTestSuite.java
+++ b/src/test/java/uk/gov/pay/ledger/pact/ConsumerContractTestSuite.java
@@ -36,6 +36,7 @@ public class ConsumerContractTestSuite {
         consumerToJUnitTest.put("connector", new JUnit4TestAdapter(DisputeCreatedEventQueueContractTest.class));
         consumerToJUnitTest.put("connector", new JUnit4TestAdapter(DisputeWonEventQueueContractTest.class));
         consumerToJUnitTest.put("connector", new JUnit4TestAdapter(DisputeEvidenceSubmittedEventQueueContractTest.class));
+        consumerToJUnitTest.put("connector", new JUnit4TestAdapter(DisputeLostEventQueueContractTest.class));
 
         return CreateTestSuite.create(consumerToJUnitTest.build());
     }

--- a/src/test/java/uk/gov/pay/ledger/pact/DisputeLostEventQueueContractTest.java
+++ b/src/test/java/uk/gov/pay/ledger/pact/DisputeLostEventQueueContractTest.java
@@ -1,0 +1,123 @@
+package uk.gov.pay.ledger.pact;
+
+import au.com.dius.pact.consumer.MessagePactBuilder;
+import au.com.dius.pact.consumer.MessagePactProviderRule;
+import au.com.dius.pact.consumer.Pact;
+import au.com.dius.pact.consumer.PactVerification;
+import au.com.dius.pact.model.v3.messaging.MessagePact;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.gson.GsonBuilder;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import uk.gov.pay.ledger.event.dao.EventDao;
+import uk.gov.pay.ledger.event.model.Event;
+import uk.gov.pay.ledger.rule.AppWithPostgresAndSqsRule;
+import uk.gov.pay.ledger.rule.SqsTestDocker;
+import uk.gov.pay.ledger.util.DatabaseTestHelper;
+import uk.gov.pay.ledger.util.fixture.QueueDisputeEventFixture;
+
+import java.time.ZonedDateTime;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+import static io.dropwizard.testing.ConfigOverride.config;
+import static java.time.Instant.ofEpochSecond;
+import static java.time.ZoneOffset.UTC;
+import static java.time.ZonedDateTime.ofInstant;
+import static org.awaitility.Awaitility.await;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static uk.gov.pay.ledger.event.model.ResourceType.DISPUTE;
+
+public class DisputeLostEventQueueContractTest {
+    @Rule
+    public MessagePactProviderRule mockProvider = new MessagePactProviderRule(this);
+
+    @Rule
+    public AppWithPostgresAndSqsRule appRule = new AppWithPostgresAndSqsRule(
+            config("queueMessageReceiverConfig.backgroundProcessingEnabled", "true")
+    );
+
+    private GsonBuilder gsonBuilder = new GsonBuilder();
+    private byte[] currentMessage;
+    private String paymentExternalId = "payment-external-id";
+    private final long fee = 1500L;
+    private final long amount = 6500L;
+    // there is a bug in pact assert where a negative number is not recognised as an integer.
+    // add net_amount to pact check once a fix is released
+    private final long netAmount = -8000L;
+    private final String gatewayAccountId = "a-gateway-account-id";
+    private final String resourceExternalId = paymentExternalId;
+    private final String parentsResourceExternalId = "external-id";
+    private final String serviceId = "service-id";
+    private final ZonedDateTime disputeCreated = ofInstant(ofEpochSecond(1642579160L), UTC);
+
+    private QueueDisputeEventFixture eventFixture;
+
+    @Pact(provider = "connector", consumer = "ledger")
+    public MessagePact createDisputeLostEventPact(MessagePactBuilder builder) {
+        String eventData = gsonBuilder.create()
+                .toJson(Map.of(
+                        "fee", fee,
+                        "gateway_account_id", gatewayAccountId,
+                        "amount", amount
+                ));
+        eventFixture = QueueDisputeEventFixture.aQueueDisputeEventFixture()
+                .withLive(true)
+                .withResourceExternalId(paymentExternalId)
+                .withParentResourceExternalId(parentsResourceExternalId)
+                .withEventDate(disputeCreated)
+                .withServiceId(serviceId)
+                .withEventData(eventData)
+                .withEventType("DISPUTE_LOST")
+                .withServiceId(serviceId);
+
+        Map<String, String> metadata = new HashMap<>();
+        metadata.put("contentType", "application/json");
+
+        return builder
+                .expectsToReceive("a dispute lost event")
+                .withMetadata(metadata)
+                .withContent(eventFixture.getAsPact())
+                .toPact();
+    }
+
+    @Before
+    public void setUp() {
+        DatabaseTestHelper.aDatabaseTestHelper(appRule.getJdbi()).truncateAllData();
+    }
+
+    @Test
+    @PactVerification({"connector"})
+    public void test() throws JsonProcessingException {
+        appRule.getSqsClient().sendMessage(SqsTestDocker.getQueueUrl("event-queue"), new String(currentMessage));
+        EventDao eventDao = appRule.getJdbi().onDemand(EventDao.class);
+        await().atMost(1, TimeUnit.SECONDS).until(
+                () -> !eventDao.findEventsForExternalIds(Set.of(resourceExternalId)).isEmpty()
+        );
+
+        List<Event> events = eventDao.findEventsForExternalIds(Set.of(resourceExternalId));
+        assertThat(events.isEmpty(), is(false));
+        Event event = events.get(0);
+        assertThat(event.getEventType(), is("DISPUTE_LOST"));
+        assertThat(event.getEventDate(), is(disputeCreated));
+        assertThat(event.getResourceType(), is(DISPUTE));
+        assertThat(event.getResourceExternalId(), is(resourceExternalId));
+        assertThat(event.getParentResourceExternalId(), is(parentsResourceExternalId));
+
+        JsonNode eventData = new ObjectMapper().readTree(event.getEventData());
+        assertThat(eventData.get("amount").asLong(), is(amount));
+        assertThat(eventData.get("fee").asLong(), is(fee));
+        assertThat(eventData.get("gateway_account_id").asText(), is(gatewayAccountId));
+    }
+
+    public void setMessage(byte[] messageContents) {
+        currentMessage = messageContents;
+    }
+}

--- a/src/test/java/uk/gov/pay/ledger/util/fixture/QueueDisputeEventFixture.java
+++ b/src/test/java/uk/gov/pay/ledger/util/fixture/QueueDisputeEventFixture.java
@@ -84,6 +84,14 @@ public class QueueDisputeEventFixture implements QueueFixture<QueueDisputeEventF
                                 .put("reason", "duplicate")
                                 .build());
                 break;
+            case "DISPUTE_LOST":
+                eventData = new GsonBuilder().create()
+                        .toJson(ImmutableMap.builder()
+                                .put("fee", 1500)
+                                .put("amount", 6500)
+                                .put("net_amount", -8000)
+                                .put("gateway_account_id", gatewayAccountId)
+                                .build());
             default:
                 eventData = new GsonBuilder().create()
                         .toJson(ImmutableMap.of("event_data", "event_data"));


### PR DESCRIPTION
- implement `a dispute lost event` pact test

Note: there is a bug in pact's matchInteger code that does not recognise a negative number as such. Add `net_amount` to this test once a fix from pact has been released.