### PR TITLE
PP-9671 Accept transaction_type query parameter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,5 @@ dependency-reduced-pom.xml
 bin
 
 .DS_Store
+
+pacts

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 - repo: https://github.com/Yelp/detect-secrets
-  rev: f6027a0521e044ba46e54611cabd787b7a88d1a9 
+  rev: 70e6cf69f2d544a49729039a374d86d7b3e472d9
   hooks:
     - id: detect-secrets
       args: ['--baseline', '.secrets.baseline']

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,5 +1,5 @@
 {
-  "version": "1.1.0",
+  "version": "1.2.0",
   "plugins_used": [
     {
       "name": "ArtifactoryDetector"
@@ -98,18 +98,41 @@
       {
         "type": "Hex High Entropy String",
         "filename": ".pre-commit-config.yaml",
-        "hashed_secret": "d8371c23f86b4df4be2854848f6f28f13d7582f5",
+        "hashed_secret": "7480301177f005722b05b9c2b80ec86d9d74b9fd",
         "is_verified": false,
         "line_number": 3
       }
     ],
-    "dev.yml": [
+    "openapi/ledger_spec.yaml": [
       {
-        "type": "Secret Keyword",
-        "filename": "dev.yml",
-        "hashed_secret": "08cd923367890009657eab812753379bdb321eeb",
-        "is_verified": true,
-        "line_number": 2
+        "type": "Hex High Entropy String",
+        "filename": "openapi/ledger_spec.yaml",
+        "hashed_secret": "cbbaa15cf3814df641e9ee9cb279046f93f322eb",
+        "is_verified": false,
+        "line_number": 1005
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "openapi/ledger_spec.yaml",
+        "hashed_secret": "9baeb3f7db14ddab5d172149762035c0c022d76d",
+        "is_verified": false,
+        "line_number": 1364
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "openapi/ledger_spec.yaml",
+        "hashed_secret": "920734ed7628ef47739eed5571412e2c8271790f",
+        "is_verified": false,
+        "line_number": 1438
+      }
+    ],
+    "src/main/java/uk/gov/pay/ledger/event/model/Event.java": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/main/java/uk/gov/pay/ledger/event/model/Event.java",
+        "hashed_secret": "cbbaa15cf3814df641e9ee9cb279046f93f322eb",
+        "is_verified": false,
+        "line_number": 20
       }
     ],
     "src/test/java/uk/gov/pay/ledger/rule/PostgresTestDocker.java": [
@@ -122,5 +145,5 @@
       }
     ]
   },
-  "generated_at": "2021-08-13T15:28:59Z"
+  "generated_at": "2022-07-26T17:15:02Z"
 }

--- a/openapi/ledger_spec.yaml
+++ b/openapi/ledger_spec.yaml
@@ -718,6 +718,16 @@ paths:
         required: true
         schema:
           type: string
+      - description: The type of transactions to return
+        example: REFUND
+        in: query
+        name: transaction_type
+        schema:
+          type: string
+          enum:
+          - PAYMENT
+          - REFUND
+          - DISPUTE
       responses:
         "200":
           content:
@@ -917,6 +927,7 @@ components:
           - GENERIC
           - REFUND_NOT_AVAILABLE
           - REFUND_AMOUNT_AVAILABLE_MISMATCH
+          - REFUND_NOT_AVAILABLE_DUE_TO_DISPUTE
           - ZERO_AMOUNT_NOT_ALLOWED
           - MOTO_NOT_ALLOWED
           - CANCEL_CHARGE_FAILURE_DUE_TO_CONFLICTING_TERMINAL_STATE_AT_GATEWAY_CHARGE_STATE_FORCIBLY_TRANSITIONED
@@ -935,6 +946,7 @@ components:
           - AUTHORISATION_ERROR
           - AUTHORISATION_TIMEOUT
           - AGREEMENT_NOT_ACTIVE
+          - INCORRECT_AUTHORISATION_MODE_FOR_SAVE_PAYMENT_INSTRUMENT_TO_AGREEMENT
           - MISSING_MANDATORY_ATTRIBUTE
           - UNEXPECTED_ATTRIBUTE
           - ACCOUNT_DISABLED
@@ -1355,6 +1367,8 @@ components:
         description:
           type: string
           example: New passport application
+        disputed:
+          type: boolean
         email:
           type: string
           example: citizen@example.org

--- a/src/main/java/uk/gov/pay/ledger/transaction/dao/TransactionDao.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/dao/TransactionDao.java
@@ -56,7 +56,8 @@ public class TransactionDao {
             "t.gateway_payout_id = po.gateway_payout_id " +
             ":payoutJoinOnGatewayIdField " +
             "WHERE t.parent_external_id = :parentExternalId " +
-            "AND t.gateway_account_id = :gatewayAccountId";
+            "AND t.gateway_account_id = :gatewayAccountId " +
+            "AND (:transactionType::transaction_type is NULL OR type = :transactionType::transaction_type)";
 
     private static final String FIND_TRANSACTIONS_BY_PARENT_EXT_ID =
             "SELECT t.*, po.paid_out_date AS paid_out_date FROM transaction t " +
@@ -264,7 +265,7 @@ public class TransactionDao {
         );
     }
 
-    public List<TransactionEntity> findTransactionByParentIdAndGatewayAccountId(String parentExternalId, String gatewayAccountId) {
+    public List<TransactionEntity> findTransactionsByParentIdAndGatewayAccountId(String parentExternalId, String gatewayAccountId, TransactionType transactionType) {
         String query = FIND_TRANSACTIONS_BY_PARENT_EXT_ID_AND_GATEWAY_ACCOUNT_ID
                 .replace(":payoutJoinOnGatewayIdField",
                         isNotBlank(gatewayAccountId)
@@ -273,6 +274,7 @@ public class TransactionDao {
                 handle.createQuery(query)
                         .bind("parentExternalId", parentExternalId)
                         .bind("gatewayAccountId", gatewayAccountId)
+                        .bind("transactionType", transactionType)
                         .map(new TransactionMapper())
                         .stream().collect(Collectors.toList())
         );

--- a/src/main/java/uk/gov/pay/ledger/transaction/resource/TransactionResource.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/resource/TransactionResource.java
@@ -247,12 +247,14 @@ public class TransactionResource {
             @Parameter(example = "d0sk01d9amdk3ks0dk2dj03kd", description = "Parent transaction external ID", required = true)
             @PathParam("parentTransactionExternalId") String parentTransactionExternalId,
             @Parameter(example = "1", description = "Gateway account ID")
-            @QueryParam("gateway_account_id") @NotEmpty String gatewayAccountId
+            @QueryParam("gateway_account_id") @NotEmpty String gatewayAccountId,
+            @Parameter(example = "REFUND", description = "The type of transactions to return")
+            @QueryParam("transaction_type") TransactionType transactionType
     ) {
         LOGGER.info("Get transactions for parent transaction: [{}], gateway_account_id [{}]",
                 parentTransactionExternalId, gatewayAccountId);
 
-        return transactionService.getTransactions(parentTransactionExternalId, gatewayAccountId);
+        return transactionService.getTransactions(parentTransactionExternalId, gatewayAccountId, transactionType);
     }
 
     @Path("/gateway-transaction/{gatewayTransactionId}")

--- a/src/main/java/uk/gov/pay/ledger/transaction/service/TransactionService.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/service/TransactionService.java
@@ -72,12 +72,13 @@ public class TransactionService {
                 .map(entity -> TransactionView.from(transactionFactory.createTransactionEntity(entity), statusVersion));
     }
 
-    public TransactionsForTransactionResponse getTransactions(String parentTransactionExternalId, String gatewayAccountId) {
+    public TransactionsForTransactionResponse getTransactions(String parentTransactionExternalId, String gatewayAccountId, TransactionType transactionType) {
         return transactionDao.findTransactionByExternalIdAndGatewayAccountId(parentTransactionExternalId, gatewayAccountId)
                 .map(transactionEntity ->
                         findTransactionsForParentExternalId(
                                 transactionEntity.getExternalId(),
-                                transactionEntity.getGatewayAccountId()))
+                                transactionEntity.getGatewayAccountId(),
+                                transactionType))
                 .orElseThrow(() ->
                         new WebApplicationException(format("Transaction with id [%s] not found", parentTransactionExternalId),
                                 Response.Status.NOT_FOUND));
@@ -225,9 +226,9 @@ public class TransactionService {
                 .collect(Collectors.toList());
     }
 
-    private TransactionsForTransactionResponse findTransactionsForParentExternalId(String parentTransactionExternalId, String gatewayAccountId) {
-        List<TransactionView> transactions = transactionDao.findTransactionByParentIdAndGatewayAccountId(
-                parentTransactionExternalId, gatewayAccountId)
+    private TransactionsForTransactionResponse findTransactionsForParentExternalId(String parentTransactionExternalId, String gatewayAccountId, TransactionType transactionType) {
+        List<TransactionView> transactions = transactionDao.findTransactionsByParentIdAndGatewayAccountId(
+                parentTransactionExternalId, gatewayAccountId, transactionType)
                 .stream()
                 .sorted(Comparator.comparing(TransactionEntity::getCreatedDate))
                 .map(transactionEntity ->

--- a/src/test/java/uk/gov/pay/ledger/pact/ContractTest.java
+++ b/src/test/java/uk/gov/pay/ledger/pact/ContractTest.java
@@ -102,6 +102,29 @@ public abstract class ContractTest {
                 "2018-09-22T10:16:16.067Z", TransactionState.ERROR_GATEWAY);
     }
 
+    @State("refund and dispute transactions for a transaction exist")
+    public void createRefundAndDisputeTransactionsForATransaction(Map<String, String> params) {
+        String transactionExternalId = params.get("transaction_external_id");
+        String gatewayAccountId = params.get("gateway_account_id");
+
+        createPaymentTransaction(transactionExternalId, gatewayAccountId);
+
+        createARefundTransaction(transactionExternalId, gatewayAccountId, "refund-transaction-1d1",
+                100L, "reference1", "description1",
+                "2018-09-22T10:14:16.067Z", TransactionState.SUBMITTED);
+
+        createARefundTransaction(transactionExternalId, gatewayAccountId, "refund-transaction-1d2",
+                200L, "reference2", "description2",
+                "2018-09-22T10:16:16.067Z", TransactionState.ERROR_GATEWAY);
+
+        JsonObject transactionDetails = new JsonObject();
+        transactionDetails.addProperty("amount", 1000L);
+        transactionDetails.addProperty("gateway_account_id", gatewayAccountId);
+
+        createDisputeTransaction("dispute-transaction", gatewayAccountId, transactionExternalId, transactionDetails.toString(),
+                TransactionState.NEEDS_RESPONSE, null, 1000L, null, null);
+    }
+
     @State("refund transactions exists for a gateway account")
     public void createRefundTransactionsForAGatewayAccount(Map<String, String> params) {
         String transactionExternalId1 = "someExternalId1";


### PR DESCRIPTION
Accept a transaction_type query parameter for the `/v1/transaction/{parentTransactionExternalId}/transaction` endpoint.

This will filter the child transactions for the specified parent transaction to only return results with the requested transaction type.

This will be used by connector to query for refunds for a transaction without also returning disputes.

Add a pact state that will add a transaction that has both refund and dispute child transactions so we can add a pact test using the `transaction_type` query parameter.

Regenerate the `.secrets.baseline` using v1.2.0 of detect-secrets, which we are now using in pay-connector. Update `.pre-commit-config.yaml` to use this version of detect-secrets.