### PR TITLE
PP-9626: Add dispute to transaction types enum

### DIFF
--- a/src/main/resources/migrations/00073_add_dispute_type_to_transaction_types.sql
+++ b/src/main/resources/migrations/00073_add_dispute_type_to_transaction_types.sql
@@ -1,0 +1,5 @@
+--liquibase formatted sql
+
+--changeset runInTransaction:false uk.gov.pay:add_dispute_type_to_transaction_type_enum
+
+ALTER type transaction_type ADD VALUE 'DISPUTE';


### PR DESCRIPTION
Adding to the type needs to be done outside of a transaction, so use
the attribute runInTransaction:false on the changeset