### PR TITLE
PP-9627 change dispute mapper

### DIFF
--- a/src/main/java/uk/gov/pay/ledger/util/DisputeReasonMapper.java
+++ b/src/main/java/uk/gov/pay/ledger/util/DisputeReasonMapper.java
@@ -6,7 +6,7 @@ public class DisputeReasonMapper {
 
     public static String mapToApi(String stripeReason) {
         if (isBlank(stripeReason)) {
-            return "";
+            return null;
         }
         switch (stripeReason) {
             case "credit_not_processed":

--- a/src/test/java/uk/gov/pay/ledger/util/DisputeReasonMapperTest.java
+++ b/src/test/java/uk/gov/pay/ledger/util/DisputeReasonMapperTest.java
@@ -1,11 +1,12 @@
 package uk.gov.pay.ledger.util;
 
 
+import org.hamcrest.CoreMatchers;
 import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.emptyString;
+import static org.hamcrest.Matchers.nullValue;
 
 public class DisputeReasonMapperTest {
 
@@ -24,12 +25,12 @@ public class DisputeReasonMapperTest {
     @Test
     public void shouldHandleNullValue() {
         String mappedValue = DisputeReasonMapper.mapToApi(null);
-        assertThat(mappedValue, is(emptyString()));
+        assertThat(mappedValue, is(CoreMatchers.nullValue()));
     }
 
     @Test
     public void shouldHandleEmptyValue() {
         String mappedValue = DisputeReasonMapper.mapToApi("");
-        assertThat(mappedValue, is(emptyString()));
+        assertThat(mappedValue, is(nullValue()));
     }
 }


### PR DESCRIPTION
- `DisputeReasonMapper` should return null when reason is missing or an empty string. That's to avoid returning an empty field through the API.