### PR TITLE
PP-9545 Add missing payment instrument columns

### DIFF
--- a/src/main/resources/migrations/00075_add_payment_instrument_types.sql
+++ b/src/main/resources/migrations/00075_add_payment_instrument_types.sql
@@ -1,0 +1,6 @@
+--liquibase formatted sql
+
+--changeset uk.gov.pay:add_missing_common_types_to_payment_instrument
+ALTER TABLE payment_instrument ADD COLUMN type TEXT;
+ALTER TABLE payment_instrument ADD COLUMN first_digits_card_number CHAR(6);
+ALTER TABLE payment_instrument ADD COLUMN card_type VARCHAR(20);


### PR DESCRIPTION
Adds
* payment instrument `type`
* `card_type`
* `first_digits_card_number`

Most of this data is already provided by Connector when taking a
payment, it should be mapped and stored by the event store.