### PR TITLE
PP-9530 Transaction search params supports agreement ID

### DIFF
--- a/openapi/ledger_spec.yaml
+++ b/openapi/ledger_spec.yaml
@@ -31,6 +31,23 @@ paths:
       summary: "Healthcheck endpoint the ledger (checks postgresql, sqs queue)"
       tags:
       - Other
+  /v1/event:
+    post:
+      operationId: writeEvent
+      requestBody:
+        content:
+          '*/*':
+            schema:
+              type: array
+              items:
+                $ref: '#/components/schemas/EventMessageDto'
+      responses:
+        default:
+          content:
+            application/json: {}
+          description: default response
+      tags:
+      - Events
   /v1/event/ticker:
     get:
       operationId: listEvents
@@ -265,17 +282,21 @@ paths:
           type: string
           enum:
           - UNDEFINED
-          - CREATED
           - STARTED
-          - SUBMITTED
           - CAPTURABLE
-          - SUCCESS
           - FAILED_REJECTED
           - FAILED_EXPIRED
           - FAILED_CANCELLED
           - CANCELLED
+          - CREATED
+          - SUBMITTED
+          - SUCCESS
           - ERROR
           - ERROR_GATEWAY
+          - NEEDS_RESPONSE
+          - UNDER_REVIEW
+          - LOST
+          - WON
       responses:
         "200":
           content:
@@ -320,17 +341,21 @@ paths:
           type: string
           enum:
           - UNDEFINED
-          - CREATED
           - STARTED
-          - SUBMITTED
           - CAPTURABLE
-          - SUCCESS
           - FAILED_REJECTED
           - FAILED_EXPIRED
           - FAILED_CANCELLED
           - CANCELLED
+          - CREATED
+          - SUBMITTED
+          - SUCCESS
           - ERROR
           - ERROR_GATEWAY
+          - NEEDS_RESPONSE
+          - UNDER_REVIEW
+          - LOST
+          - WON
       responses:
         "200":
           content:
@@ -539,6 +564,7 @@ paths:
           enum:
           - PAYMENT
           - REFUND
+          - DISPUTE
       - example: po_fj893joishj12lndk
         in: query
         name: gateway_payout_id
@@ -561,6 +587,11 @@ paths:
       - example: metadata-value-1
         in: query
         name: metadata_value
+        schema:
+          type: string
+      - example: 17ii98mg7f6si930tcjt48ldlc
+        in: query
+        name: agreement_id
         schema:
           type: string
       - example: 1
@@ -596,6 +627,12 @@ paths:
         name: gateway_transaction_id
         schema:
           type: string
+      - description: Comma delimited dispute states.
+        example: "won,needs_response"
+        in: query
+        name: dispute_states
+        schema:
+          $ref: '#/components/schemas/CommaDelimitedSetParameter'
       - description: Set to true to list transactions for all accounts.
         in: query
         name: override_account_id_restriction
@@ -723,6 +760,7 @@ paths:
           enum:
           - PAYMENT
           - REFUND
+          - DISPUTE
       - in: query
         name: parent_external_id
         schema:
@@ -890,6 +928,16 @@ components:
           - AGREEMENT_NOT_FOUND
           - ONE_TIME_TOKEN_INVALID
           - ONE_TIME_TOKEN_ALREADY_USED
+          - INVALID_ATTRIBUTE_VALUE
+          - CARD_NUMBER_REJECTED
+          - AUTHORISATION_API_NOT_ALLOWED
+          - AUTHORISATION_REJECTED
+          - AUTHORISATION_ERROR
+          - AUTHORISATION_TIMEOUT
+          - AGREEMENT_NOT_ACTIVE
+          - MISSING_MANDATORY_ATTRIBUTE
+          - UNEXPECTED_ATTRIBUTE
+          - ACCOUNT_DISABLED
           example: GENERIC
         message:
           type: array
@@ -938,6 +986,7 @@ components:
           - card_payment
           - payout
           - dispute
+          - payment_instrument
           example: payment
         service_id:
           type: string
@@ -945,6 +994,37 @@ components:
         sqs_message_id:
           type: string
           example: fe689579-63af-40bf-a783-23de97134b5f
+    EventMessageDto:
+      type: object
+      properties:
+        event_details:
+          type: string
+        event_type:
+          type: string
+        live:
+          type: boolean
+        parent_resource_external_id:
+          type: string
+        reproject_domain_object:
+          type: boolean
+        resource_external_id:
+          type: string
+        resource_type:
+          type: string
+          enum:
+          - agreement
+          - payment
+          - refund
+          - service
+          - card_payment
+          - payout
+          - dispute
+          - payment_instrument
+        service_id:
+          type: string
+        timestamp:
+          type: string
+          format: date-time
     EventTicker:
       type: object
       properties:
@@ -980,6 +1060,7 @@ components:
           - card_payment
           - payout
           - dispute
+          - payment_instrument
           example: payment
         transaction_type:
           type: string
@@ -1241,6 +1322,8 @@ components:
     TransactionView:
       type: object
       properties:
+        agreement_id:
+          type: string
         amount:
           type: integer
           format: int64
@@ -1250,6 +1333,7 @@ components:
           enum:
           - web
           - moto_api
+          - agreement
           - external
           example: web
         authorisation_summary:
@@ -1274,6 +1358,9 @@ components:
         email:
           type: string
           example: citizen@example.org
+        evidence_due_date:
+          type: string
+          format: date-time
         fee:
           type: integer
           format: int64
@@ -1311,6 +1398,9 @@ components:
         payment_provider:
           type: string
           example: sandbox
+        reason:
+          type: string
+          example: fraudulent
         reference:
           type: string
           example: payment reference
@@ -1356,6 +1446,7 @@ components:
           enum:
           - PAYMENT
           - REFUND
+          - DISPUTE
           example: PAYMENT
         wallet_type:
           type: string

--- a/src/main/java/uk/gov/pay/ledger/transaction/search/common/TransactionSearchParams.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/search/common/TransactionSearchParams.java
@@ -45,6 +45,7 @@ public class TransactionSearchParams extends SearchParams {
     private static final long DEFAULT_MAX_DISPLAY_SIZE = 500L;
     private static final Long DEFAULT_LIMIT_TOTAL_SIZE = 10000L;
     private static final String METADATA_VALUE = "metadata_value";
+    private static final String AGREEMENT_ID_FIELD = "agreement_id";
 
     private long maxDisplaySize = DEFAULT_MAX_DISPLAY_SIZE;
 
@@ -67,6 +68,7 @@ public class TransactionSearchParams extends SearchParams {
     private String fromSettledDate;
     private String toSettledDate;
     private String metadataValue;
+    private String agreementId;
     private Long pageNumber = 1L;
 
     private Long displaySize = DEFAULT_MAX_DISPLAY_SIZE;
@@ -186,6 +188,12 @@ public class TransactionSearchParams extends SearchParams {
         this.metadataValue = metadataValue;
     }
 
+    @QueryParam("agreement_id")
+    @Parameter(example = "17ii98mg7f6si930tcjt48ldlc")
+    public void setAgreementId(String agreementId) {
+        this.agreementId = agreementId;
+    }
+
     @QueryParam("page")
     @Parameter(example = "1")
     public void setPageNumber(Long pageNumber) {
@@ -258,6 +266,9 @@ public class TransactionSearchParams extends SearchParams {
         }
         if (isNotBlank(metadataValue)) {
             filters.add(" lower(tm.value) = lower(:" + METADATA_VALUE + ")");
+        }
+        if (isNotBlank(agreementId)) {
+            filters.add( " t.agreement_id = :" + AGREEMENT_ID_FIELD);
         }
 
         return List.copyOf(filters);
@@ -359,6 +370,9 @@ public class TransactionSearchParams extends SearchParams {
             }
             if (isNotBlank(metadataValue)) {
                 queryMap.put(METADATA_VALUE, metadataValue);
+            }
+            if (isNotBlank(agreementId)) {
+                queryMap.put(AGREEMENT_ID_FIELD, agreementId);
             }
         }
         return queryMap;
@@ -486,6 +500,9 @@ public class TransactionSearchParams extends SearchParams {
         }
         if (isNotBlank(metadataValue)) {
             queries.add(METADATA_VALUE + "=" + metadataValue);
+        }
+        if (isNotBlank(agreementId)) {
+            queries.add(AGREEMENT_ID_FIELD + "=" + agreementId);
         }
         queries.add("page=" + forPage);
         queries.add("display_size=" + getDisplaySize());

--- a/src/test/java/uk/gov/pay/ledger/transaction/dao/TransactionDaoSearchIT.java
+++ b/src/test/java/uk/gov/pay/ledger/transaction/dao/TransactionDaoSearchIT.java
@@ -71,6 +71,7 @@ public class TransactionDaoSearchIT {
         transactionFixture = aTransactionFixture()
                 .withDefaultCardDetails()
                 .withMoto(true)
+                .withAgreementId("an-agreement-id")
                 .insert(rule.getJdbi());
 
         searchParams.setAccountIds(List.of(transactionFixture.getGatewayAccountId()));
@@ -92,6 +93,7 @@ public class TransactionDaoSearchIT {
         assertThat(transaction.getCardBrand(), is(transactionFixture.getCardDetails().getCardBrand()));
         assertThat(transaction.getCreatedDate(), is(transactionFixture.getCreatedDate()));
         assertThat(transaction.isMoto(), is(transactionFixture.isMoto()));
+        assertThat(transaction.getAgreementId(), is(transactionFixture.getAgreementId()));
 
         Long total = transactionDao.getTotalForSearch(searchParams);
         assertThat(total, is(1L));
@@ -983,6 +985,31 @@ public class TransactionDaoSearchIT {
         assertThat(transactionList.size(), is(1));
 
         total = transactionDao.getTotalForSearch(searchParams);
+        assertThat(total, is(1L));
+    }
+
+    @Test
+    public void shouldReturn1Record_whenSearchingByAgreementId() {
+        String gatewayAccountId = "account-id-" + nextLong();
+
+        for (int i = 0; i < 2; i++) {
+            aTransactionFixture()
+                    .withGatewayAccountId(gatewayAccountId)
+                    .withAgreementId("agreement-id-" + i)
+                    .withCreatedDate(now().plusSeconds(1L))
+                    .insert(rule.getJdbi());
+        }
+
+        TransactionSearchParams searchParams = new TransactionSearchParams();
+        searchParams.setAccountIds(List.of(gatewayAccountId));
+        searchParams.setAgreementId("agreement-id-1");
+
+        List<TransactionEntity> transactionList = transactionDao.searchTransactions(searchParams);
+
+        assertThat(transactionList.size(), Matchers.is(1));
+        assertThat(transactionList.get(0).getAgreementId(), is("agreement-id-1"));
+
+        Long total = transactionDao.getTotalForSearch(searchParams);
         assertThat(total, is(1L));
     }
 


### PR DESCRIPTION
Depends on https://github.com/alphagov/pay-ledger/pull/2027 and https://github.com/alphagov/pay-ledger/pull/2026

Add `agreement_id` query param to transactions search.

Allow consumers (public api/ admin tool) to provice the `agreement_id`
query param and filter transactions by agreement id.

This will be used by the admin tool to show payments that have been
taken for a given agreement.