### PR TITLE
PP-9671 Return disputed field on transactions

### DIFF
--- a/src/main/java/uk/gov/pay/ledger/transaction/model/Payment.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/model/Payment.java
@@ -49,6 +49,7 @@ public class Payment extends Transaction {
     private String walletType;
     private AuthorisationMode authorisationMode;
     private String agreementId;
+    private Boolean disputed;
 
     public Payment() {
 
@@ -83,6 +84,7 @@ public class Payment extends Transaction {
         this.walletType = builder.walletType;
         this.authorisationMode = builder.authorisationMode;
         this.agreementId = builder.agreementId;
+        this.disputed = builder.disputed;
     }
 
     @Override
@@ -204,6 +206,10 @@ public class Payment extends Transaction {
         return agreementId;
     }
 
+    public Boolean getDisputed() {
+        return disputed;
+    }
+
     public static class Builder {
         public String serviceId;
         private Long id;
@@ -238,6 +244,7 @@ public class Payment extends Transaction {
         private String credentialExternalId;
         private AuthorisationMode authorisationMode;
         private String agreementId;
+        private Boolean disputed;
 
         public Builder() {
         }
@@ -408,6 +415,11 @@ public class Payment extends Transaction {
 
         public Builder withAgreementId(String agreementId) {
             this.agreementId = agreementId;
+            return this;
+        }
+
+        public Builder withDisputed(Boolean disputed) {
+            this.disputed = disputed;
             return this;
         }
     }

--- a/src/main/java/uk/gov/pay/ledger/transaction/model/TransactionFactory.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/model/TransactionFactory.java
@@ -126,6 +126,7 @@ public class TransactionFactory {
                     .withGatewayPayoutId(entity.getGatewayPayoutId())
                     .withAuthorisationMode(authorisationMode)
                     .withAgreementId(entity.getAgreementId())
+                    .withDisputed(safeGetAsBoolean(transactionDetails, "disputed", false))
                     .build();
         } catch (IOException e) {
             LOGGER.error("Error during the parsing transaction entity data [{}] [errorMessage={}]", entity.getExternalId(), e.getMessage());

--- a/src/main/java/uk/gov/pay/ledger/transaction/search/model/TransactionView.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/search/model/TransactionView.java
@@ -96,6 +96,7 @@ public class TransactionView {
     @Schema(example = "fraudulent")
     private String reason;
     private String agreementId;
+    private Boolean disputed;
 
     public TransactionView(Builder builder) {
         this.id = builder.id;
@@ -137,6 +138,7 @@ public class TransactionView {
         this.evidenceDueDate = builder.evidenceDueDate;
         this.reason = builder.reason;
         this.agreementId = builder.agreementId;
+        this.disputed = builder.disputed;
     }
 
     public TransactionView() {
@@ -179,7 +181,8 @@ public class TransactionView {
                     .withWalletType(payment.getWalletType())
                     .withGatewayPayoutId(payment.getGatewayPayoutId())
                     .withAuthorisationMode(payment.getAuthorisationMode())
-                    .withAgreementId(payment.getAgreementId());
+                    .withAgreementId(payment.getAgreementId())
+                    .withDisputed(payment.getDisputed());
             if (payment.getState() != null) {
                 paymentBuilder = paymentBuilder
                         .withState(ExternalTransactionState.from(payment.getState(), statusVersion));
@@ -423,6 +426,10 @@ public class TransactionView {
         return agreementId;
     }
 
+    public Boolean getDisputed() {
+        return disputed;
+    }
+
     public static class Builder {
         private Long id;
         private String gatewayAccountId;
@@ -464,6 +471,7 @@ public class TransactionView {
         private ZonedDateTime evidenceDueDate;
         private String reason;
         private String agreementId;
+        private Boolean disputed;
 
         public Builder() {
         }
@@ -664,6 +672,11 @@ public class TransactionView {
 
         public Builder withAgreementId(String agreementId) {
             this.agreementId = agreementId;
+            return this;
+        }
+
+        public Builder withDisputed(Boolean disputed) {
+            this.disputed = disputed;
             return this;
         }
     }

--- a/src/test/java/uk/gov/pay/ledger/transaction/model/TransactionFactoryTest.java
+++ b/src/test/java/uk/gov/pay/ledger/transaction/model/TransactionFactoryTest.java
@@ -84,6 +84,7 @@ public class TransactionFactoryTest {
         fullTransactionDetails.addProperty("expiry_date", cardExpiryDate);
         fullTransactionDetails.addProperty("wallet", walletType);
         fullTransactionDetails.addProperty("authorisation_mode", "moto_api");
+        fullTransactionDetails.addProperty("disputed", true);
 
         var payoutObject = aPayoutEntity()
                 .withPaidOutDate(paidOutDate)
@@ -192,6 +193,7 @@ public class TransactionFactoryTest {
         assertThat(payment.getSettlementSummary().getSettlementSubmittedTime(), is(Optional.empty()));
         assertThat(payment.getSettlementSummary().getSettledDate(), is(Optional.empty()));
         assertThat(payment.getAuthorisationMode(), is(AuthorisationMode.WEB));
+        assertThat(payment.getDisputed(), is(false));
     }
 
     @Test
@@ -392,5 +394,6 @@ public class TransactionFactoryTest {
         assertThat(payment.getSettlementSummary().getSettledDate(), is(Optional.of("2017-09-19")));
         assertThat(payment.getWalletType(), is(walletType));
         assertThat(payment.getAuthorisationMode(), is(AuthorisationMode.MOTO_API));
+        assertThat(payment.getDisputed(), is(true));
     }
 }

--- a/src/test/java/uk/gov/pay/ledger/transaction/resource/TransactionResourceIT.java
+++ b/src/test/java/uk/gov/pay/ledger/transaction/resource/TransactionResourceIT.java
@@ -52,11 +52,12 @@ public class TransactionResourceIT {
 
         transactionFixture = aTransactionFixture()
                 .withDefaultCardDetails()
-                .withDefaultTransactionDetails()
                 .withLive(Boolean.TRUE)
                 .withSource(String.valueOf(Source.CARD_API))
                 .withGatewayPayoutId(gatewayPayoutId)
-                .withAgreementId("an-agreement-id");
+                .withAgreementId("an-agreement-id")
+                .withDisputed(true)
+                .withDefaultTransactionDetails();
         transactionFixture.insert(rule.getJdbi());
 
         given().port(port)
@@ -77,7 +78,8 @@ public class TransactionResourceIT {
                 .body("source", is(String.valueOf(Source.CARD_API)))
                 .body("gateway_payout_id", is(gatewayPayoutId))
                 .body("agreement_id", is("an-agreement-id"))
-                .body("authorisation_mode", is("web"));
+                .body("authorisation_mode", is("web"))
+                .body("disputed", is(Boolean.TRUE));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/ledger/util/fixture/TransactionFixture.java
+++ b/src/test/java/uk/gov/pay/ledger/util/fixture/TransactionFixture.java
@@ -77,6 +77,7 @@ public class TransactionFixture implements DbFixture<TransactionFixture, Transac
     private String gatewayPayoutId;
     private String version3ds;
     private String agreementId;
+    private Boolean disputed;
 
     private TransactionFixture() {
     }
@@ -337,6 +338,11 @@ public class TransactionFixture implements DbFixture<TransactionFixture, Transac
         return this;
     }
 
+    public TransactionFixture withDisputed(boolean disputed) {
+        this.disputed = disputed;
+        return this;
+    }
+
     @Override
     public TransactionFixture insert(Jdbi jdbi) {
         jdbi.withHandle(h ->
@@ -482,7 +488,9 @@ public class TransactionFixture implements DbFixture<TransactionFixture, Transac
                     transactionDetails.addProperty("version_3ds", version);
                     transactionDetails.addProperty("requires_3ds", true);
                 });
-
+        Optional.ofNullable(disputed).ifPresent(
+                disputed -> transactionDetails.addProperty("disputed", disputed)
+        );
         return transactionDetails;
     }
 


### PR DESCRIPTION
For payment transactions, return a "disputed" field on the transaction in the response to the request GET a single transaction or search transactions.

The value of this field comes from the value of the "disputed" field on the "transaction_details" from the database if this field exists, otherwise it defaults to false.