### PR TITLE
PP-9545 Agreement search status accepts case insensitive

### DIFF
--- a/src/main/java/uk/gov/pay/ledger/agreement/resource/AgreementResource.java
+++ b/src/main/java/uk/gov/pay/ledger/agreement/resource/AgreementResource.java
@@ -7,7 +7,6 @@ import uk.gov.pay.ledger.agreement.model.AgreementSearchResponse;
 import uk.gov.pay.ledger.agreement.service.AgreementService;
 
 import javax.validation.Valid;
-import javax.validation.ValidationException;
 import javax.ws.rs.BeanParam;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;

--- a/src/main/java/uk/gov/pay/ledger/agreement/resource/AgreementSearchParams.java
+++ b/src/main/java/uk/gov/pay/ledger/agreement/resource/AgreementSearchParams.java
@@ -1,6 +1,8 @@
 package uk.gov.pay.ledger.agreement.resource;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import uk.gov.pay.ledger.common.search.SearchParams;
+import uk.gov.service.payments.commons.model.agreement.AgreementStatus;
 
 import javax.validation.constraints.AssertTrue;
 import javax.validation.constraints.NotNull;
@@ -36,7 +38,8 @@ public class AgreementSearchParams extends SearchParams {
     @QueryParam("gateway_account_id")
     private List<String> gatewayAccountIds;
     @QueryParam("status")
-    private String status;
+    @JsonFormat(with = JsonFormat.Feature.ACCEPT_CASE_INSENSITIVE_PROPERTIES)
+    private AgreementStatus status;
     @QueryParam("exact_reference_match")
     private Boolean exactReferenceMatch;
     @QueryParam("reference")
@@ -59,7 +62,7 @@ public class AgreementSearchParams extends SearchParams {
         this.gatewayAccountIds = List.copyOf(gatewayAccountIds);
     }
 
-    public void setStatus(String status) {
+    public void setStatus(AgreementStatus status) {
         this.status = status;
     }
 
@@ -87,7 +90,7 @@ public class AgreementSearchParams extends SearchParams {
             filters.add(" a.gateway_account_id IN (<" + GATEWAY_ACCOUNT_ID_FIELD + ">)");
         }
 
-        if (isNotBlank(status)) {
+        if (status != null) {
             filters.add(" a.status = :" + STATUS_FIELD);
         }
 
@@ -117,7 +120,7 @@ public class AgreementSearchParams extends SearchParams {
                 queryMap.put(GATEWAY_ACCOUNT_ID_FIELD, gatewayAccountIds);
             }
 
-            if (isNotBlank(status)) {
+            if (status != null) {
                 queryMap.put(STATUS_FIELD, status);
             }
 
@@ -144,7 +147,7 @@ public class AgreementSearchParams extends SearchParams {
         return serviceIds;
     }
 
-    public String getStatus() {
+    public AgreementStatus getStatus() {
         return status;
     }
 
@@ -184,7 +187,7 @@ public class AgreementSearchParams extends SearchParams {
             queries.add(GATEWAY_ACCOUNT_ID_FIELD + "=" + String.join(",", gatewayAccountIds));
         }
 
-        if (isNotBlank(status)) {
+        if (status != null) {
             queries.add(STATUS_FIELD + "=" + status);
         }
 

--- a/src/test/java/uk/gov/pay/ledger/agreement/resource/AgreementResourceIT.java
+++ b/src/test/java/uk/gov/pay/ledger/agreement/resource/AgreementResourceIT.java
@@ -3,6 +3,8 @@ package uk.gov.pay.ledger.agreement.resource;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import uk.gov.pay.ledger.extension.AppWithPostgresAndSqsExtension;
 import uk.gov.pay.ledger.transaction.model.CardType;
 import uk.gov.pay.ledger.util.fixture.AgreementFixture;
@@ -110,8 +112,9 @@ public class AgreementResourceIT {
                 .body("results.size()", is((int)(numberOfAgreements - DEFAULT_DISPLAY_SIZE)));
     }
 
-    @Test
-    public void shouldSearchWithFilterParams() {
+    @ParameterizedTest
+    @ValueSource(strings = { "created", "CREATED" })
+    public void shouldSearchWithFilterParams(String searchStatus) {
         AgreementFixture.anAgreementFixture("a-one-agreement-id", "a-one-service-id", AgreementStatus.CREATED, "partial-ref-1").insert(rule.getJdbi());
         AgreementFixture.anAgreementFixture("a-two-agreement-id", "a-one-service-id", AgreementStatus.CREATED, "notmatchingref").insert(rule.getJdbi());
         AgreementFixture.anAgreementFixture("a-three-agreement-id", "a-one-service-id", AgreementStatus.ACTIVE, "anotherref").insert(rule.getJdbi());
@@ -120,7 +123,7 @@ public class AgreementResourceIT {
         given().port(port)
                 .contentType(JSON)
                 .queryParam("service_id", "a-one-service-id")
-                .queryParam("status", "CREATED")
+                .queryParam("status", searchStatus)
                 .queryParam("reference", "partial-ref")
                 .get("/v1/agreement")
                 .then()

--- a/src/test/java/uk/gov/pay/ledger/agreement/resource/AgreementResourceTest.java
+++ b/src/test/java/uk/gov/pay/ledger/agreement/resource/AgreementResourceTest.java
@@ -55,6 +55,38 @@ class AgreementResourceTest {
     }
 
     @Test
+    public void searchShouldReturn200_WithUpperAndLowercaseStatus() {
+        when(agreementService.searchAgreements(any(), any())).thenReturn(new AgreementSearchResponse(0L, 0L, 0L, List.of()));
+        var lowerResponse = resources
+                .target("/v1/agreement")
+                .queryParam("service_id", "a-valid-service-id")
+                .queryParam("status", "created")
+                .request()
+                .get();
+        var upperResponse= resources
+                .target("/v1/agreement")
+                .queryParam("service_id", "a-valid-service-id")
+                .queryParam("status", "CREATED")
+                .request()
+                .get();
+
+        assertThat(lowerResponse.getStatus(), is(200));
+        assertThat(upperResponse.getStatus(), is(200));
+    }
+
+    @Test
+    public void searchShouldReturn400_WithInvalidStatusParam() {
+        Response response = resources
+                .target("/v1/agreement")
+                .queryParam("service_id", "a-valid-service-id")
+                .queryParam("status", "NOT_A_STATUS")
+                .request()
+                .get();
+
+        assertThat(response.getStatus(), is(400));
+    }
+
+    @Test
     public void findShouldReturn404_IfMissing() {
         Response response = resources
                 .target("/v1/agreement/missing-agreement-id")


### PR DESCRIPTION
Use the commons `AgreementStatus` enum to accept agreement search
params. Internally (in the database, in events) this is represented as
the default string version of an enum which default to caps. Public API
will be passing in parsed strings from users which will be lowercase.

Using a case insensitive match on the search param will allow Ledger to
return the expected data but will throw a reasonable error if values
that aren't present in the enum (and therefore can't have been written
to the database) are passed in.