### PR TITLE
PP-10485 Add pact state for search agreements

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -150,7 +150,7 @@
         "filename": "src/test/java/uk/gov/pay/ledger/pact/ContractTest.java",
         "hashed_secret": "fa143a7a660dac99bd4755c518d72306ad2df9d1",
         "is_verified": false,
-        "line_number": 660
+        "line_number": 683
       }
     ],
     "src/test/java/uk/gov/pay/ledger/rule/PostgresTestDocker.java": [
@@ -163,5 +163,5 @@
       }
     ]
   },
-  "generated_at": "2023-01-05T12:00:56Z"
+  "generated_at": "2023-01-10T16:41:28Z"
 }

--- a/src/test/java/uk/gov/pay/ledger/agreement/AgreementDaoIT.java
+++ b/src/test/java/uk/gov/pay/ledger/agreement/AgreementDaoIT.java
@@ -28,8 +28,7 @@ class AgreementDaoIT {
 
     @Test
     void shouldInsertAgreement() {
-        AgreementFixture fixture = AgreementFixture.anAgreementFixture();
-        fixture.setUserIdentifier("a-valid-user-identifier");
+        AgreementFixture fixture = AgreementFixture.anAgreementFixture().withUserIdentifier("a-valid-user-identifier");
         agreementDao.upsert(fixture.toEntity());
 
         AgreementEntity fetchedEntity = agreementDao.findByExternalId(fixture.getExternalId()).get();
@@ -79,7 +78,7 @@ class AgreementDaoIT {
         AgreementFixture agreementFixture = AgreementFixture.anAgreementFixture();
         var paymentInstrumentFixtureOne = PaymentInstrumentFixture.aPaymentInstrumentFixture("aaa", agreementFixture.getExternalId(), ZonedDateTime.now(ZoneOffset.UTC).minusDays(10));
         var paymentInstrumentFixtureTwo = PaymentInstrumentFixture.aPaymentInstrumentFixture("aab", agreementFixture.getExternalId(), ZonedDateTime.now(ZoneOffset.UTC));
-        var paymentInstrumentFixtureThree= PaymentInstrumentFixture.aPaymentInstrumentFixture("aac", agreementFixture.getExternalId(), ZonedDateTime.now(ZoneOffset.UTC).minusDays(5));
+        var paymentInstrumentFixtureThree = PaymentInstrumentFixture.aPaymentInstrumentFixture("aac", agreementFixture.getExternalId(), ZonedDateTime.now(ZoneOffset.UTC).minusDays(5));
         agreementDao.upsert(agreementFixture.toEntity());
         paymentInstrumentDao.upsert(paymentInstrumentFixtureOne.toEntity());
         paymentInstrumentDao.upsert(paymentInstrumentFixtureTwo.toEntity());
@@ -91,8 +90,12 @@ class AgreementDaoIT {
 
     @Test
     void shouldSearchAgreement() {
-        var fixture = AgreementFixture.anAgreementFixture("external-id", "service-id");
-        var secondFixture = AgreementFixture.anAgreementFixture("second-external-id", "second-service-id");
+        var fixture = AgreementFixture.anAgreementFixture()
+                .withExternalId("external-id")
+                .withServiceId("service-id");
+        var secondFixture = AgreementFixture.anAgreementFixture()
+                .withExternalId("second-external-id")
+                .withServiceId("second-service-id");
         agreementDao.upsert(fixture.toEntity());
         agreementDao.upsert(secondFixture.toEntity());
 

--- a/src/test/java/uk/gov/pay/ledger/agreement/resource/AgreementResourceIT.java
+++ b/src/test/java/uk/gov/pay/ledger/agreement/resource/AgreementResourceIT.java
@@ -39,9 +39,11 @@ class AgreementResourceIT {
 
     @Test
     void shouldGetAgreement() {
-        var fixture = AgreementFixture.anAgreementFixture("a-valid-agreement-id", "a-valid-service-id");
-        fixture.setUserIdentifier("a-valid-user-identifier");
-        fixture.insert(rule.getJdbi());
+        var fixture = AgreementFixture.anAgreementFixture()
+                .withExternalId("a-valid-agreement-id")
+                .withServiceId("a-valid-service-id")
+                .withUserIdentifier("a-valid-user-identifier")
+                .insert(rule.getJdbi());
 
         given().port(port)
                 .contentType(JSON)
@@ -55,7 +57,9 @@ class AgreementResourceIT {
 
     @Test
     void shouldGetAgreementWithPaymentInstrument() {
-        var agreementFixture = AgreementFixture.anAgreementFixture("a-valid-agreement-id", "a-valid-service-id")
+        var agreementFixture = AgreementFixture.anAgreementFixture()
+                .withExternalId("a-valid-agreement-id")
+                .withServiceId("a-valid-service-id")
                 .insert(rule.getJdbi());
         var paymentInstrumentFixture = PaymentInstrumentFixture.aPaymentInstrumentFixture("a-payment-instrument-id", "a-valid-agreement-id", ZonedDateTime.now())
                 .insert(rule.getJdbi());
@@ -100,9 +104,9 @@ class AgreementResourceIT {
                 .statusCode(Response.Status.OK.getStatusCode())
                 .contentType(JSON)
                 .body("total", is(numberOfAgreements))
-                .body("count", is((int)DEFAULT_DISPLAY_SIZE))
+                .body("count", is((int) DEFAULT_DISPLAY_SIZE))
                 .body("page", is(1))
-                .body("results.size()", is((int)DEFAULT_DISPLAY_SIZE))
+                .body("results.size()", is((int) DEFAULT_DISPLAY_SIZE))
                 .body("_links.self.href", containsString("v1/agreement?service_id=a-valid-service-id&page=1&display_size=20"))
                 .body("_links.first_page.href", containsString("v1/agreement?service_id=a-valid-service-id&page=1&display_size=20"))
                 .body("_links.last_page.href", containsString("v1/agreement?service_id=a-valid-service-id&page=2&display_size=20"))
@@ -118,9 +122,9 @@ class AgreementResourceIT {
                 .statusCode(Response.Status.OK.getStatusCode())
                 .contentType(JSON)
                 .body("total", is(numberOfAgreements))
-                .body("count", is((int)(numberOfAgreements - DEFAULT_DISPLAY_SIZE)))
+                .body("count", is((int) (numberOfAgreements - DEFAULT_DISPLAY_SIZE)))
                 .body("page", is(2))
-                .body("results.size()", is((int)(numberOfAgreements - DEFAULT_DISPLAY_SIZE)))
+                .body("results.size()", is((int) (numberOfAgreements - DEFAULT_DISPLAY_SIZE)))
                 .body("_links.self.href", containsString("v1/agreement?service_id=a-valid-service-id&page=2&display_size=20"))
                 .body("_links.first_page.href", containsString("v1/agreement?service_id=a-valid-service-id&page=1&display_size=20"))
                 .body("_links.last_page.href", containsString("v1/agreement?service_id=a-valid-service-id&page=2&display_size=20"))
@@ -148,13 +152,38 @@ class AgreementResourceIT {
     }
 
     @ParameterizedTest
-    @ValueSource(strings = { "created", "CREATED" })
+    @ValueSource(strings = {"created", "CREATED"})
     void shouldSearchWithFilterParams(String searchStatus) {
-        AgreementFixture.anAgreementFixture("a-one-agreement-id", "a-one-service-id", AgreementStatus.CREATED, "partial-ref-1").insert(rule.getJdbi());
-        AgreementFixture.anAgreementFixture("a-two-agreement-id", "a-one-service-id", AgreementStatus.CREATED, "notmatchingref").insert(rule.getJdbi());
-        AgreementFixture.anAgreementFixture("a-three-agreement-id", "a-one-service-id", AgreementStatus.ACTIVE, "anotherref").insert(rule.getJdbi());
-        AgreementFixture.anAgreementFixture("a-four-agreement-id", "a-two-service-id", AgreementStatus.CREATED, "reference").insert(rule.getJdbi());
-        AgreementFixture.anAgreementFixture("a-five-agreement-id", "a-one-service-id", AgreementStatus.CREATED, "avalid-partial-ref").insert(rule.getJdbi());
+        AgreementFixture.anAgreementFixture()
+                .withExternalId("a-one-agreement-id")
+                .withServiceId("a-one-service-id")
+                .withStatus(AgreementStatus.CREATED)
+                .withReference("partial-ref-1")
+                .insert(rule.getJdbi());
+        AgreementFixture.anAgreementFixture()
+                .withExternalId("a-two-agreement-id")
+                .withServiceId("a-one-service-id")
+                .withStatus(AgreementStatus.CREATED)
+                .withReference("notmatchingref")
+                .insert(rule.getJdbi());
+        AgreementFixture.anAgreementFixture()
+                .withExternalId("a-three-agreement-id")
+                .withServiceId("a-one-service-id")
+                .withStatus(AgreementStatus.ACTIVE)
+                .withReference("anotherref")
+                .insert(rule.getJdbi());
+        AgreementFixture.anAgreementFixture()
+                .withExternalId("a-four-agreement-id")
+                .withServiceId("a-two-service-id")
+                .withStatus(AgreementStatus.CREATED)
+                .withReference("reference")
+                .insert(rule.getJdbi());
+        AgreementFixture.anAgreementFixture()
+                .withExternalId("a-five-agreement-id")
+                .withServiceId("a-one-service-id")
+                .withStatus(AgreementStatus.CREATED)
+                .withReference("avalid-partial-ref")
+                .insert(rule.getJdbi());
         given().port(port)
                 .contentType(JSON)
                 .queryParam("service_id", "a-one-service-id")
@@ -174,9 +203,13 @@ class AgreementResourceIT {
 
     @Test
     void shouldGetConsistentAgreement_GetExistingProjectionWhenUpToDate() {
-        var agreementFixture = AgreementFixture.anAgreementFixture("agreement-id", "service-id", AgreementStatus.CREATED, "projected-agreement-reference");
-        agreementFixture.setEventCount(1);
-        agreementFixture.insert(rule.getJdbi());
+        var agreementFixture = AgreementFixture.anAgreementFixture()
+                .withExternalId("agreement-id")
+                .withServiceId("service-id")
+                .withStatus(AgreementStatus.CREATED)
+                .withReference("projected-agreement-reference")
+                .withEventCount(1)
+                .insert(rule.getJdbi());
 
         EventFixture.anEventFixture()
                 .withResourceExternalId("agreement-id")
@@ -203,9 +236,13 @@ class AgreementResourceIT {
 
     @Test
     void shouldGetConsistentAgreement_GetEventStreamCalculatedWhenProjectionCountBehind() {
-        var agreementFixture = AgreementFixture.anAgreementFixture("agreement-id", "service-id", AgreementStatus.CREATED, "projected-agreement-reference");
-        agreementFixture.setEventCount(1);
-        agreementFixture.insert(rule.getJdbi());
+        var agreementFixture = AgreementFixture.anAgreementFixture()
+                .withExternalId("agreement-id")
+                .withServiceId("service-id")
+                .withStatus(AgreementStatus.CREATED)
+                .withReference("projected-agreement-reference")
+                .withEventCount(1)
+                .insert(rule.getJdbi());
 
         EventFixture.anEventFixture()
                 .withResourceExternalId("agreement-id")
@@ -280,7 +317,9 @@ class AgreementResourceIT {
 
     private void prepareAgreementsForService(String serviceId, int numberOfAgreements) {
         for (int i = 0; i < numberOfAgreements; i++) {
-            AgreementFixture.anAgreementFixture("a-valid-external-id-" + i, serviceId)
+            AgreementFixture.anAgreementFixture()
+                    .withExternalId("a-valid-external-id-" + i)
+                    .withServiceId(serviceId)
                     .insert(rule.getJdbi());
         }
     }

--- a/src/test/java/uk/gov/pay/ledger/pact/ContractTest.java
+++ b/src/test/java/uk/gov/pay/ledger/pact/ContractTest.java
@@ -17,7 +17,9 @@ import uk.gov.pay.ledger.transaction.model.TransactionType;
 import uk.gov.pay.ledger.transaction.search.model.RefundSummary;
 import uk.gov.pay.ledger.transaction.state.TransactionState;
 import uk.gov.pay.ledger.util.DatabaseTestHelper;
+import uk.gov.pay.ledger.util.fixture.AgreementFixture;
 import uk.gov.pay.ledger.util.fixture.TransactionFixture;
+import uk.gov.service.payments.commons.model.agreement.AgreementStatus;
 
 import java.time.ZonedDateTime;
 import java.util.Map;
@@ -602,6 +604,27 @@ public abstract class ContractTest {
                 .withGatewayAccountId(gatewayAccountId)
                 .withPaidOutDate(ZonedDateTime.parse("2020-09-19T19:05:00Z"))
                 .build()
+                .insert(app.getJdbi());
+    }
+
+    @State("3 agreements exist for account")
+    public void agreementsExist(Map<String, String> params) {
+        String accountId = params.get("account_id");
+
+        AgreementFixture.anAgreementFixture()
+                .withGatewayAccountId(accountId)
+                .withExternalId("agreement-1")
+                .withStatus(AgreementStatus.CREATED)
+                .insert(app.getJdbi());
+        AgreementFixture.anAgreementFixture()
+                .withGatewayAccountId(accountId)
+                .withExternalId("agreement-2")
+                .withStatus(AgreementStatus.CREATED)
+                .insert(app.getJdbi());
+        AgreementFixture.anAgreementFixture()
+                .withGatewayAccountId(accountId)
+                .withExternalId("agreement-3")
+                .withStatus(AgreementStatus.ACTIVE)
                 .insert(app.getJdbi());
     }
 

--- a/src/test/java/uk/gov/pay/ledger/util/fixture/AgreementFixture.java
+++ b/src/test/java/uk/gov/pay/ledger/util/fixture/AgreementFixture.java
@@ -4,6 +4,7 @@ import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.RandomUtils;
 import org.jdbi.v3.core.Jdbi;
 import uk.gov.pay.ledger.agreement.entity.AgreementEntity;
+import uk.gov.pay.ledger.agreement.entity.PaymentInstrumentEntity;
 import uk.gov.service.payments.commons.model.agreement.AgreementStatus;
 
 import java.time.ZoneOffset;
@@ -12,11 +13,11 @@ import java.time.ZonedDateTime;
 public class AgreementFixture implements DbFixture<AgreementFixture, AgreementEntity> {
 
     private Long id = RandomUtils.nextLong(1, 99999);
-    private String serviceId = RandomStringUtils.randomAlphanumeric(26);
-    private String gatewayAccountId = RandomStringUtils.randomAlphanumeric(10);
-    private String externalId = RandomStringUtils.randomAlphanumeric(20);
-    private String reference = RandomStringUtils.randomAlphanumeric(10);
-    private String description = RandomStringUtils.randomAlphanumeric(20);
+    private String serviceId = "a-service-id";
+    private String gatewayAccountId = "1";
+    private String externalId = "an-external-id";
+    private String reference = "a-reference";
+    private String description = "a description";
     private AgreementStatus status = AgreementStatus.ACTIVE;
     private boolean live = false;
     private ZonedDateTime createdDate = ZonedDateTime.now(ZoneOffset.UTC);
@@ -26,24 +27,74 @@ public class AgreementFixture implements DbFixture<AgreementFixture, AgreementEn
     private AgreementFixture() {
     }
 
-    public static AgreementFixture anAgreementFixture(String externalId, String serviceId) {
-        var fixture = new AgreementFixture();
-        fixture.setExternalId(externalId);
-        fixture.setServiceId(serviceId);
-        return fixture;
-    }
-
-    public static AgreementFixture anAgreementFixture(String externalId, String serviceId, AgreementStatus status, String reference) {
-        var fixture = new AgreementFixture();
-        fixture.setExternalId(externalId);
-        fixture.setServiceId(serviceId);
-        fixture.setStatus(status);
-        fixture.setReference(reference);
-        return fixture;
-    }
-
     public static AgreementFixture anAgreementFixture() {
         return new AgreementFixture();
+    }
+
+    public String getExternalId() {
+        return externalId;
+    }
+
+    public String getServiceId() {
+        return serviceId;
+    }
+
+    public ZonedDateTime getCreatedDate() {
+        return createdDate;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public AgreementFixture withExternalId(String externalId) {
+        this.externalId = externalId;
+        return this;
+    }
+
+    public AgreementFixture withGatewayAccountId(String gatewayAccountId) {
+        this.gatewayAccountId = gatewayAccountId;
+        return this;
+    }
+
+    public AgreementFixture withServiceId(String serviceId) {
+        this.serviceId = serviceId;
+        return this;
+    }
+
+    public AgreementFixture withReference(String reference) {
+        this.reference = reference;
+        return this;
+    }
+
+    public AgreementFixture withDescription(String description) {
+        this.description = description;
+        return this;
+    }
+
+    public AgreementFixture withStatus(AgreementStatus status) {
+        this.status = status;
+        return this;
+    }
+
+    public AgreementFixture withLive(Boolean live) {
+        this.live = live;
+        return this;
+    }
+
+    public AgreementFixture withCreatedDate(ZonedDateTime createdDate) {
+        this.createdDate = createdDate;
+        return this;
+    }
+
+    public AgreementFixture withEventCount(Integer eventCount) {
+        this.eventCount = eventCount;
+        return this;
+    }
+
+    public AgreementFixture withUserIdentifier(String userIdentifier) {
+        this.userIdentifier = userIdentifier;
+        return this;
     }
 
     @Override
@@ -86,45 +137,5 @@ public class AgreementFixture implements DbFixture<AgreementFixture, AgreementEn
                 eventCount,
                 null,
                 userIdentifier);
-    }
-
-    public String getExternalId() {
-        return externalId;
-    }
-
-    public String getServiceId() {
-        return serviceId;
-    }
-
-    public void setServiceId(String serviceId) {
-        this.serviceId = serviceId;
-    }
-
-    public void setExternalId(String externalId) {
-        this.externalId = externalId;
-    }
-
-    public void setStatus(AgreementStatus status) {
-        this.status = status;
-    }
-
-    public void setReference(String reference) {
-        this.reference = reference;
-    }
-
-    public void setEventCount(Integer eventCount) {
-        this.eventCount = eventCount;
-    }
-
-    public String getDescription() {
-        return description;
-    }
-
-    public ZonedDateTime getCreatedDate() {
-        return createdDate;
-    }
-
-    public void setUserIdentifier(String userIdentifier) {
-        this.userIdentifier = userIdentifier;
     }
 }


### PR DESCRIPTION
- Add a pact state to set up a number of agreements for use by a public API pact to to test the page/display size query parameters and the links returned in the response.
- Convert AgreementFixture to use the builder pattern.