### PR TITLE
PP-9788 Read evidence_date as date instead of epoch

### DIFF
--- a/src/main/java/uk/gov/pay/ledger/transaction/model/TransactionFactory.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/model/TransactionFactory.java
@@ -21,7 +21,6 @@ import static uk.gov.pay.ledger.util.JsonParser.safeGetAsBoolean;
 import static uk.gov.pay.ledger.util.JsonParser.safeGetAsDate;
 import static uk.gov.pay.ledger.util.JsonParser.safeGetAsLong;
 import static uk.gov.pay.ledger.util.JsonParser.safeGetAsString;
-import static uk.gov.pay.ledger.util.JsonParser.safeGetEpochLongAsDate;
 
 public class TransactionFactory {
 
@@ -213,7 +212,7 @@ public class TransactionFactory {
                     .withState(entity.getState())
                     .withCreatedDate(entity.getCreatedDate())
                     .withGatewayTransactionId(entity.getGatewayTransactionId())
-                    .withEvidenceDueDate(safeGetEpochLongAsDate(transactionDetails, "evidence_due_date"))
+                    .withEvidenceDueDate(safeGetAsDate(transactionDetails, "evidence_due_date"))
                     .withReason(DisputeReasonMapper.mapToApi(safeGetAsString(transactionDetails, "reason")))
                     .withSettlementSummary(settlementSummary)
                     .withLive(entity.isLive())

--- a/src/main/java/uk/gov/pay/ledger/util/JsonParser.java
+++ b/src/main/java/uk/gov/pay/ledger/util/JsonParser.java
@@ -41,15 +41,6 @@ public class JsonParser {
                 .orElse(null);
     }
 
-    public static ZonedDateTime safeGetEpochLongAsDate(JsonNode object, String fieldName) {
-        Optional<Long> mightBeEpochSecond = safeGetJsonElement(object, fieldName).map(JsonNode::longValue);
-
-        return mightBeEpochSecond.map(epochSecond -> {
-            Instant instant = Instant.ofEpochSecond(epochSecond);
-            return ZonedDateTime.ofInstant(instant, ZoneOffset.UTC);
-        }).orElse(null);
-    }
-
     private static Optional<JsonNode> safeGetJsonElement(JsonNode object, String fieldName) {
         if (object == null) {
             return Optional.empty();

--- a/src/test/java/uk/gov/pay/ledger/transaction/model/TransactionFactoryTest.java
+++ b/src/test/java/uk/gov/pay/ledger/transaction/model/TransactionFactoryTest.java
@@ -295,7 +295,7 @@ public class TransactionFactoryTest {
     public void createsDispute() {
         var createdDate = ZonedDateTime.parse("2022-06-08T11:22:48.822408Z");
         var paidOutDate = ZonedDateTime.parse("2022-07-08T12:20:07.073Z");
-        var evidenceDueDate = 1652223599L;
+        var evidenceDueDate = "2022-05-10T22:59:59.000000Z";
         TransactionEntity parentTransactionEntity = aTransactionFixture()
                 .withTransactionType("PAYMENT")
                 .withDefaultCardDetails()
@@ -324,7 +324,7 @@ public class TransactionFactoryTest {
                 .withAmount(1000L)
                 .withNetAmount(-2500L)
                 .withGatewayTransactionId("gateway-transaction-id")
-                .withTransactionDetails("{\"amount\": 1000, \"payment_details\": {\"card_type\": \"CREDIT\", \"expiry_date\": \"11/23\", \"card_brand_label\": \"Visa\"}, \"gateway_account_id\": \"1\", \"gateway_transaction_id\": \"du_dl20kdldj20ejs103jns\", \"reason\": \"fraudulent\", \"evidence_due_date\": " + evidenceDueDate + "}")
+                .withTransactionDetails("{\"amount\": 1000, \"payment_details\": {\"card_type\": \"CREDIT\", \"expiry_date\": \"11/23\", \"card_brand_label\": \"Visa\"}, \"gateway_account_id\": \"1\", \"gateway_transaction_id\": \"du_dl20kdldj20ejs103jns\", \"reason\": \"fraudulent\", \"evidence_due_date\": \"" + evidenceDueDate + "\"}")
                 .withEventCount(3)
                 .withCardBrand(parentTransactionEntity.getCardBrand())
                 .withFee(1500L)
@@ -340,7 +340,7 @@ public class TransactionFactoryTest {
 
         assertThat(transaction.getReason(), is("fraudulent"));
         assertThat(transaction.getParentTransactionId(), is(parentTransactionEntity.getExternalId()));
-        assertThat(transaction.getEvidenceDueDate(), is(ZonedDateTime.ofInstant(Instant.ofEpochSecond(evidenceDueDate), ZoneOffset.UTC)));
+        assertThat(transaction.getEvidenceDueDate(), is(ZonedDateTime.parse(evidenceDueDate)));
         assertThat(transaction.getNetAmount(), is(-2500L));
         assertThat(transaction.getSettlementSummary().getSettledDate().isPresent(), is(true));
         assertThat(transaction.getSettlementSummary().getSettledDate(), is(Optional.of("2022-07-08")));

--- a/src/test/java/uk/gov/pay/ledger/transaction/resource/TransactionResourceIT.java
+++ b/src/test/java/uk/gov/pay/ledger/transaction/resource/TransactionResourceIT.java
@@ -22,6 +22,7 @@ import java.time.format.DateTimeFormatter;
 
 import static io.restassured.RestAssured.given;
 import static io.restassured.http.ContentType.JSON;
+import static java.time.ZoneOffset.UTC;
 import static org.apache.commons.lang3.RandomStringUtils.randomAlphanumeric;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
@@ -409,7 +410,7 @@ public class TransactionResourceIT {
     public void shouldGetDisputeTransaction() {
         var createdDate = ZonedDateTime.parse("2022-06-08T11:22:48.822408Z");
         var paidOutDate = ZonedDateTime.parse("2022-07-08T12:20:07.073Z");
-        var evidenceDueDate = 1652223599L;
+        ZonedDateTime evidenceDueDate = ZonedDateTime.parse("2022-05-10T22:59:59.000000Z");
 
         TransactionEntity parentTransactionEntity = aTransactionFixture()
                 .withTransactionType("PAYMENT")
@@ -433,7 +434,7 @@ public class TransactionResourceIT {
                 .withAmount(1000L)
                 .withNetAmount(-2500L)
                 .withGatewayTransactionId("gateway-transaction-id")
-                .withTransactionDetails("{\"amount\": 1000, \"payment_details\": {\"card_type\": \"CREDIT\", \"expiry_date\": \"11/23\", \"card_brand_label\": \"Visa\"}, \"gateway_account_id\": \"1\", \"gateway_transaction_id\": \"du_dl20kdldj20ejs103jns\", \"reason\": \"fraudulent\", \"evidence_due_date\": " + evidenceDueDate + "}")
+                .withTransactionDetails("{\"amount\": 1000, \"payment_details\": {\"card_type\": \"CREDIT\", \"expiry_date\": \"11/23\", \"card_brand_label\": \"Visa\"}, \"gateway_account_id\": \"1\", \"gateway_transaction_id\": \"du_dl20kdldj20ejs103jns\", \"reason\": \"fraudulent\", \"evidence_due_date\": \"" + evidenceDueDate + "\"}")
                 .withEventCount(3)
                 .withCardBrand(parentTransactionEntity.getCardBrand())
                 .withFee(1500L)
@@ -472,7 +473,7 @@ public class TransactionResourceIT {
                 .body("state.status", is("lost"))
                 .body("created_date", is(ISO_INSTANT_MILLISECOND_PRECISION.format(createdDate)))
                 .body("gateway_transaction_id", is(disputeTransactionEntity.getGatewayTransactionId()))
-                .body("evidence_due_date", is(ISO_INSTANT_MILLISECOND_PRECISION.format(ZonedDateTime.ofInstant(Instant.ofEpochSecond(evidenceDueDate), ZoneOffset.UTC))))
+                .body("evidence_due_date", is(ISO_INSTANT_MILLISECOND_PRECISION.format(evidenceDueDate)))
                 .body("reason", is("fraudulent"))
                 .body("settlement_summary.settled_date", is(paidOutDate.format(DateTimeFormatter.ofPattern("yyyy-MM-dd"))))
                 .body("transaction_type", is("DISPUTE"))

--- a/src/test/java/uk/gov/pay/ledger/transaction/resource/TransactionResourceSearchIT.java
+++ b/src/test/java/uk/gov/pay/ledger/transaction/resource/TransactionResourceSearchIT.java
@@ -15,13 +15,13 @@ import uk.gov.pay.ledger.util.fixture.TransactionFixture;
 
 import javax.ws.rs.core.Response;
 import java.time.Instant;
-import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
 
 import static io.restassured.RestAssured.given;
 import static io.restassured.http.ContentType.JSON;
+import static java.time.ZoneOffset.UTC;
 import static java.time.ZonedDateTime.now;
 import static org.apache.commons.lang3.RandomStringUtils.randomAlphanumeric;
 import static org.apache.commons.lang3.RandomUtils.nextLong;
@@ -606,7 +606,7 @@ public class TransactionResourceSearchIT {
     @Test
     public void shouldSearchCorrectlyUsingDisputeType() {
         String gatewayAccountId = "1";
-        ZonedDateTime paidOutDate = ZonedDateTime.now();
+        ZonedDateTime paidOutDate = ZonedDateTime.now(UTC);
 
         TransactionFixture parentTransactionEntity = aTransactionFixture()
                 .withTransactionType("PAYMENT")
@@ -627,7 +627,7 @@ public class TransactionResourceSearchIT {
                 .withState(TransactionState.DISPUTE_LOST)
                 .withAmount(1000L)
                 .withNetAmount(-2500L)
-                .withTransactionDetails("{\"amount\": 1000, \"payment_details\": {\"card_type\": \"CREDIT\", \"expiry_date\": \"11/23\", \"card_brand_label\": \"Visa\"}, \"gateway_account_id\": \"1\", \"gateway_transaction_id\": \"du_dl20kdldj20ejs103jnc\", \"reason\": \"fraudulent\", \"evidence_due_date\": 1652223599}")
+                .withTransactionDetails("{\"amount\": 1000, \"payment_details\": {\"card_type\": \"CREDIT\", \"expiry_date\": \"11/23\", \"card_brand_label\": \"Visa\"}, \"gateway_account_id\": \"1\", \"gateway_transaction_id\": \"du_dl20kdldj20ejs103jnc\", \"reason\": \"fraudulent\", \"evidence_due_date\": \"2022-05-10T22:59:59.000Z\"}")
                 .withEventCount(3)
                 .withCardBrand(parentTransactionEntity.getCardBrand())
                 .withFee(1500L)
@@ -667,7 +667,7 @@ public class TransactionResourceSearchIT {
                 .body("results[0].state.status", is("lost"))
                 .body("results[0].created_date", is(is(ISO_INSTANT_MILLISECOND_PRECISION.format(disputeLost.getCreatedDate()))))
                 .body("results[0].gateway_transaction_id", is(disputeLost.getGatewayTransactionId()))
-                .body("results[0].evidence_due_date", is(ISO_INSTANT_MILLISECOND_PRECISION.format(ZonedDateTime.ofInstant(Instant.ofEpochSecond(1652223599L), ZoneOffset.UTC))))
+                .body("results[0].evidence_due_date", is("2022-05-10T22:59:59.000Z"))
                 .body("results[0].reason", is("fraudulent"))
                 .body("results[0].settlement_summary.settled_date", is(paidOutDate.format(DateTimeFormatter.ofPattern("yyyy-MM-dd"))))
                 .body("results[0].transaction_type", is("DISPUTE"))
@@ -729,7 +729,7 @@ public class TransactionResourceSearchIT {
                 .withTransactionType("DISPUTE")
                 .withState(TransactionState.DISPUTE_WON)
                 .withAmount(1000L)
-                .withTransactionDetails("{\"amount\": 1000, \"payment_details\": {\"card_type\": \"CREDIT\", \"expiry_date\": \"11/23\", \"card_brand_label\": \"Visa\"}, \"gateway_account_id\": \"1\", \"gateway_transaction_id\": \"du_dl20kdldj20ejs103jny\", \"reason\": \"fraudulent\", \"evidence_due_date\": 1652223599}")
+                .withTransactionDetails("{\"amount\": 1000, \"payment_details\": {\"card_type\": \"CREDIT\", \"expiry_date\": \"11/23\", \"card_brand_label\": \"Visa\"}, \"gateway_account_id\": \"1\", \"gateway_transaction_id\": \"du_dl20kdldj20ejs103jny\", \"reason\": \"fraudulent\", \"evidence_due_date\": \"2022-05-10T22:59:59.000Z\"}")
                 .withEventCount(3)
                 .withCardBrand(parentTransactionEntity2.getCardBrand())
                 .withGatewayTransactionId("du_dl20kdldj20ejs103jny")
@@ -757,7 +757,7 @@ public class TransactionResourceSearchIT {
                 .withTransactionType("DISPUTE")
                 .withState(TransactionState.DISPUTE_NEEDS_RESPONSE)
                 .withAmount(1800L)
-                .withTransactionDetails("{\"amount\": 1000, \"payment_details\": {\"card_type\": \"CREDIT\", \"expiry_date\": \"11/23\", \"card_brand_label\": \"Visa\"}, \"gateway_account_id\": \"1\", \"gateway_transaction_id\": \"du_dl20kdldj20ejs103jng\", \"reason\": \"fraudulent\", \"evidence_due_date\": 1652223599}")
+                .withTransactionDetails("{\"amount\": 1000, \"payment_details\": {\"card_type\": \"CREDIT\", \"expiry_date\": \"11/23\", \"card_brand_label\": \"Visa\"}, \"gateway_account_id\": \"1\", \"gateway_transaction_id\": \"du_dl20kdldj20ejs103jng\", \"reason\": \"fraudulent\", \"evidence_due_date\": \"2022-05-10T22:59:59Z\"}")
                 .withEventCount(3)
                 .withCardBrand(parentTransactionEntity3.getCardBrand())
                 .withGatewayTransactionId("du_dl20kdldj20ejs103jng")
@@ -788,7 +788,7 @@ public class TransactionResourceSearchIT {
                 .body("results[0].state.status", is("won"))
                 .body("results[0].created_date", is(is(ISO_INSTANT_MILLISECOND_PRECISION.format(disputeWon.getCreatedDate()))))
                 .body("results[0].gateway_transaction_id", is(disputeWon.getGatewayTransactionId()))
-                .body("results[0].evidence_due_date", is(ISO_INSTANT_MILLISECOND_PRECISION.format(ZonedDateTime.ofInstant(Instant.ofEpochSecond(1652223599L), ZoneOffset.UTC))))
+                .body("results[0].evidence_due_date", is("2022-05-10T22:59:59.000Z"))
                 .body("results[0].reason", is("fraudulent"))
                 .body("results[0].settlement_summary.settled_date", is(nullValue()))
                 .body("results[0].transaction_type", is("DISPUTE"))
@@ -805,7 +805,7 @@ public class TransactionResourceSearchIT {
                 .body("results[1].state.status", is("needs_response"))
                 .body("results[1].created_date", is(is(ISO_INSTANT_MILLISECOND_PRECISION.format(disputeNeedsResponse.getCreatedDate()))))
                 .body("results[1].gateway_transaction_id", is(disputeNeedsResponse.getGatewayTransactionId()))
-                .body("results[1].evidence_due_date", is(ISO_INSTANT_MILLISECOND_PRECISION.format(ZonedDateTime.ofInstant(Instant.ofEpochSecond(1652223599L), ZoneOffset.UTC))))
+                .body("results[1].evidence_due_date", is(ISO_INSTANT_MILLISECOND_PRECISION.format(ZonedDateTime.ofInstant(Instant.ofEpochSecond(1652223599L), UTC))))
                 .body("results[1].reason", is("fraudulent"))
                 .body("results[1].settlement_summary.settled_date", is(nullValue()))
                 .body("results[1].transaction_type", is("DISPUTE"))
@@ -817,7 +817,7 @@ public class TransactionResourceSearchIT {
     @Test
     public void shouldSearchCorrectlyUsingState() {
         String gatewayAccountId = "1";
-        ZonedDateTime paidOutDate = ZonedDateTime.now();
+        ZonedDateTime paidOutDate = ZonedDateTime.now(UTC);
 
         TransactionFixture parentTransactionEntity = aTransactionFixture()
                 .withTransactionType("PAYMENT")
@@ -838,7 +838,7 @@ public class TransactionResourceSearchIT {
                 .withState(TransactionState.DISPUTE_LOST)
                 .withAmount(1000L)
                 .withNetAmount(-2500L)
-                .withTransactionDetails("{\"amount\": 1000, \"payment_details\": {\"card_type\": \"CREDIT\", \"expiry_date\": \"11/23\", \"card_brand_label\": \"Visa\"}, \"gateway_account_id\": \"1\", \"gateway_transaction_id\": \"du_dl20kdldj20ejs103jnx\", \"reason\": \"fraudulent\", \"evidence_due_date\": 1652223599}")
+                .withTransactionDetails("{\"amount\": 1000, \"payment_details\": {\"card_type\": \"CREDIT\", \"expiry_date\": \"11/23\", \"card_brand_label\": \"Visa\"}, \"gateway_account_id\": \"1\", \"gateway_transaction_id\": \"du_dl20kdldj20ejs103jnx\", \"reason\": \"fraudulent\", \"evidence_due_date\": \"2022-05-10T22:59:59Z\"}")
                 .withEventCount(3)
                 .withCardBrand(parentTransactionEntity.getCardBrand())
                 .withFee(1500L)
@@ -878,7 +878,7 @@ public class TransactionResourceSearchIT {
                 .body("results[0].state.status", is("lost"))
                 .body("results[0].created_date", is(is(ISO_INSTANT_MILLISECOND_PRECISION.format(disputeLost.getCreatedDate()))))
                 .body("results[0].gateway_transaction_id", is(disputeLost.getGatewayTransactionId()))
-                .body("results[0].evidence_due_date", is(ISO_INSTANT_MILLISECOND_PRECISION.format(ZonedDateTime.ofInstant(Instant.ofEpochSecond(1652223599L), ZoneOffset.UTC))))
+                .body("results[0].evidence_due_date", is(ISO_INSTANT_MILLISECOND_PRECISION.format(ZonedDateTime.ofInstant(Instant.ofEpochSecond(1652223599L), UTC))))
                 .body("results[0].reason", is("fraudulent"))
                 .body("results[0].settlement_summary.settled_date", is(paidOutDate.format(DateTimeFormatter.ofPattern("yyyy-MM-dd"))))
                 .body("results[0].transaction_type", is("DISPUTE"))

--- a/src/test/java/uk/gov/pay/ledger/util/JsonParserTest.java
+++ b/src/test/java/uk/gov/pay/ledger/util/JsonParserTest.java
@@ -104,26 +104,4 @@ public class JsonParserTest {
 
         assertThat(value, is(nullValue()));
     }
-
-    @Test
-    public void safeGetEpochLongAsDate_shouldReturnValueIfFieldExists() throws IOException {
-        String data = new GsonBuilder().create()
-                .toJson(ImmutableMap.of("epoch_long", 1652223599L));
-        JsonNode jsonNode = objectMapper.readTree(data);
-
-        ZonedDateTime value = JsonParser.safeGetEpochLongAsDate(jsonNode, "epoch_long");
-
-        assertThat(value.toString(), is("2022-05-10T22:59:59Z"));
-    }
-
-    @Test
-    public void safeGetEpochLongAsDate_shouldReturnNullWhenFieldDoesNotExist() throws IOException {
-        String data = new GsonBuilder().create()
-                .toJson(ImmutableMap.of("somefield", 1652223599L));
-        JsonNode jsonNode = objectMapper.readTree(data);
-
-        ZonedDateTime value = JsonParser.safeGetEpochLongAsDate(jsonNode, "epoch_long");
-
-        assertThat(value, is(nullValue()));
-    }
 }


### PR DESCRIPTION
## WHAT
- Reads evidence_due_date as a date from the database instead of an epoch. Connector to send evidence_due_date in ISO 8601 format as part of DISPUTE_CREATED event.