### PR TITLE
PP-9593: Change TotalAmount in report CSV

### DIFF
--- a/src/main/java/uk/gov/pay/ledger/transaction/model/CsvTransactionFactory.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/model/CsvTransactionFactory.java
@@ -99,7 +99,15 @@ public class CsvTransactionFactory {
 
                 result.put(FIELD_GOVUK_PAYMENT_ID, transactionEntity.getExternalId());
                 result.put(FIELD_AMOUNT, penceToCurrency(transactionEntity.getAmount()));
-                result.put(FIELD_TOTAL_AMOUNT, penceToCurrency(totalOrAmount));
+
+                if (transactionEntity.getState() == TransactionState.SUCCESS) {
+                    result.put(FIELD_TOTAL_AMOUNT, penceToCurrency(totalOrAmount));
+                } else if (transactionEntity.getState().isFinished()) {
+                    result.put(FIELD_TOTAL_AMOUNT, penceToCurrency(0L));
+                } else {
+                    result.put(FIELD_TOTAL_AMOUNT, "");
+                }
+
                 result.put(FIELD_FEE, penceToCurrency(transactionEntity.getFee()));
                 if (transactionEntity.getState() == TransactionState.SUCCESS) {
                     result.put(FIELD_NET, penceToCurrency(netOrTotalOrAmount));

--- a/src/test/java/uk/gov/pay/ledger/transaction/model/CsvTransactionFactoryTest.java
+++ b/src/test/java/uk/gov/pay/ledger/transaction/model/CsvTransactionFactoryTest.java
@@ -68,7 +68,7 @@ class CsvTransactionFactoryTest {
         assertThat(csvDataMap.get("Date Created"), is("12 Mar 2018"));
         assertThat(csvDataMap.get("Time Created"), is("16:25:01"));
         assertThat(csvDataMap.get("Corporate Card Surcharge"), is("0.23"));
-        assertThat(csvDataMap.get("Total Amount"), is("1.23"));
+        assertThat(csvDataMap.get("Total Amount"), is("0.00"));
         assertThat(csvDataMap.get("MOTO"), is(true));
         assertThat(csvDataMap.get("Payment Provider"), is("sandbox"));
         assertThat(csvDataMap.get("3-D Secure Required"), is(nullValue()));
@@ -143,6 +143,42 @@ class CsvTransactionFactoryTest {
         assertThat(csvDataMap.get("Card Brand"), is("Visa"));
         assertThat(csvDataMap.get("Cardholder Name"), is("J Doe"));
         assertThat(csvDataMap.get("Card Expiry Date"), is("10/21"));
+    }
+
+    @Test
+    void toMapShouldUseAmountForTotalAmountForSuccessfulPayment() {
+        TransactionEntity transactionEntity = transactionFixture
+                .withState(TransactionState.SUCCESS)
+                .withAmount(1500L)
+                .toEntity();
+        Map<String, Object> csvDataMap = csvTransactionFactory.toMap(transactionEntity);
+
+        assertPaymentDetails(csvDataMap, transactionEntity);
+        assertThat(csvDataMap.get("Total Amount"), is("15.00"));
+    }
+
+    @Test
+    void toMapShouldUseZeroForTotalAmountForFailedPayment() {
+        TransactionEntity transactionEntity = transactionFixture
+                .withState(TransactionState.FAILED_REJECTED)
+                .withAmount(1500L)
+                .toEntity();
+        Map<String, Object> csvDataMap = csvTransactionFactory.toMap(transactionEntity);
+
+        assertPaymentDetails(csvDataMap, transactionEntity);
+        assertThat(csvDataMap.get("Total Amount"), is("0.00"));
+    }
+
+    @Test
+    void toMapShouldLeaveTotalAmountBlankForInProgressPayment() {
+        TransactionEntity transactionEntity = transactionFixture
+                .withState(TransactionState.STARTED)
+                .withAmount(1500L)
+                .toEntity();
+        Map<String, Object> csvDataMap = csvTransactionFactory.toMap(transactionEntity);
+
+        assertPaymentDetails(csvDataMap, transactionEntity);
+        assertThat(csvDataMap.get("Total Amount"), is(""));
     }
 
     @Test
@@ -361,7 +397,7 @@ class CsvTransactionFactoryTest {
         assertThat(csvDataMap.get("Date Created"), is("12 Mar 2018"));
         assertThat(csvDataMap.get("Time Created"), is("16:25:01"));
         assertThat(csvDataMap.get("Corporate Card Surcharge"), is("0.23"));
-        assertThat(csvDataMap.get("Total Amount"), is("1.23"));
+        assertThat(csvDataMap.get("Total Amount"), is("0.00"));
         assertThat(csvDataMap.get("MOTO"), is(true));
         assertThat(csvDataMap.get("Payment Provider"), is("sandbox"));
         assertThat(csvDataMap.get("3-D Secure Required"), is(true));

--- a/src/test/java/uk/gov/pay/ledger/transaction/resource/TransactionResourceCsvIT.java
+++ b/src/test/java/uk/gov/pay/ledger/transaction/resource/TransactionResourceCsvIT.java
@@ -134,7 +134,7 @@ public class TransactionResourceCsvIT {
         assertThat(paymentRecord.get("Date Created"), is("12 Mar 2018"));
         assertThat(paymentRecord.get("Time Created"), is("16:25:01"));
         assertThat(paymentRecord.get("Corporate Card Surcharge"), is("0.05"));
-        assertThat(paymentRecord.get("Total Amount"), is("1.23"));
+        assertThat(paymentRecord.get("Total Amount"), is("0.00"));
         assertThat(paymentRecord.get("test-key-1 (metadata)"), is("value1"));
         assertThat(paymentRecord.get("Wallet Type"), is("Apple Pay"));
         assertThat(paymentRecord.isMapped("Net"), is(false));


### PR DESCRIPTION
This column has been causing confusion for some services, so we are changing how it is calculated:

* It remains the same as before for successful payments (amount, plus surcharge if present).
* It is now zero for all non-successful completed payments.
* It is now left blank for any payments still in progress.

These changes will also affect the TotalAmount column in the Payments To Your Bank Account download.