### PR TITLE
PP-9545 Make search param consistent with transactions

### DIFF
--- a/src/main/java/uk/gov/pay/ledger/agreement/resource/AgreementSearchParams.java
+++ b/src/main/java/uk/gov/pay/ledger/agreement/resource/AgreementSearchParams.java
@@ -20,7 +20,7 @@ import static org.apache.commons.lang3.StringUtils.isNotBlank;
 public class AgreementSearchParams extends SearchParams {
 
     private static final String SERVICE_ID_FIELD = "service_id";
-    private static final String GATEWAY_ACCOUNT_ID_FIELD = "gateway_account_id";
+    private static final String GATEWAY_ACCOUNT_ID_FIELD = "account_id";
     private static final String LIVE_FIELD = "live";
     private static final String STATUS_FIELD = "status";
     private static final String REFERENCE_FIELD = "reference";
@@ -35,7 +35,7 @@ public class AgreementSearchParams extends SearchParams {
     private List<String> serviceIds;
     @QueryParam("live")
     private Boolean live;
-    @QueryParam("gateway_account_id")
+    @QueryParam("account_id")
     private List<String> gatewayAccountIds;
     @QueryParam("status")
     @JsonFormat(with = JsonFormat.Feature.ACCEPT_CASE_INSENSITIVE_PROPERTIES)


### PR DESCRIPTION
Transactions expects an `account_id` for search, this is generally
provided by public api. Agreements originally specified this as
`gateway_account_id` as it's more descriptive but change it back to
`account_id` to bring it in line with the other endpoints public api
interacts with.