### PR TITLE
PP-9530 Add agreement id column to transactions

### DIFF
--- a/src/main/resources/migrations/00074_add_agreement_id_column_to_transactions.sql
+++ b/src/main/resources/migrations/00074_add_agreement_id_column_to_transactions.sql
@@ -1,0 +1,8 @@
+--liquibase formatted sql
+
+--changeset uk.gov.pay:add_agreement_id_to_transaction_table
+ALTER TABLE transaction ADD COLUMN agreement_id VARCHAR(32);
+--rollback ALTER TABLE transaction DROP COLUMN agreement_id;
+
+--changeset uk.gov.pay:add_index_on_agreement_id_to_transaction_table runInTransaction:false
+CREATE INDEX CONCURRENTLY transaction_agreement_id_idx ON transaction(agreement_id);


### PR DESCRIPTION
Transaction projections need to be searchable by their agreement id,
move this from the transaction details `jsonb` blob to a table that can
be indexed for lookup.

Run the add index concurrently in order to not lock existing
transactions.