### PR TITLE
Revert "Bump dropwizard-dependencies from 2.1.4 to 2.1.5"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>io.dropwizard</groupId>
         <artifactId>dropwizard-dependencies</artifactId>
-        <version>2.1.5</version>
+        <version>2.1.4</version>
     </parent>
 
     <dependencyManagement>


### PR DESCRIPTION
Reverts alphagov/pay-ledger#2482