### PR TITLE
PP-9673 CSV download - fix net_amount for dispute transaction

### DIFF
--- a/src/main/java/uk/gov/pay/ledger/transaction/model/CsvTransactionFactory.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/model/CsvTransactionFactory.java
@@ -135,7 +135,7 @@ public class CsvTransactionFactory {
             }
             if (DISPUTE.name().equals(transactionEntity.getTransactionType())) {
                 result.put(FIELD_STATE, DisputeState.getDisplayName(transactionEntity.getState()));
-                result.put(FIELD_NET, penceToCurrency(netOrTotalOrAmount));
+                result.put(FIELD_NET, penceToCurrency(transactionEntity.getNetAmount()));
                 result.put(FIELD_FEE, penceToCurrency(transactionEntity.getFee()));
             }
 


### PR DESCRIPTION
## WHAT
- Set `Net` in the CSV download only if `net_amount` is available for disputes.