### PR TITLE
Revert "Bump dropwizard-bom from 2.1.0 to 2.1.2"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <mainClass>uk.gov.pay.ledger.app.LedgerApp</mainClass>
 
-        <dropwizard.version>2.1.2</dropwizard.version>
+        <dropwizard.version>2.1.0</dropwizard.version>
         <jackson.version>2.13.4</jackson.version>
         <testcontainers.version>1.17.3</testcontainers.version>
         <postgresql.version>42.5.0</postgresql.version>


### PR DESCRIPTION
Reverts alphagov/pay-ledger#2146

An integration test fails when post-merge tests are run:

uk.gov.pay.ledger.pact.event.DisputeLostEventQueueConsumerIT
Expected: is "DISPUTE_LOST"
     but: was "DISPUTE_WON"
at uk.gov.pay.ledger.pact.event.DisputeLostEventQueueConsumerIT.test(DisputeLostEventQueueConsumerIT.java:101)