### PR TITLE
PP-10437 Add user identifier column to agreements table

### DIFF
--- a/src/main/resources/migrations/00076_add_user_identifier_column_to_agreements_table.sql
+++ b/src/main/resources/migrations/00076_add_user_identifier_column_to_agreements_table.sql
@@ -1,0 +1,7 @@
+--liquibase formatted sql
+
+--changeset uk.gov.pay:add_user_identifier_column_to_agreements_table
+ALTER TABLE agreement ADD COLUMN user_identifier VARCHAR(255);
+
+--changeset uk.gov.pay:add_user_identifier_index_to_agreements_table runInTransaction:false
+CREATE INDEX CONCURRENTLY agreement_user_identifier_idx ON agreement(user_identifier);


### PR DESCRIPTION
The user identifier is currently included in the event stream when agreements are created, this data needs to be represented on the Ledger agreement resource and will then be used by the API and the admin tool.

Add a column to the agreements projection table to allow the object mapper to appropriately set the `user_identifier` attribute.

Index the user identifier using a standard btree index, this will allow us filter agreements by this value if required in the future. It's likely that most agreements won't come with user identifiers initially so this shouldn't use up much space.