### PR TITLE
PP-10445: Add filters to `/v1/agreement/{agreementExternalId}` endpoint

### DIFF
--- a/src/main/java/uk/gov/pay/ledger/agreement/resource/AgreementResource.java
+++ b/src/main/java/uk/gov/pay/ledger/agreement/resource/AgreementResource.java
@@ -13,6 +13,7 @@ import javax.ws.rs.HeaderParam;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.Response;
@@ -46,8 +47,15 @@ public class AgreementResource {
     @Timed
     public Agreement get(@PathParam("agreementExternalId") String agreementExternalId,
                          @HeaderParam(HEADER_PARAM_X_CONSISTENT) Boolean isConsistent,
+                         @QueryParam("account_id") String accountId,
+                         @QueryParam("service_id") String serviceId,
+                         @QueryParam("override_account_or_service_id_restriction") Boolean overrideFilterRestrictions,
                          @Context UriInfo uriInfo) {
-        return agreementService.findAgreementEntity(agreementExternalId, Boolean.TRUE.equals(isConsistent))
+        if (!Boolean.TRUE.equals(overrideFilterRestrictions) && accountId == null && serviceId == null) {
+            throw new WebApplicationException("One of [service_id] or [account_id] fields is required", 422);
+        }
+
+        return agreementService.findAgreementEntity(agreementExternalId, Boolean.TRUE.equals(isConsistent), accountId, serviceId)
                 .map(Agreement::from)
                 .orElseThrow(() -> new WebApplicationException(Response.Status.NOT_FOUND));
     }

--- a/src/main/java/uk/gov/pay/ledger/agreement/resource/AgreementSearchParams.java
+++ b/src/main/java/uk/gov/pay/ledger/agreement/resource/AgreementSearchParams.java
@@ -22,6 +22,7 @@ public class AgreementSearchParams extends SearchParams {
 
     private static final String SERVICE_ID_FIELD = "service_id";
     private static final String GATEWAY_ACCOUNT_ID_FIELD = "account_id";
+    private static final String FILTERS_RESTRICTION_OVERRIDE_FIELD = "override_account_or_service_id_restriction";
     private static final String LIVE_FIELD = "live";
     private static final String STATUS_FIELD = "status";
     private static final String REFERENCE_FIELD = "reference";
@@ -38,6 +39,8 @@ public class AgreementSearchParams extends SearchParams {
     private Boolean live;
     @QueryParam("account_id")
     private List<String> gatewayAccountIds;
+    @QueryParam("override_account_or_service_id_restriction")
+    private Boolean overrideAccountOrServiceIdRestriction;
     @QueryParam("status")
     @JsonFormat(with = JsonFormat.Feature.ACCEPT_CASE_INSENSITIVE_PROPERTIES)
     private AgreementStatus status;
@@ -52,7 +55,7 @@ public class AgreementSearchParams extends SearchParams {
 
     @AssertTrue(message = "One of field [" + SERVICE_ID_FIELD + "] or field [" + GATEWAY_ACCOUNT_ID_FIELD + "] are required")
     private boolean isServiceIdsOrGatewayAccountIds() {
-        return !(getServiceIds().isEmpty() && getGatewayAccountIds().isEmpty());
+        return Boolean.TRUE == getOverrideAccountOrServiceIdRestriction() || !(getServiceIds().isEmpty() && getGatewayAccountIds().isEmpty());
     }
 
     public void setServiceIds(List<String> serviceIds) {
@@ -61,6 +64,10 @@ public class AgreementSearchParams extends SearchParams {
 
     public void setGatewayAccountIds(List<String> gatewayAccountIds) {
         this.gatewayAccountIds = List.copyOf(gatewayAccountIds);
+    }
+
+    public void setOverrideAccountOrServiceIdRestriction(Boolean overrideAccountOrServiceIdRestriction) {
+        this.overrideAccountOrServiceIdRestriction = overrideAccountOrServiceIdRestriction;
     }
 
     public void setStatus(AgreementStatus status) {
@@ -153,6 +160,10 @@ public class AgreementSearchParams extends SearchParams {
 
     public List<String> getServiceIds() {
         return serviceIds;
+    }
+
+    public Boolean getOverrideAccountOrServiceIdRestriction() {
+        return overrideAccountOrServiceIdRestriction;
     }
 
     public AgreementStatus getStatus() {

--- a/src/test/java/uk/gov/pay/ledger/agreement/resource/AgreementResourceTest.java
+++ b/src/test/java/uk/gov/pay/ledger/agreement/resource/AgreementResourceTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.pay.ledger.agreement.entity.AgreementEntity;
 import uk.gov.pay.ledger.agreement.model.AgreementSearchResponse;
 import uk.gov.pay.ledger.agreement.service.AgreementService;
 import uk.gov.pay.ledger.exception.BadRequestExceptionMapper;
@@ -95,9 +96,51 @@ class AgreementResourceTest {
     }
 
     @Test
+    public void findShouldReturn422_IfFiltersNotProvidedAndOverrideNotSpecified() {
+        when(agreementService.findAgreementEntity("agreement-id", false, null, null))
+                .thenReturn(Optional.of(stubAgreement("agreement-id", 1)));
+
+        var response = resources
+                .target("/v1/agreement/agreement-id")
+                .request()
+                .get();
+
+        assertThat(response.getStatus(), is(422));
+    }
+
+    @Test
+    public void findShouldReturn422_IfFiltersNotProvidedAndOverrideIsFalse() {
+        when(agreementService.findAgreementEntity("agreement-id", false, null, null))
+                .thenReturn(Optional.of(stubAgreement("agreement-id", 1)));
+
+        var response = resources
+                .target("/v1/agreement/agreement-id")
+                .queryParam("override_account_or_service_id_restriction", false)
+                .request()
+                .get();
+
+        assertThat(response.getStatus(), is(422));
+    }
+
+    @Test
+    public void findShouldSucceedIfFiltersNotProvidedButOverrideIsTrue() {
+        when(agreementService.findAgreementEntity("agreement-id", false, null, null))
+                .thenReturn(Optional.of(stubAgreement("agreement-id", 1)));
+
+        var response = resources
+                .target("/v1/agreement/agreement-id")
+                .queryParam("override_account_or_service_id_restriction", true)
+                .request()
+                .get();
+
+        assertThat(response.getStatus(), is(200));
+    }
+
+    @Test
     public void findShouldReturn404_IfMissing() {
         Response response = resources
                 .target("/v1/agreement/missing-agreement-id")
+                .queryParam("override_account_or_service_id_restriction", true)
                 .request()
                 .get();
 
@@ -111,9 +154,17 @@ class AgreementResourceTest {
                 .thenReturn(Optional.empty());
         var response = resources
                 .target("/v1/agreement/" + resourceId)
+                .queryParam("override_account_or_service_id_restriction", true)
                 .request()
                 .header("X-Consistent", true)
                 .get();
         assertThat(response.getStatus(), is(404));
+    }
+
+    private AgreementEntity stubAgreement(String agreementId, Integer eventCount) {
+        var agreementEntity = new AgreementEntity();
+        agreementEntity.setExternalId(agreementId);
+        agreementEntity.setEventCount(eventCount);
+        return agreementEntity;
     }
 }

--- a/src/test/java/uk/gov/pay/ledger/agreement/resource/AgreementResourceTest.java
+++ b/src/test/java/uk/gov/pay/ledger/agreement/resource/AgreementResourceTest.java
@@ -42,16 +42,6 @@ class AgreementResourceTest {
     }
 
     @Test
-    public void searchShouldReturn422_WithMissingBothServiceIdAndGatewayAccountId() {
-        Response response = resources
-                .target("/v1/agreement")
-                .request()
-                .get();
-
-        assertThat(response.getStatus(), is(422));
-    }
-
-    @Test
     public void searchShouldReturn200_WithValidParams() {
         when(agreementService.searchAgreements(any(), any())).thenReturn(new AgreementSearchResponse(0L, 0L, 0L, List.of()));
         Response response = resources
@@ -93,6 +83,39 @@ class AgreementResourceTest {
                 .get();
 
         assertThat(response.getStatus(), is(400));
+    }
+
+    @Test
+    public void searchShouldReturn422_WithMissingBothServiceIdAndGatewayAccountId_WhenOverrideNotSpecified() {
+        Response response = resources
+                .target("/v1/agreement")
+                .request()
+                .get();
+
+        assertThat(response.getStatus(), is(422));
+    }
+
+    @Test
+    public void searchShouldReturn422_WithMissingBothServiceIdAndGatewayAccountId_WhenOverrideIsFalse() {
+        Response response = resources
+                .target("/v1/agreement")
+                .queryParam("override_account_or_service_id_restriction", false)
+                .request()
+                .get();
+
+        assertThat(response.getStatus(), is(422));
+    }
+
+    @Test
+    public void searchShouldReturn200_WithMissingBothServiceIdAndGatewayAccountId_WhenOverrideIsTrue() {
+        when(agreementService.searchAgreements(any(), any())).thenReturn(new AgreementSearchResponse(0L, 0L, 0L, List.of()));
+        Response response = resources
+                .target("/v1/agreement")
+                .queryParam("override_account_or_service_id_restriction", true)
+                .request()
+                .get();
+
+        assertThat(response.getStatus(), is(200));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/ledger/queue/QueueMessageReceiverIT.java
+++ b/src/test/java/uk/gov/pay/ledger/queue/QueueMessageReceiverIT.java
@@ -465,6 +465,7 @@ public class QueueMessageReceiverIT {
 
         given().port(rule.getAppRule().getLocalPort())
                 .contentType(JSON)
+                .queryParam("override_account_or_service_id_restriction", true)
                 .get("/v1/agreement/a-valid-agreement-id")
                 .then()
                 .statusCode(200)
@@ -517,6 +518,7 @@ public class QueueMessageReceiverIT {
 
         given().port(rule.getAppRule().getLocalPort())
                 .contentType(JSON)
+                .queryParam("override_account_or_service_id_restriction", true)
                 .get("/v1/agreement/" + agreementId)
                 .then()
                 .statusCode(200)


### PR DESCRIPTION
* New filters are `account_id` and `service_id`
* Either or both of these must be provided, unless the `override_account_or_service_id_restriction` query param is submitted and set to true
* I've reordered some of the existing integration tests