### PR TITLE
PP-10116 update secrets baseline, pre-commit conf

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -8,6 +8,13 @@ permissions:
   contents: read
 
 jobs:
+  detect-secrets:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Git checkout
+        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
+      - name: Detect secrets
+        uses: alphagov/pay-ci/actions/detect-secrets@master
   integration-tests:
     name: Unit and Integration tests
     runs-on: ubuntu-latest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,6 @@
 repos:
-- repo: https://github.com/Yelp/detect-secrets
-  rev: 70e6cf69f2d544a49729039a374d86d7b3e472d9
-  hooks:
-    - id: detect-secrets
-      args: ['--baseline', '.secrets.baseline']
-      exclude: package.lock.json
+  - repo: https://github.com/Yelp/detect-secrets
+    rev: v1.4.0
+    hooks:
+      - id: detect-secrets
+        args: [ '--baseline', '.secrets.baseline' ]

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,11 +1,14 @@
 {
-  "version": "1.2.0",
+  "version": "1.4.0",
   "plugins_used": [
     {
       "name": "ArtifactoryDetector"
     },
     {
       "name": "AWSKeyDetector"
+    },
+    {
+      "name": "AzureStorageKeyDetector"
     },
     {
       "name": "Base64HighEntropyString",
@@ -18,8 +21,14 @@
       "name": "CloudantDetector"
     },
     {
+      "name": "DiscordBotTokenDetector"
+    },
+    {
+      "name": "GitHubTokenDetector"
+    },
+    {
       "name": "HexHighEntropyString",
-      "limit": 3
+      "limit": 3.0
     },
     {
       "name": "IbmCloudIamDetector"
@@ -38,13 +47,22 @@
       "name": "MailchimpDetector"
     },
     {
+      "name": "NpmDetector"
+    },
+    {
       "name": "PrivateKeyDetector"
+    },
+    {
+      "name": "SendGridDetector"
     },
     {
       "name": "SlackDetector"
     },
     {
       "name": "SoftlayerDetector"
+    },
+    {
+      "name": "SquareOAuthDetector"
     },
     {
       "name": "StripeDetector"
@@ -56,10 +74,6 @@
   "filters_used": [
     {
       "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
-    },
-    {
-      "path": "detect_secrets.filters.common.is_baseline_file",
-      "filename": ".secrets.baseline"
     },
     {
       "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
@@ -94,15 +108,6 @@
     }
   ],
   "results": {
-    ".pre-commit-config.yaml": [
-      {
-        "type": "Hex High Entropy String",
-        "filename": ".pre-commit-config.yaml",
-        "hashed_secret": "7480301177f005722b05b9c2b80ec86d9d74b9fd",
-        "is_verified": false,
-        "line_number": 3
-      }
-    ],
     "openapi/ledger_spec.yaml": [
       {
         "type": "Hex High Entropy String",
@@ -135,6 +140,15 @@
         "line_number": 20
       }
     ],
+    "src/test/java/uk/gov/pay/ledger/pact/ContractTest.java": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/test/java/uk/gov/pay/ledger/pact/ContractTest.java",
+        "hashed_secret": "fa143a7a660dac99bd4755c518d72306ad2df9d1",
+        "is_verified": false,
+        "line_number": 660
+      }
+    ],
     "src/test/java/uk/gov/pay/ledger/rule/PostgresTestDocker.java": [
       {
         "type": "Secret Keyword",
@@ -145,5 +159,5 @@
       }
     ]
   },
-  "generated_at": "2022-10-28T11:55:28Z"
+  "generated_at": "2022-11-08T17:17:29Z"
 }


### PR DESCRIPTION
### WHAT

- added a new github action to run `detect-secrets`
- updated the pre-commit config to update the detect-secrets hook to version `1.4`
- rebaselined the repository's secrets baseline

#### For reviewers

- ensure your local version of `detect-secrets` matches the latest version in use on this branch
- run `detect-secrets scan` and ensure output matches the latest `.secrets.baseline`, the only change should be the generated timestamp