### PR TITLE
PP-9530 Payment transaction entity agreement ID

### DIFF
--- a/src/main/java/uk/gov/pay/ledger/transaction/dao/TransactionDao.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/dao/TransactionDao.java
@@ -140,7 +140,8 @@ public class TransactionDao {
                     "moto, " +
                     "gateway_transaction_id, " +
                     "source, " +
-                    "gateway_payout_id" +
+                    "gateway_payout_id, " +
+                    "agreement_id" +
                     ") " +
                     "VALUES (" +
                     ":externalId," +
@@ -170,7 +171,8 @@ public class TransactionDao {
                     ":moto, " +
                     ":gatewayTransactionId, " +
                     ":source::source, " +
-                    ":gatewayPayoutId" +
+                    ":gatewayPayoutId, " +
+                    ":agreementId" +
                     ") " +
                     "ON CONFLICT (external_id) " +
                     "DO UPDATE SET " +
@@ -201,7 +203,8 @@ public class TransactionDao {
                     "moto = EXCLUDED.moto, " +
                     "gateway_transaction_id = EXCLUDED.gateway_transaction_id, " +
                     "source = EXCLUDED.source, " +
-                    "gateway_payout_id = EXCLUDED.gateway_payout_id " +
+                    "gateway_payout_id = EXCLUDED.gateway_payout_id, " +
+                    "agreement_id = EXCLUDED.agreement_id " +
                     "WHERE EXCLUDED.event_count >= transaction.event_count;";
 
     private static final String GET_SOURCE_TYPE_ENUM_VALUES =

--- a/src/main/java/uk/gov/pay/ledger/transaction/dao/mapper/TransactionMapper.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/dao/mapper/TransactionMapper.java
@@ -48,7 +48,8 @@ public class TransactionMapper implements RowMapper<TransactionEntity> {
                 .withLive(getBooleanWithNullCheck(rs,"live"))
                 .withMoto(rs.getBoolean("moto"))
                 .withGatewayTransactionId(rs.getString("gateway_transaction_id"))
-                .withGatewayPayoutId(rs.getString("gateway_payout_id"));
+                .withGatewayPayoutId(rs.getString("gateway_payout_id"))
+                .withAgreementId(rs.getString("agreement_id"));
         Source.from(rs.getString("source")).ifPresent(transactionBuilder::withSource);
         if (rs.getString("gateway_payout_id") != null) {
             var payoutBuilder = aPayoutEntity()

--- a/src/main/java/uk/gov/pay/ledger/transaction/entity/TransactionEntity.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/entity/TransactionEntity.java
@@ -51,6 +51,7 @@ public class TransactionEntity {
     private Source source;
     private String gatewayPayoutId;
     private PayoutEntity payoutEntity;
+    private String agreementId;
 
     public TransactionEntity() {
     }
@@ -86,6 +87,7 @@ public class TransactionEntity {
         this.source = builder.source;
         this.gatewayPayoutId = builder.gatewayPayoutId;
         this.payoutEntity = builder.payoutEntity;
+        this.agreementId = builder.agreementId;
     }
 
     public Long getId() {
@@ -240,6 +242,10 @@ public class TransactionEntity {
         return gatewayPayoutId;
     }
 
+    public String getAgreementId() {
+        return agreementId;
+    }
+
     public Optional<PayoutEntity> getPayoutEntity() {
         return Optional.ofNullable(payoutEntity);
     }
@@ -289,6 +295,7 @@ public class TransactionEntity {
         private boolean moto;
         private String gatewayPayoutId;
         private PayoutEntity payoutEntity;
+        private String agreementId;
 
         public Builder() {
         }
@@ -444,6 +451,11 @@ public class TransactionEntity {
 
         public Builder withPayoutEntity(PayoutEntity payoutEntity) {
             this.payoutEntity = payoutEntity;
+            return this;
+        }
+
+        public Builder withAgreementId(String agreementId) {
+            this.agreementId = agreementId;
             return this;
         }
     }

--- a/src/main/java/uk/gov/pay/ledger/transaction/model/Payment.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/model/Payment.java
@@ -48,6 +48,7 @@ public class Payment extends Transaction {
     private Source source;
     private String walletType;
     private AuthorisationMode authorisationMode;
+    private String agreementId;
 
     public Payment() {
 
@@ -80,8 +81,8 @@ public class Payment extends Transaction {
         this.live = builder.live;
         this.source = builder.source;
         this.walletType = builder.walletType;
-        this.eventCount = builder.eventCount;
         this.authorisationMode = builder.authorisationMode;
+        this.agreementId = builder.agreementId;
     }
 
     @Override
@@ -199,6 +200,10 @@ public class Payment extends Transaction {
         return authorisationMode;
     }
 
+    public String getAgreementId() {
+        return agreementId;
+    }
+
     public static class Builder {
         public String serviceId;
         private Long id;
@@ -232,6 +237,7 @@ public class Payment extends Transaction {
         private String gatewayPayoutId;
         private String credentialExternalId;
         private AuthorisationMode authorisationMode;
+        private String agreementId;
 
         public Builder() {
         }
@@ -397,6 +403,11 @@ public class Payment extends Transaction {
 
         public Builder withAuthorisationMode(AuthorisationMode authorisationMode) {
             this.authorisationMode = authorisationMode;
+            return this;
+        }
+
+        public Builder withAgreementId(String agreementId) {
+            this.agreementId = agreementId;
             return this;
         }
     }

--- a/src/main/java/uk/gov/pay/ledger/transaction/model/TransactionFactory.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/model/TransactionFactory.java
@@ -125,6 +125,7 @@ public class TransactionFactory {
                     .withWalletType(safeGetAsString(transactionDetails, "wallet"))
                     .withGatewayPayoutId(entity.getGatewayPayoutId())
                     .withAuthorisationMode(authorisationMode)
+                    .withAgreementId(entity.getAgreementId())
                     .build();
         } catch (IOException e) {
             LOGGER.error("Error during the parsing transaction entity data [{}] [errorMessage={}]", entity.getExternalId(), e.getMessage());

--- a/src/main/java/uk/gov/pay/ledger/transaction/search/model/TransactionView.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/search/model/TransactionView.java
@@ -95,6 +95,7 @@ public class TransactionView {
     private ZonedDateTime evidenceDueDate;
     @Schema(example = "fraudulent")
     private String reason;
+    private String agreementId;
 
     public TransactionView(Builder builder) {
         this.id = builder.id;
@@ -135,6 +136,7 @@ public class TransactionView {
         this.paymentDetails = builder.paymentDetails;
         this.evidenceDueDate = builder.evidenceDueDate;
         this.reason = builder.reason;
+        this.agreementId = builder.agreementId;
     }
 
     public TransactionView() {
@@ -176,7 +178,8 @@ public class TransactionView {
                     .withSource(payment.getSource())
                     .withWalletType(payment.getWalletType())
                     .withGatewayPayoutId(payment.getGatewayPayoutId())
-                    .withAuthorisationMode(payment.getAuthorisationMode());
+                    .withAuthorisationMode(payment.getAuthorisationMode())
+                    .withAgreementId(payment.getAgreementId());
             if (payment.getState() != null) {
                 paymentBuilder = paymentBuilder
                         .withState(ExternalTransactionState.from(payment.getState(), statusVersion));
@@ -416,6 +419,10 @@ public class TransactionView {
         return reason;
     }
 
+    public String getAgreementId() {
+        return agreementId;
+    }
+
     public static class Builder {
         private Long id;
         private String gatewayAccountId;
@@ -456,6 +463,7 @@ public class TransactionView {
         private AuthorisationMode authorisationMode;
         private ZonedDateTime evidenceDueDate;
         private String reason;
+        private String agreementId;
 
         public Builder() {
         }
@@ -651,6 +659,11 @@ public class TransactionView {
 
         public Builder withReason(String reason) {
             this.reason = reason;
+            return this;
+        }
+
+        public Builder withAgreementId(String agreementId) {
+            this.agreementId = agreementId;
             return this;
         }
     }

--- a/src/test/java/uk/gov/pay/ledger/event/model/TransactionEntityFactoryTest.java
+++ b/src/test/java/uk/gov/pay/ledger/event/model/TransactionEntityFactoryTest.java
@@ -80,6 +80,7 @@ public class TransactionEntityFactoryTest {
         assertThat(transactionEntity.getSource(), is(notNullValue()));
         assertThat(transactionEntity.isLive(), is(true));
         assertThat(transactionEntity.getGatewayPayoutId(), is("payout-id"));
+        assertThat(transactionEntity.getAgreementId(), is("an-agreement-id"));
 
         JsonObject transactionDetails = JsonParser.parseString(transactionEntity.getTransactionDetails()).getAsJsonObject();
         assertThat(transactionDetails.get("language").getAsString(), is("en"));

--- a/src/test/java/uk/gov/pay/ledger/queue/QueueMessageReceiverForTransactionIT.java
+++ b/src/test/java/uk/gov/pay/ledger/queue/QueueMessageReceiverForTransactionIT.java
@@ -29,6 +29,7 @@ class QueueMessageReceiverForTransactionIT {
 
     private final String gatewayAccountId = "test_gateway_account_id";
     private final String serviceId = "test_service_id";
+    private final String agreementId = "an-agreement-id";
 
     @ParameterizedTest
     @ValueSource(strings = {
@@ -61,6 +62,7 @@ class QueueMessageReceiverForTransactionIT {
                 .body("transaction_id", is(resourceExternalId))
                 .body("service_id", is(serviceId))
                 .body("live", is(live))
+                .body("agreement_id", is(agreementId))
                 .body("moto", is(moto == null ? false : moto));
 
     }
@@ -82,6 +84,7 @@ class QueueMessageReceiverForTransactionIT {
                 .put("address_postcode", "N1 3QU")
                 .put("address_city", "London")
                 .put("source", CARD_API)
+                .put("agreement_id", agreementId)
                 .put("address_country", "GB");
 
         if (moto != null) {

--- a/src/test/java/uk/gov/pay/ledger/transaction/dao/TransactionDaoIT.java
+++ b/src/test/java/uk/gov/pay/ledger/transaction/dao/TransactionDaoIT.java
@@ -45,6 +45,7 @@ class TransactionDaoIT {
                 .withLive(true)
                 .withGatewayTransactionId("gateway_transaction_id")
                 .withGatewayPayoutId("payout-id")
+                .withAgreementId("an-agreement-id")
                 .withDefaultTransactionDetails();
         TransactionEntity transactionEntity = fixture.toEntity();
 
@@ -126,7 +127,7 @@ class TransactionDaoIT {
                 .insert(rule.getJdbi());
 
         TransactionEntity retrievedTransaction = transactionDao.findTransactionByExternalId(fixture.getExternalId()).get();
-        
+
         assertThat(retrievedTransaction.getPayoutEntity().isPresent(), is(true));
         assertThat(retrievedTransaction.getPayoutEntity().get().getPaidOutDate(), is(paidOutDate));
     }
@@ -159,6 +160,7 @@ class TransactionDaoIT {
         assertThat(transaction.getRefundStatus(), is(fixture.getRefundStatus()));
         assertThat(transaction.getGatewayTransactionId(), is(fixture.getGatewayTransactionId()));
         assertThat(transaction.getGatewayPayoutId(), is(fixture.getGatewayPayoutId()));
+        assertThat(transaction.getAgreementId(), is(fixture.getAgreementId()));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/ledger/transaction/resource/TransactionResourceIT.java
+++ b/src/test/java/uk/gov/pay/ledger/transaction/resource/TransactionResourceIT.java
@@ -55,7 +55,8 @@ public class TransactionResourceIT {
                 .withDefaultTransactionDetails()
                 .withLive(Boolean.TRUE)
                 .withSource(String.valueOf(Source.CARD_API))
-                .withGatewayPayoutId(gatewayPayoutId);
+                .withGatewayPayoutId(gatewayPayoutId)
+                .withAgreementId("an-agreement-id");
         transactionFixture.insert(rule.getJdbi());
 
         given().port(port)
@@ -75,6 +76,7 @@ public class TransactionResourceIT {
                 .body("wallet_type", is("APPLE_PAY"))
                 .body("source", is(String.valueOf(Source.CARD_API)))
                 .body("gateway_payout_id", is(gatewayPayoutId))
+                .body("agreement_id", is("an-agreement-id"))
                 .body("authorisation_mode", is("web"));
     }
 

--- a/src/test/java/uk/gov/pay/ledger/util/fixture/QueuePaymentEventFixture.java
+++ b/src/test/java/uk/gov/pay/ledger/util/fixture/QueuePaymentEventFixture.java
@@ -5,7 +5,6 @@ import com.amazonaws.services.sqs.AmazonSQS;
 import com.google.common.collect.ImmutableMap;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonObject;
-import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.StringUtils;
 import uk.gov.service.payments.commons.model.Source;
 import uk.gov.pay.ledger.event.model.Event;
@@ -140,6 +139,7 @@ public class QueuePaymentEventFixture implements QueueFixture<QueuePaymentEventF
                                 .put("source", CARD_API)
                                 .put("address_country", "GB")
                                 .put("authorisation_mode", "web")
+                                .put("agreement_id", "an-agreement-id")
                                 .build());
                 break;
             case "PAYMENT_DETAILS_ENTERED":

--- a/src/test/java/uk/gov/pay/ledger/util/fixture/TransactionFixture.java
+++ b/src/test/java/uk/gov/pay/ledger/util/fixture/TransactionFixture.java
@@ -76,6 +76,7 @@ public class TransactionFixture implements DbFixture<TransactionFixture, Transac
     private String source;
     private String gatewayPayoutId;
     private String version3ds;
+    private String agreementId;
 
     private TransactionFixture() {
     }
@@ -331,6 +332,11 @@ public class TransactionFixture implements DbFixture<TransactionFixture, Transac
         return this;
     }
 
+    public TransactionFixture withAgreementId(String agreementId) {
+        this.agreementId = agreementId;
+        return this;
+    }
+
     @Override
     public TransactionFixture insert(Jdbi jdbi) {
         jdbi.withHandle(h ->
@@ -365,9 +371,10 @@ public class TransactionFixture implements DbFixture<TransactionFixture, Transac
                                 "        moto,\n" +
                                 "        gateway_transaction_id,\n" +
                                 "        source,\n" +
-                                "        gateway_payout_id\n" +
+                                "        gateway_payout_id,\n" +
+                                "        agreement_id\n" +
                                 "    )\n" +
-                                "VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, CAST(? as jsonb), ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?::transaction_type, ?, ?, ?, ?::source, ?)\n",
+                                "VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, CAST(? as jsonb), ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?::transaction_type, ?, ?, ?, ?::source, ?, ?)\n",
                         id,
                         externalId,
                         parentExternalId,
@@ -396,7 +403,8 @@ public class TransactionFixture implements DbFixture<TransactionFixture, Transac
                         moto,
                         gatewayTransactionId,
                         source,
-                        gatewayPayoutId
+                        gatewayPayoutId,
+                        agreementId
                 )
         );
         return this;
@@ -508,7 +516,8 @@ public class TransactionFixture implements DbFixture<TransactionFixture, Transac
                 .withLive(live)
                 .withMoto(moto)
                 .withGatewayTransactionId(gatewayTransactionId)
-                .withGatewayPayoutId(gatewayPayoutId);
+                .withGatewayPayoutId(gatewayPayoutId)
+                .withAgreementId(agreementId);
         Source.from(source).ifPresent(builder::withSource);
         return builder.build();
     }
@@ -603,6 +612,10 @@ public class TransactionFixture implements DbFixture<TransactionFixture, Transac
 
     public String getCredentialExternalId() {
         return credentialExternalId;
+    }
+
+    public String getAgreementId() {
+        return agreementId;
     }
 
     public TransactionFixture withDefaultCardDetails(boolean includeCardDetails) {


### PR DESCRIPTION
Depends on https://github.com/alphagov/pay-ledger/pull/2026

Agreement ID on payment transactions should now be persisted in a column
rather than transaction details.

Update the myriad entities/ mappers/ fixtures/ builders to make this
happen and cover the persisting/ retrieving with tests.