### PR TITLE
PP-9626 Refactor EventDigestHandlerTest

### DIFF
--- a/src/main/java/uk/gov/pay/ledger/queue/EventDigestHandler.java
+++ b/src/main/java/uk/gov/pay/ledger/queue/EventDigestHandler.java
@@ -3,23 +3,13 @@ package uk.gov.pay.ledger.queue;
 import com.google.inject.Inject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import uk.gov.pay.ledger.agreement.service.AgreementService;
-import uk.gov.pay.ledger.app.LedgerConfig;
 import uk.gov.pay.ledger.event.model.Event;
-import uk.gov.pay.ledger.event.model.TransactionEntityFactory;
-import uk.gov.pay.ledger.event.service.EventService;
-import uk.gov.pay.ledger.payout.service.PayoutService;
 import uk.gov.pay.ledger.queue.eventprocessor.AgreementEventProcessor;
 import uk.gov.pay.ledger.queue.eventprocessor.ChildTransactionEventProcessor;
 import uk.gov.pay.ledger.queue.eventprocessor.EventProcessor;
 import uk.gov.pay.ledger.queue.eventprocessor.PaymentEventProcessor;
 import uk.gov.pay.ledger.queue.eventprocessor.PaymentInstrumentEventProcessor;
 import uk.gov.pay.ledger.queue.eventprocessor.PayoutEventProcessor;
-import uk.gov.pay.ledger.transaction.service.TransactionMetadataService;
-import uk.gov.pay.ledger.transaction.service.TransactionService;
-import uk.gov.pay.ledger.transactionsummary.service.TransactionSummaryService;
-
-import java.time.Clock;
 
 public class EventDigestHandler {
 
@@ -32,20 +22,17 @@ public class EventDigestHandler {
     private PaymentInstrumentEventProcessor paymentInstrumentEventProcessor;
 
     @Inject
-    public EventDigestHandler(EventService eventService,
-                              TransactionService transactionService,
-                              TransactionMetadataService transactionMetadataService,
-                              PayoutService payoutService,
-                              TransactionEntityFactory transactionEntityFactory,
-                              TransactionSummaryService transactionSummaryService,
-                              AgreementService agreementService,
-                              LedgerConfig ledgerConfig,
-                              Clock clock) {
-        childTransactionEventProcessor = new ChildTransactionEventProcessor(eventService, transactionService, transactionEntityFactory, ledgerConfig, clock);
-        paymentEventProcessor = new PaymentEventProcessor(eventService, transactionService, transactionMetadataService, childTransactionEventProcessor, transactionSummaryService);
-        payoutEventProcessor = new PayoutEventProcessor(eventService, payoutService);
-        agreementEventProcessor = new AgreementEventProcessor(eventService, agreementService);
-        paymentInstrumentEventProcessor = new PaymentInstrumentEventProcessor(eventService, agreementService);
+    public EventDigestHandler(PaymentEventProcessor paymentEventProcessor,
+                              PayoutEventProcessor payoutEventProcessor,
+                              ChildTransactionEventProcessor childTransactionEventProcessor,
+                              AgreementEventProcessor agreementEventProcessor,
+                              PaymentInstrumentEventProcessor paymentInstrumentEventProcessor) {
+
+        this.paymentEventProcessor = paymentEventProcessor;
+        this.payoutEventProcessor = payoutEventProcessor;
+        this.childTransactionEventProcessor = childTransactionEventProcessor;
+        this.agreementEventProcessor = agreementEventProcessor;
+        this.paymentInstrumentEventProcessor = paymentInstrumentEventProcessor;
     }
 
     public EventProcessor processorFor(Event event) {

--- a/src/main/java/uk/gov/pay/ledger/queue/eventprocessor/AgreementEventProcessor.java
+++ b/src/main/java/uk/gov/pay/ledger/queue/eventprocessor/AgreementEventProcessor.java
@@ -1,5 +1,6 @@
 package uk.gov.pay.ledger.queue.eventprocessor;
 
+import com.google.inject.Inject;
 import uk.gov.pay.ledger.agreement.service.AgreementService;
 import uk.gov.pay.ledger.event.model.Event;
 import uk.gov.pay.ledger.event.service.EventService;
@@ -8,6 +9,7 @@ public class AgreementEventProcessor extends EventProcessor {
     private final EventService eventService;
     private final AgreementService agreementService;
 
+    @Inject
     public AgreementEventProcessor(EventService eventService, AgreementService agreementService) {
         this.eventService = eventService;
         this.agreementService = agreementService;

--- a/src/main/java/uk/gov/pay/ledger/queue/eventprocessor/PaymentEventProcessor.java
+++ b/src/main/java/uk/gov/pay/ledger/queue/eventprocessor/PaymentEventProcessor.java
@@ -1,5 +1,6 @@
 package uk.gov.pay.ledger.queue.eventprocessor;
 
+import com.google.inject.Inject;
 import uk.gov.pay.ledger.event.model.Event;
 import uk.gov.pay.ledger.event.model.EventDigest;
 import uk.gov.pay.ledger.event.model.SalientEventType;
@@ -25,6 +26,7 @@ public class PaymentEventProcessor extends EventProcessor {
     private final ChildTransactionEventProcessor childTransactionEventProcessor;
     private final TransactionSummaryService transactionSummaryService;
 
+    @Inject
     public PaymentEventProcessor(EventService eventService,
                                  TransactionService transactionService,
                                  TransactionMetadataService transactionMetadataService,

--- a/src/main/java/uk/gov/pay/ledger/queue/eventprocessor/PaymentInstrumentEventProcessor.java
+++ b/src/main/java/uk/gov/pay/ledger/queue/eventprocessor/PaymentInstrumentEventProcessor.java
@@ -1,5 +1,6 @@
 package uk.gov.pay.ledger.queue.eventprocessor;
 
+import com.google.inject.Inject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.pay.ledger.agreement.service.AgreementService;
@@ -11,7 +12,7 @@ public class PaymentInstrumentEventProcessor extends EventProcessor {
     private AgreementService agreementService;
     private static final Logger LOGGER = LoggerFactory.getLogger(PaymentInstrumentEventProcessor.class);
 
-
+    @Inject
     public PaymentInstrumentEventProcessor(EventService eventService, AgreementService agreementService) {
         this.eventService = eventService;
         this.agreementService = agreementService;

--- a/src/main/java/uk/gov/pay/ledger/queue/eventprocessor/PayoutEventProcessor.java
+++ b/src/main/java/uk/gov/pay/ledger/queue/eventprocessor/PayoutEventProcessor.java
@@ -1,5 +1,6 @@
 package uk.gov.pay.ledger.queue.eventprocessor;
 
+import com.google.inject.Inject;
 import uk.gov.pay.ledger.event.model.Event;
 import uk.gov.pay.ledger.event.service.EventService;
 import uk.gov.pay.ledger.payout.service.PayoutService;
@@ -8,6 +9,7 @@ public class PayoutEventProcessor extends EventProcessor {
     private EventService eventService;
     private PayoutService payoutService;
 
+    @Inject
     public PayoutEventProcessor(EventService eventService, PayoutService payoutService) {
         this.eventService = eventService;
         this.payoutService = payoutService;

--- a/src/test/java/uk/gov/pay/ledger/queue/eventprocessor/AgreementEventProcessorTest.java
+++ b/src/test/java/uk/gov/pay/ledger/queue/eventprocessor/AgreementEventProcessorTest.java
@@ -1,0 +1,43 @@
+package uk.gov.pay.ledger.queue.eventprocessor;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.pay.ledger.agreement.service.AgreementService;
+import uk.gov.pay.ledger.event.model.Event;
+import uk.gov.pay.ledger.event.model.EventDigest;
+import uk.gov.pay.ledger.event.service.EventService;
+
+import java.util.List;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static uk.gov.pay.ledger.event.model.ResourceType.AGREEMENT;
+import static uk.gov.pay.ledger.util.fixture.EventFixture.anEventFixture;
+
+@ExtendWith(MockitoExtension.class)
+class AgreementEventProcessorTest {
+
+    @Mock
+    EventService mockEventService;
+
+    @Mock
+    AgreementService mockAgreementService;
+
+    @InjectMocks
+    AgreementEventProcessor agreementEventProcessor;
+
+    @Test
+    void shouldUpsertAgreement() {
+        Event event = anEventFixture().withResourceType(AGREEMENT).toEntity();
+        var eventDigest = EventDigest.fromEventList(List.of(anEventFixture().toEntity()));
+        when(mockEventService.getEventDigestForResource(event)).thenReturn(eventDigest);
+
+        agreementEventProcessor.process(event, true);
+
+        verify(mockEventService).getEventDigestForResource(event);
+        verify(mockAgreementService).upsertAgreementFor(eventDigest);
+    }
+}

--- a/src/test/java/uk/gov/pay/ledger/queue/eventprocessor/ChildTransactionEventProcessorTest.java
+++ b/src/test/java/uk/gov/pay/ledger/queue/eventprocessor/ChildTransactionEventProcessorTest.java
@@ -19,34 +19,40 @@ import uk.gov.pay.ledger.event.model.EventDigest;
 import uk.gov.pay.ledger.event.model.ResourceType;
 import uk.gov.pay.ledger.event.model.TransactionEntityFactory;
 import uk.gov.pay.ledger.event.service.EventService;
+import uk.gov.pay.ledger.exception.EmptyEventsException;
 import uk.gov.pay.ledger.transaction.entity.TransactionEntity;
 import uk.gov.pay.ledger.transaction.service.TransactionService;
 
 import java.time.Clock;
 import java.time.Instant;
+import java.time.ZonedDateTime;
 import java.util.List;
+import java.util.Map;
 
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static uk.gov.pay.ledger.event.model.ResourceType.REFUND;
 import static uk.gov.pay.ledger.util.fixture.EventFixture.anEventFixture;
+import static uk.gov.pay.ledger.util.fixture.QueuePaymentEventFixture.aQueuePaymentEventFixture;
 
 @ExtendWith(MockitoExtension.class)
 class ChildTransactionEventProcessorTest {
 
     @Mock
-    private EventService eventService;
+    private EventService mockEventService;
     @Mock
-    private TransactionService transactionService;
+    private TransactionService mockTransactionService;
     @Mock
-    private LedgerConfig ledgerConfig;
+    private LedgerConfig mockLedgerConfig;
     @Mock
-    private Clock clock;
+    private Clock mockClock;
     @Captor
     private ArgumentCaptor<TransactionEntity> transactionEntityArgumentCaptor;
 
@@ -56,12 +62,105 @@ class ChildTransactionEventProcessorTest {
     @BeforeEach
     void setUp() {
         transactionEntityFactory = new TransactionEntityFactory(new ObjectMapper());
-        childTransactionEventProcessor = new ChildTransactionEventProcessor(eventService, transactionService,
-                transactionEntityFactory, ledgerConfig, clock);
+        childTransactionEventProcessor = new ChildTransactionEventProcessor(mockEventService, mockTransactionService,
+                transactionEntityFactory, mockLedgerConfig, mockClock);
     }
 
     @Test
-    void shouldIncludePaymentInformationWhenRefundTransactionReprojected() {
+    void shouldProjectRefundTransactionWithPaymentInformation() {
+        String refundExternalId = "refund-external-id";
+        String paymentExternalId = "payment-external-id";
+
+        Event refundEvent = anEventFixture()
+                .withResourceType(REFUND)
+                .withEventType("REFUND_SUCCEEDED")
+                .withEventDate(ZonedDateTime.parse("2022-07-01T10:00:00Z"))
+                .withResourceExternalId(refundExternalId)
+                .withParentResourceExternalId(paymentExternalId)
+                .withEventData(new GsonBuilder().create()
+                        .toJson(ImmutableMap.builder()
+                                .put("amount", 99)
+                                .put("gateway_transaction_id", "a-gateway-id")
+                                .build()))
+                .toEntity();
+
+        Event paymentEvent1 = aQueuePaymentEventFixture()
+                .withResourceExternalId(paymentExternalId)
+                .withEventType("PAYMENT_CREATED")
+                .withEventDate(ZonedDateTime.parse("2022-06-01T10:00:00Z"))
+                .withDefaultEventDataForEventType("PAYMENT_CREATED")
+                .toEntity();
+        Event paymentEvent2 = aQueuePaymentEventFixture()
+                .withResourceExternalId(paymentExternalId)
+                .withEventType("PAYMENT_DETAILS_ENTERED")
+                .withEventDate(ZonedDateTime.parse("2022-06-01T10:01:00Z"))
+                .withDefaultEventDataForEventType("PAYMENT_DETAILS_ENTERED")
+                .toEntity();
+        Event paymentEvent3 = aQueuePaymentEventFixture()
+                .withResourceExternalId(paymentExternalId)
+                .withEventType("FEE_INCURRED")
+                .withEventDate(ZonedDateTime.parse("2022-06-01T10:02:00Z"))
+                .withEventData(new GsonBuilder().create()
+                        .toJson(Map.of(
+                                "net_amount", 900,
+                                "fee", 100
+                        )))
+                .toEntity();
+
+        EventDigest refundEventDigest = EventDigest.fromEventList(List.of(refundEvent));
+        when(mockEventService.getEventDigestForResource(refundEvent)).thenReturn(refundEventDigest);
+        EventDigest paymentEventDigest = EventDigest.fromEventList(List.of(paymentEvent1, paymentEvent2, paymentEvent3));
+        when(mockEventService.getEventDigestForResource(paymentExternalId)).thenReturn(paymentEventDigest);
+
+        childTransactionEventProcessor.process(refundEvent, true);
+
+        verify(mockTransactionService).upsertTransaction(transactionEntityArgumentCaptor.capture());
+
+        TransactionEntity transactionEntity = transactionEntityArgumentCaptor.getValue();
+        // these fields come from the refund events
+        assertThat(transactionEntity.getAmount(), is(99L));
+        assertThat(transactionEntity.getGatewayTransactionId(), is("a-gateway-id"));
+        assertThat(transactionEntity.getNetAmount(), is(nullValue()));
+        assertThat(transactionEntity.getTotalAmount(), is(nullValue()));
+        assertThat(transactionEntity.getFee(), is(nullValue()));
+
+        // these fields come from the payment events
+        assertThat(transactionEntity.getReference(), is(paymentEventDigest.getEventAggregate().get("reference")));
+        assertThat(transactionEntity.getCardBrand(), is(paymentEventDigest.getEventAggregate().get("card_brand")));
+        assertThat(transactionEntity.getCardholderName(), is(paymentEventDigest.getEventAggregate().get("cardholder_name")));
+        assertThat(transactionEntity.getFirstDigitsCardNumber(), is(paymentEventDigest.getEventAggregate().get("first_digits_card_number")));
+        assertThat(transactionEntity.getLastDigitsCardNumber(), is(paymentEventDigest.getEventAggregate().get("last_digits_card_number")));
+        assertThat(transactionEntity.getDescription(), is(paymentEventDigest.getEventAggregate().get("description")));
+        assertThat(transactionEntity.getEmail(), is(paymentEventDigest.getEventAggregate().get("email")));
+
+        JsonObject transactionDetails = JsonParser.parseString(transactionEntity.getTransactionDetails()).getAsJsonObject();
+        assertThat(transactionDetails.get("payment_details").getAsJsonObject(), is(notNullValue()));
+        assertThat(transactionDetails.get("payment_details").getAsJsonObject().get("card_type").getAsString(), is("DEBIT"));
+    }
+
+    @Test
+    void shouldProjectRefundTransactionWithoutPaymentInformationIfUnavailable() {
+        String refundExternalId = "refund-external-id";
+        String paymentExternalId = "payment-external-id";
+
+        Event refundEvent = anEventFixture()
+                .withResourceType(REFUND)
+                .withEventType("REFUND_SUCCEEDED")
+                .withResourceExternalId(refundExternalId)
+                .withParentResourceExternalId(paymentExternalId)
+                .toEntity();
+
+        EventDigest refundEventDigest = EventDigest.fromEventList(List.of(refundEvent));
+        when(mockEventService.getEventDigestForResource(refundEvent)).thenReturn(refundEventDigest);
+        when(mockEventService.getEventDigestForResource(paymentExternalId)).thenThrow(EmptyEventsException.class);
+
+        childTransactionEventProcessor.process(refundEvent, true);
+
+        verify(mockTransactionService).upsertTransactionFor(refundEventDigest);
+    }
+
+    @Test
+    void shouldIncludePaymentInformationWhenChildTransactionReprojected() {
 
         String paymentEventData = new GsonBuilder().create()
                 .toJson(ImmutableMap.builder()
@@ -74,18 +173,18 @@ class ChildTransactionEventProcessorTest {
 
         String refundEventData = new GsonBuilder().create()
                 .toJson(ImmutableMap.builder()
-                .put("amount", -50)
-                .put("some_refund_info", "blah")
-                .build());
+                        .put("amount", -50)
+                        .put("some_refund_info", "blah")
+                        .build());
         Event refundEvent = anEventFixture().withEventData(refundEventData).toEntity();
         EventDigest refundEventDigest = EventDigest.fromEventList(List.of(refundEvent));
 
         String refundExternalId = "refund-external-id";
-        when(eventService.getEventDigestForResource(refundExternalId)).thenReturn(refundEventDigest);
+        when(mockEventService.getEventDigestForResource(refundExternalId)).thenReturn(refundEventDigest);
 
         childTransactionEventProcessor.reprojectChildTransaction(refundExternalId, paymentEventDigest);
 
-        verify(transactionService).upsertTransaction(transactionEntityArgumentCaptor.capture());
+        verify(mockTransactionService).upsertTransaction(transactionEntityArgumentCaptor.capture());
 
         TransactionEntity transactionEntity = transactionEntityArgumentCaptor.getValue();
         assertThat(transactionEntity.getReference(), is("payment-ref"));
@@ -99,61 +198,61 @@ class ChildTransactionEventProcessorTest {
 
     @Test
     void shouldNotProjectTestDisputeIfBeforeEnabledDate() {
-        when(clock.instant()).thenReturn(Instant.parse("2022-07-08T00:00:00Z"));
+        when(mockClock.instant()).thenReturn(Instant.parse("2022-07-08T00:00:00Z"));
         QueueMessageReceiverConfig mockQueueMessageReceiverConfig = mock(QueueMessageReceiverConfig.class);
-        when(ledgerConfig.getQueueMessageReceiverConfig()).thenReturn(mockQueueMessageReceiverConfig);
+        when(mockLedgerConfig.getQueueMessageReceiverConfig()).thenReturn(mockQueueMessageReceiverConfig);
         when(mockQueueMessageReceiverConfig.getProjectTestPaymentsDisputeEventsFromDate()).thenReturn(Instant.parse("2022-07-08T00:00:01Z"));
 
         Event disputeEvent = anEventFixture().withResourceType(ResourceType.DISPUTE).withLive(false).toEntity();
-        when(eventService.getEventDigestForResource(disputeEvent)).thenReturn(EventDigest.fromEventList(List.of(disputeEvent)));
+        when(mockEventService.getEventDigestForResource(disputeEvent)).thenReturn(EventDigest.fromEventList(List.of(disputeEvent)));
         childTransactionEventProcessor.process(disputeEvent, true);
 
-        verify(transactionService, never()).upsertTransaction(any());
-        verify(transactionService, never()).upsertTransactionFor(any());
+        verify(mockTransactionService, never()).upsertTransaction(any());
+        verify(mockTransactionService, never()).upsertTransactionFor(any());
     }
 
     @Test
     void shouldNotProjectLiveDisputeIfBeforeEnabledDate() {
-        when(clock.instant()).thenReturn(Instant.parse("2022-07-08T00:00:00Z"));
+        when(mockClock.instant()).thenReturn(Instant.parse("2022-07-08T00:00:00Z"));
         QueueMessageReceiverConfig mockQueueMessageReceiverConfig = mock(QueueMessageReceiverConfig.class);
-        when(ledgerConfig.getQueueMessageReceiverConfig()).thenReturn(mockQueueMessageReceiverConfig);
+        when(mockLedgerConfig.getQueueMessageReceiverConfig()).thenReturn(mockQueueMessageReceiverConfig);
         when(mockQueueMessageReceiverConfig.getProjectLivePaymentsDisputeEventsFromDate()).thenReturn(Instant.parse("2022-07-08T00:00:01Z"));
 
         Event disputeEvent = anEventFixture().withResourceType(ResourceType.DISPUTE).withLive(true).toEntity();
-        when(eventService.getEventDigestForResource(disputeEvent)).thenReturn(EventDigest.fromEventList(List.of(disputeEvent)));
+        when(mockEventService.getEventDigestForResource(disputeEvent)).thenReturn(EventDigest.fromEventList(List.of(disputeEvent)));
         childTransactionEventProcessor.process(disputeEvent, true);
 
-        verify(transactionService, never()).upsertTransaction(any());
-        verify(transactionService, never()).upsertTransactionFor(any());
+        verify(mockTransactionService, never()).upsertTransaction(any());
+        verify(mockTransactionService, never()).upsertTransactionFor(any());
     }
 
     @Test
     void shouldProjectTestDisputeIfAfterEnabledDate() {
-        when(clock.instant()).thenReturn(Instant.parse("2022-07-08T00:00:01Z"));
+        when(mockClock.instant()).thenReturn(Instant.parse("2022-07-08T00:00:01Z"));
         QueueMessageReceiverConfig mockQueueMessageReceiverConfig = mock(QueueMessageReceiverConfig.class);
-        when(ledgerConfig.getQueueMessageReceiverConfig()).thenReturn(mockQueueMessageReceiverConfig);
+        when(mockLedgerConfig.getQueueMessageReceiverConfig()).thenReturn(mockQueueMessageReceiverConfig);
         when(mockQueueMessageReceiverConfig.getProjectTestPaymentsDisputeEventsFromDate()).thenReturn(Instant.parse("2022-07-08T00:00:00Z"));
 
         Event disputeEvent = anEventFixture().withResourceType(ResourceType.DISPUTE).withLive(false).toEntity();
         EventDigest eventDigest = EventDigest.fromEventList(List.of(disputeEvent));
-        when(eventService.getEventDigestForResource(disputeEvent)).thenReturn(eventDigest);
+        when(mockEventService.getEventDigestForResource(disputeEvent)).thenReturn(eventDigest);
         childTransactionEventProcessor.process(disputeEvent, true);
 
-        verify(transactionService).upsertTransactionFor(eventDigest);
+        verify(mockTransactionService).upsertTransactionFor(eventDigest);
     }
 
     @Test
     void shouldProjectLiveDisputeIfAfterEnabledDate() {
-        when(clock.instant()).thenReturn(Instant.parse("2022-07-08T00:00:01Z"));
+        when(mockClock.instant()).thenReturn(Instant.parse("2022-07-08T00:00:01Z"));
         QueueMessageReceiverConfig mockQueueMessageReceiverConfig = mock(QueueMessageReceiverConfig.class);
-        when(ledgerConfig.getQueueMessageReceiverConfig()).thenReturn(mockQueueMessageReceiverConfig);
+        when(mockLedgerConfig.getQueueMessageReceiverConfig()).thenReturn(mockQueueMessageReceiverConfig);
         when(mockQueueMessageReceiverConfig.getProjectLivePaymentsDisputeEventsFromDate()).thenReturn(Instant.parse("2022-07-08T00:00:00Z"));
 
         Event disputeEvent = anEventFixture().withResourceType(ResourceType.DISPUTE).withLive(true).toEntity();
         EventDigest eventDigest = EventDigest.fromEventList(List.of(disputeEvent));
-        when(eventService.getEventDigestForResource(disputeEvent)).thenReturn(eventDigest);
+        when(mockEventService.getEventDigestForResource(disputeEvent)).thenReturn(eventDigest);
         childTransactionEventProcessor.process(disputeEvent, true);
 
-        verify(transactionService).upsertTransactionFor(eventDigest);
+        verify(mockTransactionService).upsertTransactionFor(eventDigest);
     }
 }

--- a/src/test/java/uk/gov/pay/ledger/queue/eventprocessor/PaymentEventProcessorTest.java
+++ b/src/test/java/uk/gov/pay/ledger/queue/eventprocessor/PaymentEventProcessorTest.java
@@ -165,4 +165,19 @@ class PaymentEventProcessorTest {
         paymentEventProcessor.process(event, false);
         verifyNoInteractions(transactionSummaryService);
     }
+
+    @Test
+    void shouldReprojectTransactionMetadataIfReprojectEvent() {
+        Event event = anEventFixture()
+                .withResourceType(PAYMENT)
+                .withIsReprojectDomainObject(true)
+                .toEntity();
+
+        when(eventService.getEventsForResource(event.getResourceExternalId())).thenReturn(List.of(anEventFixture().toEntity()));
+        paymentEventProcessor.process(event, true);
+
+        verify(transactionService).upsertTransactionFor(any(EventDigest.class));
+        verify(transactionMetadataService).reprojectFromEventDigest(any(EventDigest.class));
+        verify(transactionMetadataService, never()).upsertMetadataFor(event);
+    }
 }

--- a/src/test/java/uk/gov/pay/ledger/queue/eventprocessor/PaymentInstrumentEventProcessorTest.java
+++ b/src/test/java/uk/gov/pay/ledger/queue/eventprocessor/PaymentInstrumentEventProcessorTest.java
@@ -1,0 +1,42 @@
+package uk.gov.pay.ledger.queue.eventprocessor;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.pay.ledger.agreement.service.AgreementService;
+import uk.gov.pay.ledger.event.model.Event;
+import uk.gov.pay.ledger.event.model.EventDigest;
+import uk.gov.pay.ledger.event.service.EventService;
+
+import java.util.List;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static uk.gov.pay.ledger.event.model.ResourceType.PAYMENT_INSTRUMENT;
+import static uk.gov.pay.ledger.util.fixture.EventFixture.anEventFixture;
+
+@ExtendWith(MockitoExtension.class)
+class PaymentInstrumentEventProcessorTest {
+    @Mock
+    EventService mockEventService;
+
+    @Mock
+    AgreementService mockAgreementService;
+
+    @InjectMocks
+    PaymentInstrumentEventProcessor paymentInstrumentEventProcessor;
+
+    @Test
+    void shouldUpsertPaymentInstrument() {
+        Event event = anEventFixture().withResourceType(PAYMENT_INSTRUMENT).toEntity();
+        var eventDigest = EventDigest.fromEventList(List.of(anEventFixture().toEntity()));
+        when(mockEventService.getEventDigestForResource(event)).thenReturn(eventDigest);
+
+        paymentInstrumentEventProcessor.process(event, true);
+
+        verify(mockEventService).getEventDigestForResource(event);
+        verify(mockAgreementService).upsertPaymentInstrumentFor(eventDigest);
+    }
+}

--- a/src/test/java/uk/gov/pay/ledger/queue/eventprocessor/PayoutEventProcessorTest.java
+++ b/src/test/java/uk/gov/pay/ledger/queue/eventprocessor/PayoutEventProcessorTest.java
@@ -1,0 +1,43 @@
+package uk.gov.pay.ledger.queue.eventprocessor;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.pay.ledger.event.model.Event;
+import uk.gov.pay.ledger.event.model.EventDigest;
+import uk.gov.pay.ledger.event.service.EventService;
+import uk.gov.pay.ledger.payout.service.PayoutService;
+
+import java.util.List;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static uk.gov.pay.ledger.event.model.ResourceType.PAYOUT;
+import static uk.gov.pay.ledger.util.fixture.EventFixture.anEventFixture;
+
+@ExtendWith(MockitoExtension.class)
+class PayoutEventProcessorTest {
+
+    @Mock
+    EventService mockEventService;
+
+    @Mock
+    PayoutService mockPayoutService;
+
+    @InjectMocks
+    PayoutEventProcessor payoutEventProcessor;
+
+    @Test
+    void shouldUpsertPayout() {
+        Event event = anEventFixture().withResourceType(PAYOUT).toEntity();
+        var eventDigest = EventDigest.fromEventList(List.of(anEventFixture().toEntity()));
+        when(mockEventService.getEventDigestForResource(event)).thenReturn(eventDigest);
+
+        payoutEventProcessor.process(event, true);
+
+        verify(mockEventService).getEventDigestForResource(event);
+        verify(mockPayoutService).upsertPayoutFor(eventDigest);
+    }
+}


### PR DESCRIPTION
This test was kind of a hybrid integration/unit test, which was performing some unit testing of the EventProcessor implementations.

Move all unit testing of the EventProcessors to dedicated unit tests.

Make EventDigestHandlerTest a pure unit test, so that it is only testing that the correct EventProcessor is selected.