### PR TITLE
PP-10004 M1 support for integration tests

### DIFF
--- a/.github/workflows/_run-pact-provider-tests.yml
+++ b/.github/workflows/_run-pact-provider-tests.yml
@@ -47,7 +47,7 @@ jobs:
           restore-keys: ${{ runner.os }}-m2
       - name: Pull docker image dependencies
         run: |
-          docker pull govukpay/postgres:11.1
+          docker pull postgres:11.16
       - name: Run provider pact tests
         run: |
           export MAVEN_REPO="$HOME/.m2"

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -32,7 +32,7 @@ jobs:
           key: ${{ runner.os }}-build-id-${{ github.head_ref }}-${{ github.sha }}-pacts
       - name: Pull docker image dependencies
         run: |
-          docker pull govukpay/postgres:11.1
+          docker pull postgres:11.16
       - name: Run unit and integration tests
         run: mvn clean verify
 

--- a/src/test/java/uk/gov/pay/ledger/rule/SqsTestDocker.java
+++ b/src/test/java/uk/gov/pay/ledger/rule/SqsTestDocker.java
@@ -13,7 +13,7 @@ import org.testcontainers.containers.wait.strategy.Wait;
 public class SqsTestDocker {
     private static final Logger logger = LoggerFactory.getLogger(SqsTestDocker.class);
 
-    private static GenericContainer sqsContainer;
+    private static GenericContainer<?> sqsContainer;
 
     public static AmazonSQS initialise(String... queues) {
         try {
@@ -29,9 +29,9 @@ public class SqsTestDocker {
         if (sqsContainer == null) {
             logger.info("Creating SQS Container");
 
-            sqsContainer = new GenericContainer("mvisonneau/alpine-sqs:1.2.0")
+            sqsContainer = new GenericContainer<>("softwaremill/elasticmq-native")
                     .withExposedPorts(9324)
-                    .waitingFor(Wait.forHttp("/?Action=GetQueueUrl&QueueName=default"));
+                    .waitingFor(Wait.forLogMessage(".*ElasticMQ server.*.*started.*", 1));
 
             sqsContainer.start();
         }

--- a/src/test/resources/config/test-config.yaml
+++ b/src/test/resources/config/test-config.yaml
@@ -22,10 +22,12 @@ database:
   validationQueryTimeout: 3s
 
   # the minimum number of connections to keep open
-  minSize: 8
+  minSize: 2
+
+  initialSize: 2
 
   # the maximum number of connections to keep open
-  maxSize: 32
+  maxSize: 2
 
   # whether or not idle connections should be validated
   checkConnectionWhileIdle: false


### PR DESCRIPTION
### WHAT

- removed use of `govuk/postgres:11`, baselining on architecture agnostic `postgres:11.16`
- updated local sqs image to be consistent with other Pay applications, updated sqs waiting strategy to be compatible with new image
- replaced generic test container with postgres module
  - the module exposes the relevant port and can automatically determine when the database is healthy, removing the need to sleep the thread
- updated GHA to use new images
- limit number of open database connections during integration testing, resolves intermittent PSQLException