### PR TITLE
PP-10445: Factor out some resource logic into a service

### DIFF
--- a/src/test/java/uk/gov/pay/ledger/agreement/resource/AgreementResourceTest.java
+++ b/src/test/java/uk/gov/pay/ledger/agreement/resource/AgreementResourceTest.java
@@ -7,48 +7,37 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
-import uk.gov.pay.ledger.agreement.entity.AgreementEntity;
 import uk.gov.pay.ledger.agreement.model.AgreementSearchResponse;
 import uk.gov.pay.ledger.agreement.service.AgreementService;
-import uk.gov.pay.ledger.event.model.EventDigest;
-import uk.gov.pay.ledger.event.service.EventService;
 import uk.gov.pay.ledger.exception.BadRequestExceptionMapper;
-import uk.gov.pay.ledger.exception.EmptyEventsException;
 import uk.gov.pay.ledger.exception.JerseyViolationExceptionMapper;
 
 import javax.ws.rs.core.Response;
 
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
-import static uk.gov.pay.ledger.util.fixture.EventFixture.anEventFixture;
 
 @ExtendWith(DropwizardExtensionsSupport.class)
 @ExtendWith(MockitoExtension.class)
 class AgreementResourceTest {
 
     private static final AgreementService agreementService = mock(AgreementService.class);
-    private static final EventService eventService = mock(EventService.class);
 
     public static final ResourceExtension resources = ResourceExtension.builder()
-            .addResource(new AgreementResource(agreementService, eventService))
+            .addResource(new AgreementResource(agreementService))
             .addProvider(BadRequestExceptionMapper.class)
             .addProvider(JerseyViolationExceptionMapper.class)
             .build();
 
     @BeforeEach
     public void setUp() {
-        Mockito.reset(agreementService, eventService);
+        Mockito.reset(agreementService);
     }
 
     @Test
@@ -116,117 +105,15 @@ class AgreementResourceTest {
     }
 
     @Test
-    public void findShouldReturnProjectionDirectlyIfConsistentNotProvided() {
-        when(agreementService.findAgreementEntity("agreement-id"))
-                .thenReturn(Optional.of(stubAgreement("agreement-id", 1)));
-        var response = resources
-                .target("/v1/agreement/agreement-id")
-                .request()
-                .get();
-        assertThat(response.getStatus(), is(200));
-        assertThat(response.readEntity(Map.class).get("external_id"), is("agreement-id"));
-        verifyNoInteractions(eventService);
-    }
-    @Test
-    public void findShouldReturnProjectionDirectlyIfConsistentFalse() {
-        when(agreementService.findAgreementEntity("agreement-id"))
-                .thenReturn(Optional.of(stubAgreement("agreement-id", 1)));
-        var response = resources
-                .target("/v1/agreement/agreement-id")
-                .request()
-                .header("X-Consistent", false)
-                .get();
-        assertThat(response.getStatus(), is(200));
-        assertThat(response.readEntity(Map.class).get("external_id"), is("agreement-id"));
-        verifyNoInteractions(eventService);
-    }
-
-    @Test
-    public void findConsistentShouldReturnProjectionDirectlyIfThereAreNoNewEvents() {
-        var resourceId = "agreement-id";
-        when(agreementService.findAgreementEntity(resourceId))
-                .thenReturn(Optional.of(stubAgreement(resourceId, 1)));
-        when(eventService.getEventDigestForResource(resourceId))
-                .thenReturn(stubEventDigest(resourceId, 1));
-        var response = resources
-                .target("/v1/agreement/" + resourceId)
-                .request()
-                .header("X-Consistent", true)
-                .get();
-        assertThat(response.getStatus(), is(200));
-        assertThat(response.readEntity(Map.class).get("external_id"), is(resourceId));
-        verify(eventService).getEventDigestForResource(resourceId);
-    }
-
-    @Test
-    public void findConsistentShouldReturnNewProjectionIfThereAreNewEvents() {
-        var resourceId = "agreement-id";
-        var agreement = stubAgreement(resourceId, 1);
-        var eventDigest = stubEventDigest(resourceId, 2);
-        when(agreementService.findAgreementEntity(resourceId))
-                .thenReturn(Optional.of(agreement));
-        when(eventService.getEventDigestForResource(resourceId))
-                .thenReturn(eventDigest);
-        when(agreementService.projectAgreement(eventDigest))
-                .thenReturn(agreement);
-        var response = resources
-                .target("/v1/agreement/" + resourceId)
-                .request()
-                .header("X-Consistent", true)
-                .get();
-        assertThat(response.getStatus(), is(200));
-        assertThat(response.readEntity(Map.class).get("external_id"), is(resourceId));
-        verify(eventService).getEventDigestForResource(resourceId);
-        verify(agreementService).projectAgreement(eventDigest);
-    }
-
-    @Test
-    public void findConsistentShouldReturnNewProjectionIfThereAreOnlyEventsAndNoProjection() {
-        var resourceId = "agreement-id";
-        var eventDigest = stubEventDigest(resourceId, 1);
-        when(agreementService.findAgreementEntity(resourceId))
-                .thenReturn(Optional.empty());
-        when(eventService.getEventDigestForResource(resourceId))
-                .thenReturn(eventDigest);
-        when(agreementService.projectAgreement(eventDigest))
-                .thenReturn(stubAgreement(resourceId, 1));
-        var response = resources
-                .target("/v1/agreement/" + resourceId)
-                .request()
-                .header("X-Consistent", true)
-                .get();
-        assertThat(response.getStatus(), is(200));
-        assertThat(response.readEntity(Map.class).get("external_id"), is(resourceId));
-        verify(eventService).getEventDigestForResource(resourceId);
-        verify(agreementService).projectAgreement(eventDigest);
-    }
-
-    @Test
     public void findConsistentShouldReturn404_IfMissing() {
         var resourceId = "agreement-id";
-        when(agreementService.findAgreementEntity(resourceId))
+        when(agreementService.findAgreementEntity(resourceId, true))
                 .thenReturn(Optional.empty());
-        when(eventService.getEventDigestForResource(resourceId))
-                .thenThrow(EmptyEventsException.class);
         var response = resources
                 .target("/v1/agreement/" + resourceId)
                 .request()
                 .header("X-Consistent", true)
                 .get();
         assertThat(response.getStatus(), is(404));
-        verify(eventService).getEventDigestForResource(resourceId);
-    }
-
-    private AgreementEntity stubAgreement(String agreementId, Integer eventCount) {
-        var agreementEntity = new AgreementEntity();
-        agreementEntity.setExternalId(agreementId);
-        agreementEntity.setEventCount(eventCount);
-        return agreementEntity;
-    }
-
-    private EventDigest stubEventDigest(String agreementId, Integer eventCount) {
-        return EventDigest.fromEventList(IntStream.range(0, eventCount)
-                .mapToObj(i -> anEventFixture().withResourceExternalId(agreementId).toEntity())
-                .collect(Collectors.toUnmodifiableList()));
     }
 }

--- a/src/test/java/uk/gov/pay/ledger/agreement/service/AgreementServiceTest.java
+++ b/src/test/java/uk/gov/pay/ledger/agreement/service/AgreementServiceTest.java
@@ -1,0 +1,124 @@
+package uk.gov.pay.ledger.agreement.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.pay.ledger.agreement.dao.AgreementDao;
+import uk.gov.pay.ledger.agreement.dao.PaymentInstrumentDao;
+import uk.gov.pay.ledger.agreement.entity.AgreementEntity;
+import uk.gov.pay.ledger.agreement.entity.AgreementsFactory;
+import uk.gov.pay.ledger.event.model.EventDigest;
+import uk.gov.pay.ledger.event.service.EventService;
+import uk.gov.pay.ledger.exception.EmptyEventsException;
+
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+import static uk.gov.pay.ledger.util.fixture.EventFixture.anEventFixture;
+
+@ExtendWith(MockitoExtension.class)
+public class AgreementServiceTest {
+
+    private static final AgreementDao agreementDao = mock(AgreementDao.class);
+    private static final PaymentInstrumentDao paymentInstrumentDao = mock(PaymentInstrumentDao.class);
+    private static final AgreementsFactory agreementEntityFactory = mock(AgreementsFactory.class);
+    private static final EventService eventService = mock(EventService.class);
+
+    private AgreementService agreementService;
+
+    @BeforeEach
+    public void setUp() {
+        reset(agreementDao, paymentInstrumentDao, agreementEntityFactory, eventService);
+        agreementService = new AgreementService(agreementDao, paymentInstrumentDao, agreementEntityFactory, eventService);
+    }
+
+    @Test
+    public void findShouldReturnProjectionDirectlyIfConsistentFalse() {
+        var resourceId = "agreement-id";
+        var agreement = stubAgreement(resourceId, 1);
+        when(agreementDao.findByExternalId(resourceId))
+                .thenReturn(Optional.of(agreement));
+
+        var result = agreementService.findAgreementEntity("agreement-id", false);
+
+        assertThat(result, is(Optional.of(agreement)));
+        verifyNoInteractions(eventService);
+    }
+
+    @Test
+    public void findShouldReturnProjectionDirectlyIfConsistentTrueButThereAreNoNewEvents() {
+        var resourceId = "agreement-id";
+        var agreement = stubAgreement(resourceId, 1);
+        when(eventService.getEventDigestForResource(resourceId))
+                .thenReturn(stubEventDigest(resourceId, 1));
+        when(agreementDao.findByExternalId(resourceId))
+                .thenReturn(Optional.of(agreement));
+
+        var result = agreementService.findAgreementEntity(resourceId, true);
+
+        assertThat(result, is(Optional.of(agreement)));
+    }
+
+    @Test
+    public void findShouldReturnNewProjectionIfConsistentTrueAndThereAreNewEvents() {
+        var resourceId = "agreement-id";
+        var agreement = stubAgreement(resourceId, 1);
+        var eventDigest = stubEventDigest(resourceId, 2);
+        when(eventService.getEventDigestForResource(resourceId))
+                .thenReturn(eventDigest);
+        when(agreementEntityFactory.create(eventDigest))
+                .thenReturn(agreement);
+
+        var result = agreementService.findAgreementEntity(resourceId, true);
+
+        assertThat(result, is(Optional.of(agreement)));
+    }
+
+    @Test
+    public void findShouldReturnNewProjectionIfConsistentTrueAndThereAreOnlyEventsAndNoProjection() {
+        var resourceId = "agreement-id";
+        var agreement = stubAgreement(resourceId, 1);
+        var eventDigest = stubEventDigest(resourceId, 1);
+        when(eventService.getEventDigestForResource(resourceId))
+                .thenReturn(eventDigest);
+        when(agreementEntityFactory.create(eventDigest))
+                .thenReturn(agreement);
+
+        var result = agreementService.findAgreementEntity(resourceId, true);
+
+        assertThat(result, is(Optional.of(agreement)));
+    }
+
+    @Test
+    public void findShouldReturnEmptyValueWhenEventServiceHasNoEvents() {
+        var resourceId = "agreement-id";
+        when(eventService.getEventDigestForResource(resourceId))
+                .thenThrow(EmptyEventsException.class);
+
+        var result = agreementService.findAgreementEntity(resourceId, true);
+
+        assertThat(result, is(Optional.empty()));
+    }
+
+    private AgreementEntity stubAgreement(String agreementId, Integer eventCount) {
+        var agreementEntity = new AgreementEntity();
+        agreementEntity.setExternalId(agreementId);
+        agreementEntity.setEventCount(eventCount);
+        return agreementEntity;
+    }
+
+    private EventDigest stubEventDigest(String agreementId, Integer eventCount) {
+        return EventDigest.fromEventList(IntStream.range(0, eventCount)
+                .mapToObj(i -> anEventFixture().withResourceExternalId(agreementId).toEntity())
+                .collect(Collectors.toUnmodifiableList()));
+    }
+
+}


### PR DESCRIPTION
Move the bulk of the logic for endpoint `/v1/agreement/{agreementExternalId}` into `AgreementService`, to facilitate testing.  We're about to make this more complex by adding some filters, so taking the existing logic out of the resource class is worthwhile.