### PR TITLE
PP-10485 Add pact state for search payments by agreement_id

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -150,7 +150,7 @@
         "filename": "src/test/java/uk/gov/pay/ledger/pact/ContractTest.java",
         "hashed_secret": "fa143a7a660dac99bd4755c518d72306ad2df9d1",
         "is_verified": false,
-        "line_number": 683
+        "line_number": 703
       }
     ],
     "src/test/java/uk/gov/pay/ledger/rule/PostgresTestDocker.java": [
@@ -163,5 +163,5 @@
       }
     ]
   },
-  "generated_at": "2023-01-10T16:41:28Z"
+  "generated_at": "2023-01-12T16:20:31Z"
 }

--- a/src/test/java/uk/gov/pay/ledger/pact/ContractTest.java
+++ b/src/test/java/uk/gov/pay/ledger/pact/ContractTest.java
@@ -19,6 +19,7 @@ import uk.gov.pay.ledger.transaction.state.TransactionState;
 import uk.gov.pay.ledger.util.DatabaseTestHelper;
 import uk.gov.pay.ledger.util.fixture.AgreementFixture;
 import uk.gov.pay.ledger.util.fixture.TransactionFixture;
+import uk.gov.service.payments.commons.model.AuthorisationMode;
 import uk.gov.service.payments.commons.model.agreement.AgreementStatus;
 
 import java.time.ZonedDateTime;
@@ -625,6 +626,25 @@ public abstract class ContractTest {
                 .withGatewayAccountId(accountId)
                 .withExternalId("agreement-3")
                 .withStatus(AgreementStatus.ACTIVE)
+                .insert(app.getJdbi());
+    }
+
+    @State("a recurring card payment exists for agreement")
+    public void recurringCardPaymentExistsForAgreement(Map<String, String> params) {
+        String accountId = params.get("account_id");
+        String agreementId = params.get("agreement_id");
+
+        TransactionFixture.aTransactionFixture()
+                .withGatewayAccountId(accountId)
+                .withAgreementId(agreementId)
+                .withAuthorisationMode(AuthorisationMode.AGREEMENT)
+                .withDefaultTransactionDetails()
+                .insert(app.getJdbi());
+        TransactionFixture.aTransactionFixture()
+                .withGatewayAccountId(accountId)
+                .withAgreementId("other-agreement-id")
+                .withAuthorisationMode(AuthorisationMode.AGREEMENT)
+                .withDefaultTransactionDetails()
                 .insert(app.getJdbi());
     }
 

--- a/src/test/java/uk/gov/pay/ledger/util/fixture/TransactionFixture.java
+++ b/src/test/java/uk/gov/pay/ledger/util/fixture/TransactionFixture.java
@@ -17,6 +17,7 @@ import uk.gov.pay.ledger.transaction.model.TransactionFactory;
 import uk.gov.pay.ledger.transaction.model.TransactionType;
 import uk.gov.pay.ledger.transaction.search.model.RefundSummary;
 import uk.gov.pay.ledger.transaction.state.TransactionState;
+import uk.gov.service.payments.commons.model.AuthorisationMode;
 import uk.gov.service.payments.commons.model.Source;
 
 import java.time.ZoneOffset;
@@ -78,6 +79,7 @@ public class TransactionFixture implements DbFixture<TransactionFixture, Transac
     private String version3ds;
     private String agreementId;
     private Boolean disputed;
+    private AuthorisationMode authorisationMode = AuthorisationMode.WEB;
 
     private TransactionFixture() {
     }
@@ -351,6 +353,11 @@ public class TransactionFixture implements DbFixture<TransactionFixture, Transac
         return this;
     }
 
+    public TransactionFixture withAuthorisationMode(AuthorisationMode authorisationMode) {
+        this.authorisationMode = authorisationMode;
+        return this;
+    }
+
     @Override
     public TransactionFixture insert(Jdbi jdbi) {
         jdbi.withHandle(h ->
@@ -459,6 +466,7 @@ public class TransactionFixture implements DbFixture<TransactionFixture, Transac
         transactionDetails.addProperty("user_email", refundedByUserEmail);
         transactionDetails.addProperty("card_type", defaultCardType);
         transactionDetails.addProperty("wallet", defaultWalletType);
+        transactionDetails.addProperty("authorisation_mode", authorisationMode.getName());
 
         if ("REFUND".equals(transactionType) || "DISPUTE".equals(transactionType)) {
             refundPaymentDetails.addProperty("card_brand_label", cardBrandLabel);


### PR DESCRIPTION
Add pact state that inserts a recurring payment for an agreement with with the specified ID so we can have a pact test for searching for payments by agreement_id.