### PR TITLE
PP-10255 Check if there are uncommitted changes to OpenApi file

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -33,6 +33,14 @@ jobs:
       - name: Pull docker image dependencies
         run: |
           docker pull postgres:11.16
+      - name: Compile
+        run: mvn clean compile
+      - name: Check for OpenApi file changes
+        run: |
+          if [[ $(git status --porcelain) ]]; then
+            echo "Changes to the OpenApi file have not been committed. Run \`mvn compile\` on your branch to regenerate the file and then commit the changes."
+            exit 1
+          fi
       - name: Run unit and integration tests
-        run: mvn clean verify
+        run: mvn verify
 

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -109,21 +109,21 @@
         "filename": "openapi/ledger_spec.yaml",
         "hashed_secret": "cbbaa15cf3814df641e9ee9cb279046f93f322eb",
         "is_verified": false,
-        "line_number": 1005
+        "line_number": 1021
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/ledger_spec.yaml",
         "hashed_secret": "9baeb3f7db14ddab5d172149762035c0c022d76d",
         "is_verified": false,
-        "line_number": 1364
+        "line_number": 1380
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/ledger_spec.yaml",
         "hashed_secret": "920734ed7628ef47739eed5571412e2c8271790f",
         "is_verified": false,
-        "line_number": 1438
+        "line_number": 1454
       }
     ],
     "src/main/java/uk/gov/pay/ledger/event/model/Event.java": [
@@ -145,5 +145,5 @@
       }
     ]
   },
-  "generated_at": "2022-07-26T17:15:02Z"
+  "generated_at": "2022-10-28T11:55:28Z"
 }

--- a/README.MD
+++ b/README.MD
@@ -2,6 +2,12 @@
 
 This is a bare bones Dropwizard App for the Pay Ledger microservice.
 
+## API Specification
+
+The [API Specification](/openapi/ledger_spec.yaml) provides more detail on the paths and operations including examples.
+
+[View the API specification for ledger in Swagger Editor](https://editor.swagger.io/?url=https://raw.githubusercontent.com/alphagov/pay-ledger/master/openapi/ledger_spec.yaml).
+
 ## Environment variables
 
 There are several environment variables used for the app configuration. They're grouped in categories: database, SQS

--- a/openapi/ledger_spec.yaml
+++ b/openapi/ledger_spec.yaml
@@ -700,6 +700,22 @@ paths:
       summary: Get transaction for a gateway transaction ID
       tags:
       - Transactions
+  /v1/transaction/redact-reference/{transactionExternalId}:
+    post:
+      operationId: redactReference
+      parameters:
+      - in: path
+        name: transactionExternalId
+        required: true
+        schema:
+          type: string
+      responses:
+        default:
+          content:
+            application/json; qs=1: {}
+          description: default response
+      tags:
+      - Transactions
   /v1/transaction/{parentTransactionExternalId}/transaction:
     get:
       operationId: getTransactionsForParentTransaction


### PR DESCRIPTION
Add a check in the GitHub actions workflow that runs on PR builds to check whether there are uncommitted changes after running `mvn compile`. If there are, this suggests that there have been changes to the API specification and the OpenApi file has not been regenerated. Fail the build when uncommitted changes are detected.

Add section for the API specification in the README with a link to view in Swagger Editor.