### PR TITLE
PP-9788 Update DisputeCreated pact test

### DIFF
--- a/src/test/java/uk/gov/pay/ledger/pact/DisputeLostEventQueueContractTest.java
+++ b/src/test/java/uk/gov/pay/ledger/pact/DisputeLostEventQueueContractTest.java
@@ -8,12 +8,12 @@ import au.com.dius.pact.model.v3.messaging.MessagePact;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.gson.GsonBuilder;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import uk.gov.pay.ledger.event.dao.EventDao;
 import uk.gov.pay.ledger.event.model.Event;
+import uk.gov.pay.ledger.event.model.SalientEventType;
 import uk.gov.pay.ledger.rule.AppWithPostgresAndSqsRule;
 import uk.gov.pay.ledger.rule.SqsTestDocker;
 import uk.gov.pay.ledger.util.DatabaseTestHelper;
@@ -44,7 +44,6 @@ public class DisputeLostEventQueueContractTest {
             config("queueMessageReceiverConfig.backgroundProcessingEnabled", "true")
     );
 
-    private GsonBuilder gsonBuilder = new GsonBuilder();
     private byte[] currentMessage;
     private String paymentExternalId = "payment-external-id";
     private final long fee = 1500L;
@@ -62,19 +61,13 @@ public class DisputeLostEventQueueContractTest {
 
     @Pact(provider = "connector", consumer = "ledger")
     public MessagePact createDisputeLostEventPact(MessagePactBuilder builder) {
-        String eventData = gsonBuilder.create()
-                .toJson(Map.of(
-                        "fee", fee,
-                        "gateway_account_id", gatewayAccountId,
-                        "amount", amount
-                ));
         eventFixture = QueueDisputeEventFixture.aQueueDisputeEventFixture()
                 .withLive(true)
                 .withResourceExternalId(paymentExternalId)
                 .withParentResourceExternalId(parentsResourceExternalId)
                 .withEventDate(disputeCreated)
                 .withServiceId(serviceId)
-                .withEventData(eventData)
+                .withDefaultEventDataForEventType(SalientEventType.DISPUTE_LOST.name())
                 .withEventType("DISPUTE_LOST")
                 .withServiceId(serviceId);
 

--- a/src/test/java/uk/gov/pay/ledger/util/fixture/QueueDisputeEventFixture.java
+++ b/src/test/java/uk/gov/pay/ledger/util/fixture/QueueDisputeEventFixture.java
@@ -10,12 +10,11 @@ import uk.gov.pay.ledger.event.model.ResourceType;
 import java.time.ZonedDateTime;
 
 import static org.apache.commons.lang3.RandomStringUtils.randomAlphanumeric;
-import static org.apache.commons.lang3.StringUtils.EMPTY;
 import static uk.gov.pay.ledger.event.model.ResourceType.DISPUTE;
 
 public class QueueDisputeEventFixture implements QueueFixture<QueueDisputeEventFixture, Event> {
     private String sqsMessageId;
-    private String serviceId = randomAlphanumeric(10);;
+    private String serviceId = randomAlphanumeric(10);
     private Boolean live = true;
     private ResourceType resourceType = DISPUTE;
     private String resourceExternalId = randomAlphanumeric(20);
@@ -77,9 +76,7 @@ public class QueueDisputeEventFixture implements QueueFixture<QueueDisputeEventF
             case "DISPUTE_CREATED":
                 eventData = new GsonBuilder().create()
                         .toJson(ImmutableMap.builder()
-                                .put("fee", 1500)
-                                .put("evidence_due_date", 1644883199)
-                                .put("gateway_account_id", gatewayAccountId)
+                                .put("gateway_account_id", "a-gateway-account-id")
                                 .put("amount", 6500)
                                 .put("reason", "duplicate")
                                 .build());
@@ -89,9 +86,9 @@ public class QueueDisputeEventFixture implements QueueFixture<QueueDisputeEventF
                         .toJson(ImmutableMap.builder()
                                 .put("fee", 1500)
                                 .put("amount", 6500)
-                                .put("net_amount", -8000)
-                                .put("gateway_account_id", gatewayAccountId)
+                                .put("gateway_account_id", "a-gateway-account-id")
                                 .build());
+                break;
             default:
                 eventData = new GsonBuilder().create()
                         .toJson(ImmutableMap.of("event_data", "event_data"));


### PR DESCRIPTION
## WHAT
- Removed `fee` from DisputeCreated fixture as Connector will be sending `fee` only for DISPUTE_LOST event
- Removed `evidence_due_date` from DisputeCreated event fixture. To be added back once connector starts sending evidence_due_date value as a `date` instead of timestamp.