### PR TITLE
PP-9292 Send raw event message to SNS

### DIFF
--- a/src/main/java/uk/gov/pay/ledger/queue/EventMessage.java
+++ b/src/main/java/uk/gov/pay/ledger/queue/EventMessage.java
@@ -22,6 +22,10 @@ public class EventMessage {
         return Optional.ofNullable(queueMessage).map(QueueMessage::getMessageId);
     }
 
+    public String getRawMessageBody() {
+        return queueMessage.getMessageBody();
+    }
+
     public Event getEvent() {
         return new Event(
                 getQueueMessageId().orElse(null),

--- a/src/main/java/uk/gov/pay/ledger/queue/EventMessageHandler.java
+++ b/src/main/java/uk/gov/pay/ledger/queue/EventMessageHandler.java
@@ -35,7 +35,6 @@ public class EventMessageHandler {
     private final EventPublisher eventPublisher;
     private final MetricRegistry metricRegistry;
     private final LedgerConfig ledgerConfig;
-    private final ObjectMapper objectMapper;
     private final Jdbi jdbi;
 
     @Inject
@@ -45,7 +44,6 @@ public class EventMessageHandler {
                                EventPublisher eventPublisher,
                                MetricRegistry metricRegistry,
                                LedgerConfig ledgerConfig,
-                               ObjectMapper objectMapper,
                                Jdbi jdbi) {
         this.eventQueue = eventQueue;
         this.eventService = eventService;
@@ -53,7 +51,6 @@ public class EventMessageHandler {
         this.eventPublisher = eventPublisher;
         this.metricRegistry = metricRegistry;
         this.ledgerConfig = ledgerConfig;
-        this.objectMapper = objectMapper;
         this.jdbi = jdbi;
     }
 
@@ -103,14 +100,14 @@ public class EventMessageHandler {
                 if (message.getEvent().getResourceType() == ResourceType.DISPUTE) {
                     if (ledgerConfig.getSnsConfig().isPublishCardPaymentDisputeEventsToSns()) {
                         eventPublisher.publishMessageToTopic(
-                                objectMapper.writeValueAsString(message.getEventDto()),
+                                message.getRawMessageBody(),
                                 TopicName.CARD_PAYMENT_DISPUTE_EVENTS
                         );
                     }
                 } else {
                     if (ledgerConfig.getSnsConfig().isPublishCardPaymentEventsToSns()) {
                         eventPublisher.publishMessageToTopic(
-                                objectMapper.writeValueAsString(message.getEventDto()),
+                                message.getRawMessageBody(),
                                 TopicName.CARD_PAYMENT_EVENTS
                         );
                     }

--- a/src/test/java/uk/gov/pay/ledger/queue/EventMessageHandlerTest.java
+++ b/src/test/java/uk/gov/pay/ledger/queue/EventMessageHandlerTest.java
@@ -162,36 +162,34 @@ class EventMessageHandlerTest {
 
     @Test
     void shouldPublishCardPaymentMessageWhenSnsEnabled() throws Exception {
-        var deserializedEvent = "deserialized event";
+        String messageBody = "{ \"foo\": \"bar\"}";
+
         Event event = aQueuePaymentEventFixture().toEntity();
         when(eventMessage.getEvent()).thenReturn(event);
-        var eventDto = new EventMessageDto();
-        when(eventMessage.getEventDto()).thenReturn(eventDto);
+        when(eventMessage.getRawMessageBody()).thenReturn(messageBody);
         when(ledgerConfig.getSnsConfig()).thenReturn(snsConfig);
         when(snsConfig.isSnsEnabled()).thenReturn(true);
         when(snsConfig.isPublishCardPaymentEventsToSns()).thenReturn(true);
-        when(objectMapper.writeValueAsString(eventDto)).thenReturn(deserializedEvent);
 
         eventMessageHandler.handle();
 
-        verify(eventPublisher).publishMessageToTopic(deserializedEvent, TopicName.CARD_PAYMENT_EVENTS);
+        verify(eventPublisher).publishMessageToTopic(messageBody, TopicName.CARD_PAYMENT_EVENTS);
     }
 
     @Test
-    void shouldPublishDisputeMessageWhenSnsEnabled() throws Exception {
-        var deserializedEvent = "deserialized event";
+    void shouldPublishDisputeMessageWhenSnsEnabled() throws Exception {;
+        String messageBody = "{ \"foo\": \"bar\"}";
+
         Event event = aQueuePaymentEventFixture().withResourceType(ResourceType.DISPUTE).toEntity();
         when(eventMessage.getEvent()).thenReturn(event);
-        var eventDto = new EventMessageDto();
-        when(eventMessage.getEventDto()).thenReturn(eventDto);
+        when(eventMessage.getRawMessageBody()).thenReturn(messageBody);
         when(ledgerConfig.getSnsConfig()).thenReturn(snsConfig);
         when(snsConfig.isSnsEnabled()).thenReturn(true);
         when(snsConfig.isPublishCardPaymentDisputeEventsToSns()).thenReturn(true);
-        when(objectMapper.writeValueAsString(eventDto)).thenReturn(deserializedEvent);
 
         eventMessageHandler.handle();
 
-        verify(eventPublisher).publishMessageToTopic(deserializedEvent, TopicName.CARD_PAYMENT_DISPUTE_EVENTS);
+        verify(eventPublisher).publishMessageToTopic(messageBody, TopicName.CARD_PAYMENT_DISPUTE_EVENTS);
     }
 
     @Test


### PR DESCRIPTION
Previously, we were deserialising the event message coming from
SQS queue and then re-serialising it to send it on to SNS.

We weren't re-serialising the event in an identical way, and were
serialising the `event_details` as an escaped string rather than a
nested JSON object.

To avoid these deserialisation mistakes, get the raw string contained in
the original SQS message to send to SNS. The intention is that ledger
does not change the message, and this will ensure this.