### PR TITLE
PP-10437 Serialisation for user identifier on agreements 

### DIFF
--- a/src/main/java/uk/gov/pay/ledger/agreement/dao/AgreementDao.java
+++ b/src/main/java/uk/gov/pay/ledger/agreement/dao/AgreementDao.java
@@ -50,7 +50,8 @@ public class AgreementDao {
             "description," +
             "status," +
             "created_date," +
-            "event_count" +
+            "event_count," +
+            "user_identifier" +
             ") " +
             "VALUES (" +
             ":externalId, " +
@@ -61,7 +62,8 @@ public class AgreementDao {
             ":description, " +
             ":status, " +
             ":createdDate, " +
-            ":eventCount" +
+            ":eventCount," +
+            ":userIdentifier" +
             ") " +
             "ON CONFLICT (external_id) DO UPDATE SET " +
             "external_id = EXCLUDED.external_id, " +
@@ -72,7 +74,8 @@ public class AgreementDao {
             "description = EXCLUDED.description, " +
             "status = EXCLUDED.status, " +
             "created_date = EXCLUDED.created_date, " +
-            "event_count = EXCLUDED.event_count " +
+            "event_count = EXCLUDED.event_count," +
+            "user_identifier = EXCLUDED.user_identifier " +
             "WHERE EXCLUDED.event_count >= agreement.event_count";
 
     private static final String SEARCH_AGREEMENT =

--- a/src/main/java/uk/gov/pay/ledger/agreement/dao/AgreementMapper.java
+++ b/src/main/java/uk/gov/pay/ledger/agreement/dao/AgreementMapper.java
@@ -4,8 +4,6 @@ import org.jdbi.v3.core.mapper.RowMapper;
 import org.jdbi.v3.core.statement.StatementContext;
 import uk.gov.pay.ledger.agreement.entity.AgreementEntity;
 import uk.gov.pay.ledger.agreement.entity.PaymentInstrumentEntity;
-import uk.gov.pay.ledger.event.model.Event;
-import uk.gov.pay.ledger.event.model.ResourceType;
 import uk.gov.pay.ledger.transaction.model.CardType;
 import uk.gov.service.payments.commons.model.agreement.AgreementStatus;
 import uk.gov.service.payments.commons.model.agreement.PaymentInstrumentType;
@@ -58,7 +56,7 @@ public class AgreementMapper implements RowMapper<AgreementEntity> {
                 getBooleanWithNullCheck(resultSet,"live"),
                 ZonedDateTime.ofInstant(resultSet.getTimestamp("created_date").toInstant(), ZoneOffset.UTC),
                 resultSet.getInt("event_count"),
-                paymentInstrument
-        );
+                paymentInstrument,
+                resultSet.getString("user_identifier"));
     }
 }

--- a/src/main/java/uk/gov/pay/ledger/agreement/entity/AgreementEntity.java
+++ b/src/main/java/uk/gov/pay/ledger/agreement/entity/AgreementEntity.java
@@ -20,12 +20,13 @@ public class AgreementEntity {
     private ZonedDateTime createdDate;
     private Integer eventCount;
     private PaymentInstrumentEntity paymentInstrument;
+    private String userIdentifier;
 
     public AgreementEntity() {
 
     }
 
-    public AgreementEntity(String externalId, String gatewayAccountId, String serviceId, String reference, String description, AgreementStatus status, Boolean live, ZonedDateTime createdDate, Integer eventCount, PaymentInstrumentEntity paymentInstrument) {
+    public AgreementEntity(String externalId, String gatewayAccountId, String serviceId, String reference, String description, AgreementStatus status, Boolean live, ZonedDateTime createdDate, Integer eventCount, PaymentInstrumentEntity paymentInstrument, String userIdentifier) {
         this.externalId = externalId;
         this.gatewayAccountId = gatewayAccountId;
         this.serviceId = serviceId;
@@ -36,6 +37,7 @@ public class AgreementEntity {
         this.createdDate = createdDate;
         this.eventCount = eventCount;
         this.paymentInstrument = paymentInstrument;
+        this.userIdentifier = userIdentifier;
     }
 
     public String getExternalId() {
@@ -116,5 +118,13 @@ public class AgreementEntity {
 
     public void setPaymentInstrument(PaymentInstrumentEntity paymentInstrument) {
         this.paymentInstrument = paymentInstrument;
+    }
+
+    public String getUserIdentifier() {
+        return userIdentifier;
+    }
+
+    public void setUserIdentifier(String userIdentifier) {
+        this.userIdentifier = userIdentifier;
     }
 }

--- a/src/main/java/uk/gov/pay/ledger/agreement/model/Agreement.java
+++ b/src/main/java/uk/gov/pay/ledger/agreement/model/Agreement.java
@@ -21,8 +21,9 @@ public class Agreement {
     @JsonSerialize(using = ApiResponseDateTimeSerializer.class)
     private ZonedDateTime createdDate;
     private PaymentInstrument paymentInstrument;
+    private String userIdentifier;
 
-    public Agreement(String externalId, String serviceId, String reference, String description, AgreementStatus status, Boolean live, ZonedDateTime createdDate, PaymentInstrument paymentInstrument) {
+    public Agreement(String externalId, String serviceId, String reference, String description, AgreementStatus status, Boolean live, ZonedDateTime createdDate, PaymentInstrument paymentInstrument, String userIdentifier) {
         this.externalId = externalId;
         this.serviceId = serviceId;
         this.reference = reference;
@@ -31,6 +32,7 @@ public class Agreement {
         this.live = live;
         this.createdDate = createdDate;
         this.paymentInstrument = paymentInstrument;
+        this.userIdentifier = userIdentifier;
     }
 
     public static Agreement from(AgreementEntity entity) {
@@ -42,8 +44,8 @@ public class Agreement {
                 entity.getStatus(),
                 entity.getLive(),
                 entity.getCreatedDate(),
-                Optional.ofNullable(entity.getPaymentInstrument()).map(PaymentInstrument::from).orElse(null)
-        );
+                Optional.ofNullable(entity.getPaymentInstrument()).map(PaymentInstrument::from).orElse(null),
+                entity.getUserIdentifier());
     }
 
     public String getExternalId() {
@@ -76,5 +78,9 @@ public class Agreement {
 
     public PaymentInstrument getPaymentInstrument() {
         return paymentInstrument;
+    }
+
+    public String getUserIdentifier() {
+        return userIdentifier;
     }
 }

--- a/src/test/java/uk/gov/pay/ledger/agreement/AgreementDaoIT.java
+++ b/src/test/java/uk/gov/pay/ledger/agreement/AgreementDaoIT.java
@@ -29,12 +29,14 @@ class AgreementDaoIT {
     @Test
     void shouldInsertAgreement() {
         AgreementFixture fixture = AgreementFixture.anAgreementFixture();
+        fixture.setUserIdentifier("an-valid-user-identifier");
         agreementDao.upsert(fixture.toEntity());
 
         AgreementEntity fetchedEntity = agreementDao.findByExternalId(fixture.getExternalId()).get();
 
         assertThat(fetchedEntity, is(notNullValue()));
         assertThat(fetchedEntity.getExternalId(), is(fixture.getExternalId()));
+        assertThat(fetchedEntity.getUserIdentifier(), is("an-valid-user-identifier"));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/ledger/agreement/AgreementDaoIT.java
+++ b/src/test/java/uk/gov/pay/ledger/agreement/AgreementDaoIT.java
@@ -29,14 +29,14 @@ class AgreementDaoIT {
     @Test
     void shouldInsertAgreement() {
         AgreementFixture fixture = AgreementFixture.anAgreementFixture();
-        fixture.setUserIdentifier("an-valid-user-identifier");
+        fixture.setUserIdentifier("a-valid-user-identifier");
         agreementDao.upsert(fixture.toEntity());
 
         AgreementEntity fetchedEntity = agreementDao.findByExternalId(fixture.getExternalId()).get();
 
         assertThat(fetchedEntity, is(notNullValue()));
         assertThat(fetchedEntity.getExternalId(), is(fixture.getExternalId()));
-        assertThat(fetchedEntity.getUserIdentifier(), is("an-valid-user-identifier"));
+        assertThat(fetchedEntity.getUserIdentifier(), is("a-valid-user-identifier"));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/ledger/agreement/entity/AgreementsFactoryTest.java
+++ b/src/test/java/uk/gov/pay/ledger/agreement/entity/AgreementsFactoryTest.java
@@ -27,6 +27,7 @@ class AgreementsFactoryTest {
                         .toJson(Map.of(
                                 "reference", "agreement-reference",
                                 "description", "agreement description text",
+                                "user_identifier", "a-valid-user-identifier",
                                 "status", "CREATED"
                         ))
                 )
@@ -40,6 +41,7 @@ class AgreementsFactoryTest {
         assertThat(entity.getEventCount(), is(1));
         assertThat(entity.getReference(), is("agreement-reference"));
         assertThat(entity.getDescription(), is("agreement description text"));
+        assertThat(entity.getUserIdentifier(), is("a-valid-user-identifier"));
         assertThat(entity.getStatus(), is(AgreementStatus.CREATED));
     }
 

--- a/src/test/java/uk/gov/pay/ledger/agreement/resource/AgreementResourceIT.java
+++ b/src/test/java/uk/gov/pay/ledger/agreement/resource/AgreementResourceIT.java
@@ -37,8 +37,9 @@ public class AgreementResourceIT {
 
     @Test
     public void shouldGetAgreement() {
-        var fixture = AgreementFixture.anAgreementFixture("a-valid-agreement-id", "a-valid-service-id")
-            .insert(rule.getJdbi());
+        var fixture = AgreementFixture.anAgreementFixture("a-valid-agreement-id", "a-valid-service-id");
+        fixture.setUserIdentifier("a-valid-user-identifier");
+        fixture.insert(rule.getJdbi());
 
         given().port(port)
                 .contentType(JSON)
@@ -46,7 +47,8 @@ public class AgreementResourceIT {
                 .then()
                 .statusCode(Response.Status.OK.getStatusCode())
                 .contentType(JSON)
-                .body("external_id", is(fixture.getExternalId()));
+                .body("external_id", is(fixture.getExternalId()))
+                .body("user_identifier", is("a-valid-user-identifier"));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/ledger/util/fixture/AgreementFixture.java
+++ b/src/test/java/uk/gov/pay/ledger/util/fixture/AgreementFixture.java
@@ -21,6 +21,7 @@ public class AgreementFixture implements DbFixture<AgreementFixture, AgreementEn
     private boolean live = false;
     private ZonedDateTime createdDate = ZonedDateTime.now(ZoneOffset.UTC);
     private Integer eventCount = 1;
+    private String userIdentifier;
 
     private AgreementFixture() {
     }
@@ -48,9 +49,9 @@ public class AgreementFixture implements DbFixture<AgreementFixture, AgreementEn
     @Override
     public AgreementFixture insert(Jdbi jdbi) {
         var sql = "INSERT INTO agreement" +
-                "(id, external_id, gateway_account_id, service_id, reference, description, status, live, created_date, event_count) " +
+                "(id, external_id, gateway_account_id, service_id, reference, description, status, live, created_date, event_count, user_identifier) " +
                 "VALUES " +
-                "(?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
+                "(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
 
         jdbi.withHandle(h ->
                 h.execute(
@@ -64,7 +65,8 @@ public class AgreementFixture implements DbFixture<AgreementFixture, AgreementEn
                         status,
                         live,
                         createdDate,
-                        eventCount
+                        eventCount,
+                        userIdentifier
                 )
         );
         return this;
@@ -82,8 +84,8 @@ public class AgreementFixture implements DbFixture<AgreementFixture, AgreementEn
                 live,
                 createdDate,
                 eventCount,
-                null
-        );
+                null,
+                userIdentifier);
     }
 
     public String getExternalId() {
@@ -120,5 +122,9 @@ public class AgreementFixture implements DbFixture<AgreementFixture, AgreementEn
 
     public ZonedDateTime getCreatedDate() {
         return createdDate;
+    }
+
+    public void setUserIdentifier(String userIdentifier) {
+        this.userIdentifier = userIdentifier;
     }
 }


### PR DESCRIPTION
Depends on https://github.com/alphagov/pay-ledger/pull/2340

Add `userIdentifier` to the agreement entity which maps to the new
`user_identifier` column introduced in
https://github.com/alphagov/pay-ledger/pull/2340.

Set mappings between the agreement entity and agreement model, assert
that this is appropriately then shown from the agreement resource.