### PR TITLE
PP-9545 Add missing payment instrument properties

### DIFF
--- a/src/main/java/uk/gov/pay/ledger/agreement/dao/AgreementDao.java
+++ b/src/main/java/uk/gov/pay/ledger/agreement/dao/AgreementDao.java
@@ -27,6 +27,7 @@ public class AgreementDao {
             "pi.last_digits_card_number as p_last_digits_card_number," +
             "pi.expiry_date as p_expiry_date," +
             "pi.card_brand as p_card_brand," +
+            "pi.type as p_type," +
             "pi.event_count as p_event_count," +
             "pi.created_date as p_created_date " +
             "FROM agreement a LEFT JOIN (" +

--- a/src/main/java/uk/gov/pay/ledger/agreement/dao/AgreementDao.java
+++ b/src/main/java/uk/gov/pay/ledger/agreement/dao/AgreementDao.java
@@ -25,8 +25,10 @@ public class AgreementDao {
             "pi.address_county as p_address_county," +
             "pi.address_country as p_address_country," +
             "pi.last_digits_card_number as p_last_digits_card_number," +
+            "pi.first_digits_card_number as p_first_digits_card_number," +
             "pi.expiry_date as p_expiry_date," +
             "pi.card_brand as p_card_brand," +
+            "pi.card_type as p_card_type," +
             "pi.type as p_type," +
             "pi.event_count as p_event_count," +
             "pi.created_date as p_created_date " +

--- a/src/main/java/uk/gov/pay/ledger/agreement/dao/AgreementMapper.java
+++ b/src/main/java/uk/gov/pay/ledger/agreement/dao/AgreementMapper.java
@@ -6,6 +6,7 @@ import uk.gov.pay.ledger.agreement.entity.AgreementEntity;
 import uk.gov.pay.ledger.agreement.entity.PaymentInstrumentEntity;
 import uk.gov.pay.ledger.event.model.Event;
 import uk.gov.pay.ledger.event.model.ResourceType;
+import uk.gov.pay.ledger.transaction.model.CardType;
 import uk.gov.service.payments.commons.model.agreement.PaymentInstrumentType;
 
 import java.sql.ResultSet;
@@ -21,6 +22,7 @@ public class AgreementMapper implements RowMapper<AgreementEntity> {
         PaymentInstrumentEntity paymentInstrument = null;
         var paymentInstrumentExternalId = resultSet.getString("p_external_id");
         var paymentInstrumentType = PaymentInstrumentType.from(resultSet.getString("p_type"));
+        var paymentInstrumentCardType = CardType.fromString(resultSet.getString("p_card_type"));
 
         if (paymentInstrumentExternalId != null) {
             paymentInstrument = new PaymentInstrumentEntity(
@@ -35,8 +37,10 @@ public class AgreementMapper implements RowMapper<AgreementEntity> {
                     resultSet.getString("p_address_county"),
                     resultSet.getString("p_address_country"),
                     resultSet.getString("p_last_digits_card_number"),
+                    resultSet.getString("p_first_digits_card_number"),
                     resultSet.getString("p_expiry_date"),
                     resultSet.getString("p_card_brand"),
+                    paymentInstrumentCardType,
                     paymentInstrumentType.orElseGet(() -> null),
                     ZonedDateTime.ofInstant(resultSet.getTimestamp("p_created_date").toInstant(), ZoneOffset.UTC),
                     resultSet.getInt("p_event_count")

--- a/src/main/java/uk/gov/pay/ledger/agreement/dao/AgreementMapper.java
+++ b/src/main/java/uk/gov/pay/ledger/agreement/dao/AgreementMapper.java
@@ -6,6 +6,7 @@ import uk.gov.pay.ledger.agreement.entity.AgreementEntity;
 import uk.gov.pay.ledger.agreement.entity.PaymentInstrumentEntity;
 import uk.gov.pay.ledger.event.model.Event;
 import uk.gov.pay.ledger.event.model.ResourceType;
+import uk.gov.service.payments.commons.model.agreement.PaymentInstrumentType;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -19,6 +20,7 @@ public class AgreementMapper implements RowMapper<AgreementEntity> {
     public AgreementEntity map(ResultSet resultSet, StatementContext statementContext) throws SQLException {
         PaymentInstrumentEntity paymentInstrument = null;
         var paymentInstrumentExternalId = resultSet.getString("p_external_id");
+        var paymentInstrumentType = PaymentInstrumentType.from(resultSet.getString("p_type"));
 
         if (paymentInstrumentExternalId != null) {
             paymentInstrument = new PaymentInstrumentEntity(
@@ -35,6 +37,7 @@ public class AgreementMapper implements RowMapper<AgreementEntity> {
                     resultSet.getString("p_last_digits_card_number"),
                     resultSet.getString("p_expiry_date"),
                     resultSet.getString("p_card_brand"),
+                    paymentInstrumentType.orElseGet(() -> null),
                     ZonedDateTime.ofInstant(resultSet.getTimestamp("p_created_date").toInstant(), ZoneOffset.UTC),
                     resultSet.getInt("p_event_count")
             );

--- a/src/main/java/uk/gov/pay/ledger/agreement/dao/AgreementMapper.java
+++ b/src/main/java/uk/gov/pay/ledger/agreement/dao/AgreementMapper.java
@@ -7,6 +7,7 @@ import uk.gov.pay.ledger.agreement.entity.PaymentInstrumentEntity;
 import uk.gov.pay.ledger.event.model.Event;
 import uk.gov.pay.ledger.event.model.ResourceType;
 import uk.gov.pay.ledger.transaction.model.CardType;
+import uk.gov.service.payments.commons.model.agreement.AgreementStatus;
 import uk.gov.service.payments.commons.model.agreement.PaymentInstrumentType;
 
 import java.sql.ResultSet;
@@ -23,6 +24,7 @@ public class AgreementMapper implements RowMapper<AgreementEntity> {
         var paymentInstrumentExternalId = resultSet.getString("p_external_id");
         var paymentInstrumentType = PaymentInstrumentType.from(resultSet.getString("p_type"));
         var paymentInstrumentCardType = CardType.fromString(resultSet.getString("p_card_type"));
+        var agreementStatus = AgreementStatus.from(resultSet.getString("status"));
 
         if (paymentInstrumentExternalId != null) {
             paymentInstrument = new PaymentInstrumentEntity(
@@ -52,7 +54,7 @@ public class AgreementMapper implements RowMapper<AgreementEntity> {
                 resultSet.getString("service_id"),
                 resultSet.getString("reference"),
                 resultSet.getString("description"),
-                resultSet.getString("status"),
+                agreementStatus.orElseGet(() -> null),
                 getBooleanWithNullCheck(resultSet,"live"),
                 ZonedDateTime.ofInstant(resultSet.getTimestamp("created_date").toInstant(), ZoneOffset.UTC),
                 resultSet.getInt("event_count"),

--- a/src/main/java/uk/gov/pay/ledger/agreement/dao/PaymentInstrumentDao.java
+++ b/src/main/java/uk/gov/pay/ledger/agreement/dao/PaymentInstrumentDao.java
@@ -22,6 +22,7 @@ public class PaymentInstrumentDao {
             "last_digits_card_number," +
             "expiry_date," +
             "card_brand," +
+            "type," +
             "event_count," +
             "created_date" +
             ") " +
@@ -39,6 +40,7 @@ public class PaymentInstrumentDao {
             ":lastDigitsCardNumber, " +
             ":expiryDate, " +
             ":cardBrand, " +
+            ":type, " +
             ":eventCount, " +
             ":createdDate" +
             ") " +
@@ -56,6 +58,7 @@ public class PaymentInstrumentDao {
             "last_digits_card_number = EXCLUDED.last_digits_card_number," +
             "expiry_date = EXCLUDED.expiry_date," +
             "card_brand = EXCLUDED.card_brand," +
+            "type = EXCLUDED.type," +
             "event_count = EXCLUDED.event_count," +
             "created_date = EXCLUDED.created_date " +
             "WHERE EXCLUDED.event_count >= payment_instrument.event_count";

--- a/src/main/java/uk/gov/pay/ledger/agreement/dao/PaymentInstrumentDao.java
+++ b/src/main/java/uk/gov/pay/ledger/agreement/dao/PaymentInstrumentDao.java
@@ -20,8 +20,10 @@ public class PaymentInstrumentDao {
             "address_county," +
             "address_country," +
             "last_digits_card_number," +
+            "first_digits_card_number," +
             "expiry_date," +
             "card_brand," +
+            "card_type," +
             "type," +
             "event_count," +
             "created_date" +
@@ -38,8 +40,10 @@ public class PaymentInstrumentDao {
             ":addressCounty, " +
             ":addressCountry, " +
             ":lastDigitsCardNumber, " +
+            ":firstDigitsCardNumber, " +
             ":expiryDate, " +
             ":cardBrand, " +
+            ":cardType, " +
             ":type, " +
             ":eventCount, " +
             ":createdDate" +
@@ -56,8 +60,10 @@ public class PaymentInstrumentDao {
             "address_county = EXCLUDED.address_county," +
             "address_country = EXCLUDED.address_country," +
             "last_digits_card_number = EXCLUDED.last_digits_card_number," +
+            "first_digits_card_number = EXCLUDED.first_digits_card_number," +
             "expiry_date = EXCLUDED.expiry_date," +
             "card_brand = EXCLUDED.card_brand," +
+            "card_type = EXCLUDED.card_type," +
             "type = EXCLUDED.type," +
             "event_count = EXCLUDED.event_count," +
             "created_date = EXCLUDED.created_date " +

--- a/src/main/java/uk/gov/pay/ledger/agreement/entity/AgreementEntity.java
+++ b/src/main/java/uk/gov/pay/ledger/agreement/entity/AgreementEntity.java
@@ -3,6 +3,7 @@ package uk.gov.pay.ledger.agreement.entity;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import uk.gov.service.payments.commons.model.agreement.AgreementStatus;
 
 import java.time.ZonedDateTime;
 
@@ -14,7 +15,7 @@ public class AgreementEntity {
     private String serviceId;
     private String reference;
     private String description;
-    private String status;
+    private AgreementStatus status;
     private Boolean live;
     private ZonedDateTime createdDate;
     private Integer eventCount;
@@ -24,7 +25,7 @@ public class AgreementEntity {
 
     }
 
-    public AgreementEntity(String externalId, String gatewayAccountId, String serviceId, String reference, String description, String status, Boolean live, ZonedDateTime createdDate, Integer eventCount, PaymentInstrumentEntity paymentInstrument) {
+    public AgreementEntity(String externalId, String gatewayAccountId, String serviceId, String reference, String description, AgreementStatus status, Boolean live, ZonedDateTime createdDate, Integer eventCount, PaymentInstrumentEntity paymentInstrument) {
         this.externalId = externalId;
         this.gatewayAccountId = gatewayAccountId;
         this.serviceId = serviceId;
@@ -57,7 +58,7 @@ public class AgreementEntity {
         return description;
     }
 
-    public String getStatus() {
+    public AgreementStatus getStatus() {
         return status;
     }
 
@@ -109,7 +110,7 @@ public class AgreementEntity {
         this.description = description;
     }
 
-    public void setStatus(String status) {
+    public void setStatus(AgreementStatus status) {
         this.status = status;
     }
 

--- a/src/main/java/uk/gov/pay/ledger/agreement/entity/PaymentInstrumentEntity.java
+++ b/src/main/java/uk/gov/pay/ledger/agreement/entity/PaymentInstrumentEntity.java
@@ -3,6 +3,7 @@ package uk.gov.pay.ledger.agreement.entity;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import uk.gov.service.payments.commons.model.agreement.PaymentInstrumentType;
 
 import java.time.ZonedDateTime;
 
@@ -26,13 +27,14 @@ public class PaymentInstrumentEntity {
     private String cardBrand;
 
     private ZonedDateTime createdDate;
+    private PaymentInstrumentType type;
     private Integer eventCount;
 
     public PaymentInstrumentEntity() {
 
     }
 
-    public PaymentInstrumentEntity(String externalId, String agreementExternalId, String email, String cardholderName, String addressLine1, String addressLine2, String addressPostcode, String addressCity, String addressCounty, String addressCountry, String lastDigitsCardNumber, String expiryDate, String cardBrand, ZonedDateTime createdDate, Integer eventCount) {
+    public PaymentInstrumentEntity(String externalId, String agreementExternalId, String email, String cardholderName, String addressLine1, String addressLine2, String addressPostcode, String addressCity, String addressCounty, String addressCountry, String lastDigitsCardNumber, String expiryDate, String cardBrand, PaymentInstrumentType type, ZonedDateTime createdDate, Integer eventCount) {
         this.externalId = externalId;
         this.agreementExternalId = agreementExternalId;
         this.email = email;
@@ -46,6 +48,7 @@ public class PaymentInstrumentEntity {
         this.lastDigitsCardNumber = lastDigitsCardNumber;
         this.expiryDate = expiryDate;
         this.cardBrand = cardBrand;
+        this.type = type;
         this.createdDate = createdDate;
         this.eventCount = eventCount;
     }
@@ -100,6 +103,10 @@ public class PaymentInstrumentEntity {
 
     public void setLastDigitsCardNumber(String lastDigitsCardNumber) {
         this.lastDigitsCardNumber = lastDigitsCardNumber;
+    }
+
+    public void setType(PaymentInstrumentType type) {
+        this.type = type;
     }
 
     public void setExpiryDate(String expiryDate) {
@@ -167,5 +174,9 @@ public class PaymentInstrumentEntity {
     }
     public String getAddressCounty() {
         return addressCounty;
+    }
+
+    public PaymentInstrumentType getType() {
+        return type;
     }
 }

--- a/src/main/java/uk/gov/pay/ledger/agreement/entity/PaymentInstrumentEntity.java
+++ b/src/main/java/uk/gov/pay/ledger/agreement/entity/PaymentInstrumentEntity.java
@@ -3,6 +3,7 @@ package uk.gov.pay.ledger.agreement.entity;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import uk.gov.pay.ledger.transaction.model.CardType;
 import uk.gov.service.payments.commons.model.agreement.PaymentInstrumentType;
 
 import java.time.ZonedDateTime;
@@ -23,9 +24,10 @@ public class PaymentInstrumentEntity {
     private String addressCountry;
 
     private String lastDigitsCardNumber;
+    private String firstDigitsCardNumber;
     private String expiryDate;
     private String cardBrand;
-
+    private CardType cardType;
     private ZonedDateTime createdDate;
     private PaymentInstrumentType type;
     private Integer eventCount;
@@ -34,7 +36,7 @@ public class PaymentInstrumentEntity {
 
     }
 
-    public PaymentInstrumentEntity(String externalId, String agreementExternalId, String email, String cardholderName, String addressLine1, String addressLine2, String addressPostcode, String addressCity, String addressCounty, String addressCountry, String lastDigitsCardNumber, String expiryDate, String cardBrand, PaymentInstrumentType type, ZonedDateTime createdDate, Integer eventCount) {
+    public PaymentInstrumentEntity(String externalId, String agreementExternalId, String email, String cardholderName, String addressLine1, String addressLine2, String addressPostcode, String addressCity, String addressCounty, String addressCountry, String lastDigitsCardNumber, String firstDigitsCardNumber, String expiryDate, String cardBrand, CardType cardType, PaymentInstrumentType type, ZonedDateTime createdDate, Integer eventCount) {
         this.externalId = externalId;
         this.agreementExternalId = agreementExternalId;
         this.email = email;
@@ -46,8 +48,10 @@ public class PaymentInstrumentEntity {
         this.addressCounty = addressCounty;
         this.addressCountry = addressCountry;
         this.lastDigitsCardNumber = lastDigitsCardNumber;
+        this.firstDigitsCardNumber = firstDigitsCardNumber;
         this.expiryDate = expiryDate;
         this.cardBrand = cardBrand;
+        this.cardType = cardType;
         this.type = type;
         this.createdDate = createdDate;
         this.eventCount = eventCount;
@@ -117,6 +121,14 @@ public class PaymentInstrumentEntity {
         this.cardBrand = cardBrand;
     }
 
+    public void setFirstDigitsCardNumber(String firstDigitsCardNumber) {
+        this.firstDigitsCardNumber = firstDigitsCardNumber;
+    }
+
+    public void setCardType(CardType cardType) {
+        this.cardType = cardType;
+    }
+
     public String getExternalId() {
         return externalId;
     }
@@ -178,5 +190,13 @@ public class PaymentInstrumentEntity {
 
     public PaymentInstrumentType getType() {
         return type;
+    }
+
+    public String getFirstDigitsCardNumber() {
+        return firstDigitsCardNumber;
+    }
+
+    public CardType getCardType() {
+        return cardType;
     }
 }

--- a/src/main/java/uk/gov/pay/ledger/agreement/model/Agreement.java
+++ b/src/main/java/uk/gov/pay/ledger/agreement/model/Agreement.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import uk.gov.pay.ledger.agreement.entity.AgreementEntity;
 import uk.gov.service.payments.commons.api.json.ApiResponseDateTimeSerializer;
+import uk.gov.service.payments.commons.model.agreement.AgreementStatus;
 
 import java.time.ZonedDateTime;
 import java.util.Optional;
@@ -15,13 +16,13 @@ public class Agreement {
     private String serviceId;
     private String reference;
     private String description;
-    private String status;
+    private AgreementStatus status;
     private Boolean live;
     @JsonSerialize(using = ApiResponseDateTimeSerializer.class)
     private ZonedDateTime createdDate;
     private PaymentInstrument paymentInstrument;
 
-    public Agreement(String externalId, String serviceId, String reference, String description, String status, Boolean live, ZonedDateTime createdDate, PaymentInstrument paymentInstrument) {
+    public Agreement(String externalId, String serviceId, String reference, String description, AgreementStatus status, Boolean live, ZonedDateTime createdDate, PaymentInstrument paymentInstrument) {
         this.externalId = externalId;
         this.serviceId = serviceId;
         this.reference = reference;
@@ -61,7 +62,7 @@ public class Agreement {
         return description;
     }
 
-    public String getStatus() {
+    public AgreementStatus getStatus() {
         return status;
     }
 

--- a/src/main/java/uk/gov/pay/ledger/agreement/model/PaymentInstrument.java
+++ b/src/main/java/uk/gov/pay/ledger/agreement/model/PaymentInstrument.java
@@ -42,9 +42,9 @@ public class PaymentInstrument {
                 billingAddress,
                 entity.getCardBrand(),
                 entity.getLastDigitsCardNumber(),
-                null,
+                entity.getFirstDigitsCardNumber(),
                 entity.getExpiryDate(),
-                null
+                entity.getCardType()
         );
         return new PaymentInstrument(
                 entity.getExternalId(),

--- a/src/main/java/uk/gov/pay/ledger/agreement/model/PaymentInstrument.java
+++ b/src/main/java/uk/gov/pay/ledger/agreement/model/PaymentInstrument.java
@@ -7,6 +7,7 @@ import uk.gov.pay.ledger.agreement.entity.PaymentInstrumentEntity;
 import uk.gov.pay.ledger.transaction.model.Address;
 import uk.gov.pay.ledger.transaction.model.CardDetails;
 import uk.gov.service.payments.commons.api.json.ApiResponseDateTimeSerializer;
+import uk.gov.service.payments.commons.model.agreement.PaymentInstrumentType;
 
 import java.time.ZonedDateTime;
 
@@ -15,13 +16,15 @@ public class PaymentInstrument {
     private String externalId;
     private String agreementExternalId;
     private CardDetails cardDetails;
+    private PaymentInstrumentType type;
     @JsonSerialize(using = ApiResponseDateTimeSerializer.class)
     private ZonedDateTime createdDate;
 
-    public PaymentInstrument(String externalId, String agreementExternalId, CardDetails cardDetails, ZonedDateTime createdDate) {
+    public PaymentInstrument(String externalId, String agreementExternalId, CardDetails cardDetails, PaymentInstrumentType type, ZonedDateTime createdDate) {
         this.externalId = externalId;
         this.agreementExternalId = agreementExternalId;
         this.cardDetails = cardDetails;
+        this.type = type;
         this.createdDate = createdDate;
     }
 
@@ -47,6 +50,7 @@ public class PaymentInstrument {
                 entity.getExternalId(),
                 entity.getAgreementExternalId(),
                 cardDetails,
+                entity.getType(),
                 entity.getCreatedDate()
         );
     }
@@ -65,5 +69,9 @@ public class PaymentInstrument {
 
     public ZonedDateTime getCreatedDate() {
         return createdDate;
+    }
+
+    public PaymentInstrumentType getType() {
+        return type;
     }
 }

--- a/src/main/resources/migrations/00075_add_payment_instrument_types.sql
+++ b/src/main/resources/migrations/00075_add_payment_instrument_types.sql
@@ -1,0 +1,6 @@
+--liquibase formatted sql
+
+--changeset uk.gov.pay:add_missing_common_types_to_payment_instrument
+ALTER TABLE payment_instrument ADD COLUMN type TEXT;
+ALTER TABLE payment_instrument ADD COLUMN first_digits_card_number CHAR(6);
+ALTER TABLE payment_instrument ADD COLUMN card_type VARCHAR(20);

--- a/src/test/java/uk/gov/pay/ledger/agreement/entity/AgreementsFactoryTest.java
+++ b/src/test/java/uk/gov/pay/ledger/agreement/entity/AgreementsFactoryTest.java
@@ -5,6 +5,7 @@ import com.google.gson.GsonBuilder;
 import org.junit.jupiter.api.Test;
 import uk.gov.pay.ledger.event.model.EventDigest;
 import uk.gov.pay.ledger.event.model.ResourceType;
+import uk.gov.service.payments.commons.model.agreement.AgreementStatus;
 
 import java.util.List;
 import java.util.Map;
@@ -39,7 +40,7 @@ class AgreementsFactoryTest {
         assertThat(entity.getEventCount(), is(1));
         assertThat(entity.getReference(), is("agreement-reference"));
         assertThat(entity.getDescription(), is("agreement description text"));
-        assertThat(entity.getStatus(), is("CREATED"));
+        assertThat(entity.getStatus(), is(AgreementStatus.CREATED));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/ledger/agreement/resource/AgreementResourceIT.java
+++ b/src/test/java/uk/gov/pay/ledger/agreement/resource/AgreementResourceIT.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import uk.gov.pay.ledger.extension.AppWithPostgresAndSqsExtension;
 import uk.gov.pay.ledger.util.fixture.AgreementFixture;
 import uk.gov.pay.ledger.util.fixture.PaymentInstrumentFixture;
+import uk.gov.service.payments.commons.model.agreement.PaymentInstrumentType;
 
 import javax.ws.rs.core.Response;
 
@@ -56,7 +57,8 @@ public class AgreementResourceIT {
                 .statusCode(Response.Status.OK.getStatusCode())
                 .contentType(JSON)
                 .body("external_id", is(agreementFixture.getExternalId()))
-                .body("payment_instrument.external_id", is(paymentInstrumentFixture.getExternalId()));
+                .body("payment_instrument.external_id", is(paymentInstrumentFixture.getExternalId()))
+                .body("payment_instrument.type", is(PaymentInstrumentType.CARD.name()));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/ledger/agreement/resource/AgreementResourceIT.java
+++ b/src/test/java/uk/gov/pay/ledger/agreement/resource/AgreementResourceIT.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import uk.gov.pay.ledger.extension.AppWithPostgresAndSqsExtension;
+import uk.gov.pay.ledger.transaction.model.CardType;
 import uk.gov.pay.ledger.util.fixture.AgreementFixture;
 import uk.gov.pay.ledger.util.fixture.PaymentInstrumentFixture;
 import uk.gov.service.payments.commons.model.agreement.PaymentInstrumentType;
@@ -58,7 +59,9 @@ public class AgreementResourceIT {
                 .contentType(JSON)
                 .body("external_id", is(agreementFixture.getExternalId()))
                 .body("payment_instrument.external_id", is(paymentInstrumentFixture.getExternalId()))
-                .body("payment_instrument.type", is(PaymentInstrumentType.CARD.name()));
+                .body("payment_instrument.type", is(PaymentInstrumentType.CARD.name()))
+                .body("payment_instrument.card_details.card_type", is(CardType.CREDIT.name().toLowerCase()))
+                .body("payment_instrument.card_details.first_digits_card_number", is("424242"));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/ledger/agreement/resource/AgreementResourceIT.java
+++ b/src/test/java/uk/gov/pay/ledger/agreement/resource/AgreementResourceIT.java
@@ -7,6 +7,7 @@ import uk.gov.pay.ledger.extension.AppWithPostgresAndSqsExtension;
 import uk.gov.pay.ledger.transaction.model.CardType;
 import uk.gov.pay.ledger.util.fixture.AgreementFixture;
 import uk.gov.pay.ledger.util.fixture.PaymentInstrumentFixture;
+import uk.gov.service.payments.commons.model.agreement.AgreementStatus;
 import uk.gov.service.payments.commons.model.agreement.PaymentInstrumentType;
 
 import javax.ws.rs.core.Response;
@@ -111,11 +112,11 @@ public class AgreementResourceIT {
 
     @Test
     public void shouldSearchWithFilterParams() {
-        AgreementFixture.anAgreementFixture("a-one-agreement-id", "a-one-service-id", "CREATED", "partial-ref-1").insert(rule.getJdbi());
-        AgreementFixture.anAgreementFixture("a-two-agreement-id", "a-one-service-id", "CREATED", "notmatchingref").insert(rule.getJdbi());
-        AgreementFixture.anAgreementFixture("a-three-agreement-id", "a-one-service-id", "ACTIVE", "anotherref").insert(rule.getJdbi());
-        AgreementFixture.anAgreementFixture("a-four-agreement-id", "a-two-service-id", "CREATED", "reference").insert(rule.getJdbi());
-        AgreementFixture.anAgreementFixture("a-five-agreement-id", "a-one-service-id", "CREATED", "avalid-partial-ref").insert(rule.getJdbi());
+        AgreementFixture.anAgreementFixture("a-one-agreement-id", "a-one-service-id", AgreementStatus.CREATED, "partial-ref-1").insert(rule.getJdbi());
+        AgreementFixture.anAgreementFixture("a-two-agreement-id", "a-one-service-id", AgreementStatus.CREATED, "notmatchingref").insert(rule.getJdbi());
+        AgreementFixture.anAgreementFixture("a-three-agreement-id", "a-one-service-id", AgreementStatus.ACTIVE, "anotherref").insert(rule.getJdbi());
+        AgreementFixture.anAgreementFixture("a-four-agreement-id", "a-two-service-id", AgreementStatus.CREATED, "reference").insert(rule.getJdbi());
+        AgreementFixture.anAgreementFixture("a-five-agreement-id", "a-one-service-id", AgreementStatus.CREATED, "avalid-partial-ref").insert(rule.getJdbi());
         given().port(port)
                 .contentType(JSON)
                 .queryParam("service_id", "a-one-service-id")

--- a/src/test/java/uk/gov/pay/ledger/util/fixture/AgreementFixture.java
+++ b/src/test/java/uk/gov/pay/ledger/util/fixture/AgreementFixture.java
@@ -4,6 +4,7 @@ import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.RandomUtils;
 import org.jdbi.v3.core.Jdbi;
 import uk.gov.pay.ledger.agreement.entity.AgreementEntity;
+import uk.gov.service.payments.commons.model.agreement.AgreementStatus;
 
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
@@ -16,7 +17,7 @@ public class AgreementFixture implements DbFixture<AgreementFixture, AgreementEn
     private String externalId = RandomStringUtils.randomAlphanumeric(20);
     private String reference = RandomStringUtils.randomAlphanumeric(10);
     private String description = RandomStringUtils.randomAlphanumeric(20);
-    private String status = "ACTIVE";
+    private AgreementStatus status = AgreementStatus.ACTIVE;
     private boolean live = false;
     private ZonedDateTime createdDate = ZonedDateTime.now(ZoneOffset.UTC);
     private Integer eventCount = 1;
@@ -31,7 +32,7 @@ public class AgreementFixture implements DbFixture<AgreementFixture, AgreementEn
         return fixture;
     }
 
-    public static AgreementFixture anAgreementFixture(String externalId, String serviceId, String status, String reference) {
+    public static AgreementFixture anAgreementFixture(String externalId, String serviceId, AgreementStatus status, String reference) {
         var fixture = new AgreementFixture();
         fixture.setExternalId(externalId);
         fixture.setServiceId(serviceId);
@@ -101,7 +102,7 @@ public class AgreementFixture implements DbFixture<AgreementFixture, AgreementEn
         this.externalId = externalId;
     }
 
-    public void setStatus(String status) {
+    public void setStatus(AgreementStatus status) {
         this.status = status;
     }
 

--- a/src/test/java/uk/gov/pay/ledger/util/fixture/PaymentInstrumentFixture.java
+++ b/src/test/java/uk/gov/pay/ledger/util/fixture/PaymentInstrumentFixture.java
@@ -4,6 +4,7 @@ import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.RandomUtils;
 import org.jdbi.v3.core.Jdbi;
 import uk.gov.pay.ledger.agreement.entity.PaymentInstrumentEntity;
+import uk.gov.pay.ledger.transaction.model.CardType;
 import uk.gov.service.payments.commons.model.agreement.PaymentInstrumentType;
 
 import java.time.ZoneOffset;
@@ -23,8 +24,10 @@ public class PaymentInstrumentFixture implements DbFixture<PaymentInstrumentFixt
     private String addressCounty;
     private String addressCountry = "UK";
     private String lastDigitsCardNumber = "4242";
+    private String firstDigitsCardNumber = "424242";
     private String expiryDate = "10/21";
     private String cardBrand = "visa";
+    private CardType cardType = CardType.CREDIT;
     private PaymentInstrumentType type = PaymentInstrumentType.CARD;
     private Integer eventCount = 1;
     private ZonedDateTime createdDate = ZonedDateTime.now(ZoneOffset.UTC);
@@ -47,9 +50,9 @@ public class PaymentInstrumentFixture implements DbFixture<PaymentInstrumentFixt
     @Override
     public PaymentInstrumentFixture insert(Jdbi jdbi) {
         var sql = "INSERT INTO payment_instrument" +
-                "(id, external_id, agreement_external_id, email, cardholder_name, address_line1, address_line2, address_postcode, address_city, address_county, address_country, last_digits_card_number, expiry_date, card_brand, type, event_count, created_date) " +
+                "(id, external_id, agreement_external_id, email, cardholder_name, address_line1, address_line2, address_postcode, address_city, address_county, address_country, last_digits_card_number, first_digits_card_number, expiry_date, card_brand, card_type, type, event_count, created_date) " +
                 "VALUES " +
-                "(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
+                "(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
 
         jdbi.withHandle(h ->
                 h.execute(
@@ -66,8 +69,10 @@ public class PaymentInstrumentFixture implements DbFixture<PaymentInstrumentFixt
                         addressCounty,
                         addressCountry,
                         lastDigitsCardNumber,
+                        firstDigitsCardNumber,
                         expiryDate,
                         cardBrand,
+                        cardType,
                         type,
                         eventCount,
                         createdDate
@@ -90,8 +95,10 @@ public class PaymentInstrumentFixture implements DbFixture<PaymentInstrumentFixt
                 addressCounty,
                 addressCountry,
                 lastDigitsCardNumber,
+                firstDigitsCardNumber,
                 expiryDate,
                 cardBrand,
+                cardType,
                 type,
                 createdDate,
                 eventCount

--- a/src/test/java/uk/gov/pay/ledger/util/fixture/PaymentInstrumentFixture.java
+++ b/src/test/java/uk/gov/pay/ledger/util/fixture/PaymentInstrumentFixture.java
@@ -4,6 +4,7 @@ import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.RandomUtils;
 import org.jdbi.v3.core.Jdbi;
 import uk.gov.pay.ledger.agreement.entity.PaymentInstrumentEntity;
+import uk.gov.service.payments.commons.model.agreement.PaymentInstrumentType;
 
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
@@ -24,7 +25,7 @@ public class PaymentInstrumentFixture implements DbFixture<PaymentInstrumentFixt
     private String lastDigitsCardNumber = "4242";
     private String expiryDate = "10/21";
     private String cardBrand = "visa";
-
+    private PaymentInstrumentType type = PaymentInstrumentType.CARD;
     private Integer eventCount = 1;
     private ZonedDateTime createdDate = ZonedDateTime.now(ZoneOffset.UTC);
 
@@ -46,9 +47,9 @@ public class PaymentInstrumentFixture implements DbFixture<PaymentInstrumentFixt
     @Override
     public PaymentInstrumentFixture insert(Jdbi jdbi) {
         var sql = "INSERT INTO payment_instrument" +
-                "(id, external_id, agreement_external_id, email, cardholder_name, address_line1, address_line2, address_postcode, address_city, address_county, address_country, last_digits_card_number, expiry_date, card_brand, event_count, created_date) " +
+                "(id, external_id, agreement_external_id, email, cardholder_name, address_line1, address_line2, address_postcode, address_city, address_county, address_country, last_digits_card_number, expiry_date, card_brand, type, event_count, created_date) " +
                 "VALUES " +
-                "(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
+                "(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
 
         jdbi.withHandle(h ->
                 h.execute(
@@ -67,6 +68,7 @@ public class PaymentInstrumentFixture implements DbFixture<PaymentInstrumentFixt
                         lastDigitsCardNumber,
                         expiryDate,
                         cardBrand,
+                        type,
                         eventCount,
                         createdDate
                 )
@@ -90,6 +92,7 @@ public class PaymentInstrumentFixture implements DbFixture<PaymentInstrumentFixt
                 lastDigitsCardNumber,
                 expiryDate,
                 cardBrand,
+                type,
                 createdDate,
                 eventCount
         );


### PR DESCRIPTION
Depends on https://github.com/alphagov/pay-ledger/pull/2048

Adds `type`, `card_type` and `first_digits_card_number` properties to payment instrument entities and mappers.

---

Include the commons enum `PaymentInstrumentType` across the various
entities and mappers required to set and read from the payment
instrument table.

---

Now that the agreement status is represented with a pay java commons
enum, use this when storing projections from the event stream and
reading from the projection database.