### PR TITLE
PP-10701: Rename/remove some Event-related stuff

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -116,29 +116,22 @@
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/ledger_spec.yaml",
-        "hashed_secret": "cbbaa15cf3814df641e9ee9cb279046f93f322eb",
-        "is_verified": false,
-        "line_number": 1238
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "openapi/ledger_spec.yaml",
         "hashed_secret": "9baeb3f7db14ddab5d172149762035c0c022d76d",
         "is_verified": false,
-        "line_number": 1635
+        "line_number": 1563
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/ledger_spec.yaml",
         "hashed_secret": "920734ed7628ef47739eed5571412e2c8271790f",
         "is_verified": false,
-        "line_number": 1709
+        "line_number": 1637
       }
     ],
-    "src/main/java/uk/gov/pay/ledger/event/model/Event.java": [
+    "src/main/java/uk/gov/pay/ledger/event/model/EventEntity.java": [
       {
         "type": "Hex High Entropy String",
-        "filename": "src/main/java/uk/gov/pay/ledger/event/model/Event.java",
+        "filename": "src/main/java/uk/gov/pay/ledger/event/model/EventEntity.java",
         "hashed_secret": "cbbaa15cf3814df641e9ee9cb279046f93f322eb",
         "is_verified": false,
         "line_number": 20
@@ -163,5 +156,5 @@
       }
     ]
   },
-  "generated_at": "2023-03-07T11:15:55Z"
+  "generated_at": "2023-03-09T16:21:02Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -128,13 +128,13 @@
         "line_number": 1637
       }
     ],
-    "src/main/java/uk/gov/pay/ledger/event/model/EventEntity.java": [
+    "src/main/java/uk/gov/pay/ledger/event/dao/entity/EventEntity.java": [
       {
         "type": "Hex High Entropy String",
-        "filename": "src/main/java/uk/gov/pay/ledger/event/model/EventEntity.java",
+        "filename": "src/main/java/uk/gov/pay/ledger/event/dao/entity/EventEntity.java",
         "hashed_secret": "cbbaa15cf3814df641e9ee9cb279046f93f322eb",
         "is_verified": false,
-        "line_number": 20
+        "line_number": 21
       }
     ],
     "src/test/java/uk/gov/pay/ledger/pact/ContractTest.java": [
@@ -156,5 +156,5 @@
       }
     ]
   },
-  "generated_at": "2023-03-09T16:21:02Z"
+  "generated_at": "2023-03-09T16:37:02Z"
 }

--- a/openapi/ledger_spec.yaml
+++ b/openapi/ledger_spec.yaml
@@ -250,28 +250,6 @@ paths:
       summary: Get list of events between a date/time range
       tags:
       - Events
-  /v1/event/{eventId}:
-    get:
-      operationId: getEvent
-      parameters:
-      - in: path
-        name: eventId
-        required: true
-        schema:
-          type: integer
-          format: int64
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Event'
-          description: OK
-        "404":
-          description: Not found
-      summary: Find event by ID (id of event table)
-      tags:
-      - Events
   /v1/payout:
     get:
       operationId: search_1
@@ -1189,56 +1167,6 @@ components:
           items:
             type: string
             example: example error message
-    Event:
-      type: object
-      properties:
-        event_data:
-          type: string
-          example: "{\"live\": false, \"moto\": false, \"amount\": 1000, \"source\"\
-            : \"CARD_API\", \"language\": \"en\", \"reference\": \"my payment reference\"\
-            , \"return_url\": \"https://www.payments.service.gov.uk\", \"description\"\
-            : \"my payment\", \"delayed_capture\": false, \"payment_provider\": \"\
-            sandbox\", \"gateway_account_id\": \"3\", \"credential_external_id\":\
-            \ \"ddb294481de146c09598c8cce0461af9\", \"save_payment_instrument_to_agreement\"\
-            : false}\""
-        event_date:
-          type: string
-          format: date-time
-        event_type:
-          type: string
-          example: PAYMENT_CREATED
-        live:
-          type: boolean
-          example: true
-        parent_resource_external_id:
-          type: string
-          default: "null"
-          example: l40ajdf0923uojlkfjsldkjfl2
-        reproject_domain_object:
-          type: boolean
-          default: false
-          example: true
-        resource_external_id:
-          type: string
-          example: 58na2dr7rv7h6h53bef1l0soep
-        resource_type:
-          type: string
-          enum:
-          - agreement
-          - payment
-          - refund
-          - service
-          - card_payment
-          - payout
-          - dispute
-          - payment_instrument
-          example: payment
-        service_id:
-          type: string
-          example: ea2d6673b23d4ff7ad88a1fd3c7ab0f6
-        sqs_message_id:
-          type: string
-          example: fe689579-63af-40bf-a783-23de97134b5f
     EventDto:
       type: object
       properties:

--- a/openapi/ledger_spec.yaml
+++ b/openapi/ledger_spec.yaml
@@ -1067,7 +1067,7 @@ components:
         events:
           type: array
           items:
-            $ref: '#/components/schemas/EventDto'
+            $ref: '#/components/schemas/Event'
     AgreementSearchResponse:
       type: object
       properties:
@@ -1167,7 +1167,7 @@ components:
           items:
             type: string
             example: example error message
-    EventDto:
+    Event:
       type: object
       properties:
         data:

--- a/src/main/java/uk/gov/pay/ledger/agreement/dao/AgreementDao.java
+++ b/src/main/java/uk/gov/pay/ledger/agreement/dao/AgreementDao.java
@@ -7,7 +7,7 @@ import org.jdbi.v3.core.statement.Query;
 import uk.gov.pay.ledger.agreement.entity.AgreementEntity;
 import uk.gov.pay.ledger.agreement.resource.AgreementSearchParams;
 import uk.gov.pay.ledger.event.dao.mapper.EventMapper;
-import uk.gov.pay.ledger.event.model.EventEntity;
+import uk.gov.pay.ledger.event.dao.entity.EventEntity;
 
 import java.util.List;
 import java.util.Optional;

--- a/src/main/java/uk/gov/pay/ledger/agreement/dao/AgreementDao.java
+++ b/src/main/java/uk/gov/pay/ledger/agreement/dao/AgreementDao.java
@@ -7,7 +7,7 @@ import org.jdbi.v3.core.statement.Query;
 import uk.gov.pay.ledger.agreement.entity.AgreementEntity;
 import uk.gov.pay.ledger.agreement.resource.AgreementSearchParams;
 import uk.gov.pay.ledger.event.dao.mapper.EventMapper;
-import uk.gov.pay.ledger.event.model.Event;
+import uk.gov.pay.ledger.event.model.EventEntity;
 
 import java.util.List;
 import java.util.Optional;
@@ -148,7 +148,7 @@ public class AgreementDao {
     }
 
     // Includes events for all associated payment instruments, including old payment instruments that have been replaced.
-    public List<Event> findAssociatedEvents(String agreementExternalId) {
+    public List<EventEntity> findAssociatedEvents(String agreementExternalId) {
         return jdbi.withHandle(handle -> {
             Query query = handle.createQuery(SELECT_ASSOCIATED_EVENTS);
             query.bind("externalId", agreementExternalId);

--- a/src/main/java/uk/gov/pay/ledger/agreement/model/AgreementEventsResponse.java
+++ b/src/main/java/uk/gov/pay/ledger/agreement/model/AgreementEventsResponse.java
@@ -1,20 +1,20 @@
 package uk.gov.pay.ledger.agreement.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import uk.gov.pay.ledger.event.model.EventDto;
+import uk.gov.pay.ledger.event.model.Event;
 
 import java.util.List;
 
 public class AgreementEventsResponse {
 
     @JsonProperty("events")
-    private final List<EventDto> events;
+    private final List<Event> events;
     
-    public AgreementEventsResponse(List<EventDto> events) {
+    public AgreementEventsResponse(List<Event> events) {
         this.events = events;
     }
     
-    public List<EventDto> getEvents() {
+    public List<Event> getEvents() {
         return events;
     }
     

--- a/src/main/java/uk/gov/pay/ledger/agreement/service/AgreementService.java
+++ b/src/main/java/uk/gov/pay/ledger/agreement/service/AgreementService.java
@@ -10,7 +10,7 @@ import uk.gov.pay.ledger.agreement.model.Agreement;
 import uk.gov.pay.ledger.agreement.model.AgreementSearchResponse;
 import uk.gov.pay.ledger.agreement.resource.AgreementSearchParams;
 import uk.gov.pay.ledger.event.model.EventDigest;
-import uk.gov.pay.ledger.event.model.EventDto;
+import uk.gov.pay.ledger.event.model.Event;
 import uk.gov.pay.ledger.event.service.EventService;
 import uk.gov.pay.ledger.exception.EmptyEventsException;
 import uk.gov.pay.ledger.util.pagination.PaginationBuilder;
@@ -122,14 +122,14 @@ public class AgreementService {
                 .withPaginationBuilder(paginationBuilder);
     }
 
-    public List<EventDto> findEvents(String agreementExternalId, String serviceId) {
+    public List<Event> findEvents(String agreementExternalId, String serviceId) {
         if (findAgreementEntity(agreementExternalId, true, null, serviceId).isEmpty()) {
             throw new WebApplicationException(format("Agreement with id [%s] not found", agreementExternalId), Response.Status.NOT_FOUND);
         }
 
         var events = agreementDao.findAssociatedEvents(agreementExternalId);
 
-        return events.stream().map(event -> EventDto.from(event, objectMapper)).collect(Collectors.toList());
+        return events.stream().map(event -> Event.from(event, objectMapper)).collect(Collectors.toList());
     }
 
     private boolean databaseProjectionSnapshotIsUpToDateWithEventStream(AgreementEntity agreementEntity, EventDigest eventDigest) {

--- a/src/main/java/uk/gov/pay/ledger/event/dao/EventDao.java
+++ b/src/main/java/uk/gov/pay/ledger/event/dao/EventDao.java
@@ -11,7 +11,7 @@ import org.jdbi.v3.sqlobject.statement.SqlUpdate;
 import org.jdbi.v3.sqlobject.transaction.Transaction;
 import uk.gov.pay.ledger.event.dao.mapper.EventMapper;
 import uk.gov.pay.ledger.event.dao.mapper.EventTickerMapper;
-import uk.gov.pay.ledger.event.model.Event;
+import uk.gov.pay.ledger.event.model.EventEntity;
 import uk.gov.pay.ledger.event.model.EventTicker;
 
 import java.time.ZonedDateTime;
@@ -30,14 +30,14 @@ public interface EventDao {
     @SqlQuery("SELECT e.id, e.sqs_message_id, e.service_id, e.live, rt.name AS resource_type_name, e.resource_external_id, e.parent_resource_external_id," +
             " e.event_date, e.event_type, e.event_data" +
             " FROM event e, resource_type rt WHERE e.id = :eventId AND e.resource_type_id = rt.id")
-    Optional<Event> getById(@Bind("eventId") Long eventId);
+    Optional<EventEntity> getById(@Bind("eventId") Long eventId);
 
     @SqlUpdate("INSERT INTO event(sqs_message_id, service_id, live, resource_type_id, resource_external_id, parent_resource_external_id, " +
                 "event_date, event_type, event_data) " +
             "VALUES (:sqsMessageId, :serviceId, :live, :resourceTypeId, :resourceExternalId, :parentResourceExternalId, " +
                 ":eventDate, :eventType, CAST(:eventData as jsonb))")
     @GetGeneratedKeys
-    Long insert(@BindBean Event event, @Bind("resourceTypeId") int resourceTypeId);
+    Long insert(@BindBean EventEntity event, @Bind("resourceTypeId") int resourceTypeId);
 
     @SqlUpdate("INSERT INTO event(sqs_message_id, service_id, live, resource_type_id, resource_external_id, parent_resource_external_id, " +
             "event_date, event_type, event_data) " +
@@ -51,16 +51,16 @@ public interface EventDao {
             "          event_date = :eventDate AND   " +
             "          event_type = :eventType) ")
     @GetGeneratedKeys
-    Optional<Long> insertIfDoesNotExist(@BindBean Event event, @Bind("resourceTypeId") int resourceTypeId);
+    Optional<Long> insertIfDoesNotExist(@BindBean EventEntity event, @Bind("resourceTypeId") int resourceTypeId);
 
     @Transaction
-    default Long insertEventWithResourceTypeId(Event event) {
+    default Long insertEventWithResourceTypeId(EventEntity event) {
         int resourceTypeId = getResourceTypeDao().getResourceTypeIdByName(event.getResourceType().name());
         return insert(event, resourceTypeId);
     }
 
     @Transaction
-    default Optional<Long> insertEventIfDoesNotExistWithResourceTypeId(Event event) {
+    default Optional<Long> insertEventIfDoesNotExistWithResourceTypeId(EventEntity event) {
         int resourceTypeId = getResourceTypeDao().getResourceTypeIdByName(event.getResourceType().name());
         return insertIfDoesNotExist(event, resourceTypeId);
     }
@@ -69,7 +69,7 @@ public interface EventDao {
             "e.parent_resource_external_id, e.event_date," +
             "e.event_type, e.event_data FROM event e, resource_type rt WHERE e.resource_external_id = :resourceExternalId" +
             " AND e.resource_type_id = rt.id ORDER BY e.event_date DESC")
-    List<Event> getEventsByResourceExternalId(@Bind("resourceExternalId") String resourceExternalId);
+    List<EventEntity> getEventsByResourceExternalId(@Bind("resourceExternalId") String resourceExternalId);
 
 
     @SqlQuery("SELECT  e.id, e.sqs_message_id, e.service_id, e.live, rt.name AS resource_type_name, e.resource_external_id, " +
@@ -78,7 +78,7 @@ public interface EventDao {
             " WHERE e.resource_external_id in (<externalIds>)" +
             " AND e.resource_type_id = rt.id" +
             " ORDER BY e.event_date ASC")
-    List<Event> findEventsForExternalIds(@BindList("externalIds") Set<String> externalIds);
+    List<EventEntity> findEventsForExternalIds(@BindList("externalIds") Set<String> externalIds);
 
     @SqlQuery("SELECT e.id, e.event_type, e.resource_external_id, e.event_date, t.card_brand, t.amount, " +
             "t.transaction_details->'payment_provider' as payment_provider, t.gateway_account_id, t.type " +

--- a/src/main/java/uk/gov/pay/ledger/event/dao/EventDao.java
+++ b/src/main/java/uk/gov/pay/ledger/event/dao/EventDao.java
@@ -11,7 +11,7 @@ import org.jdbi.v3.sqlobject.statement.SqlUpdate;
 import org.jdbi.v3.sqlobject.transaction.Transaction;
 import uk.gov.pay.ledger.event.dao.mapper.EventMapper;
 import uk.gov.pay.ledger.event.dao.mapper.EventTickerMapper;
-import uk.gov.pay.ledger.event.model.EventEntity;
+import uk.gov.pay.ledger.event.dao.entity.EventEntity;
 import uk.gov.pay.ledger.event.model.EventTicker;
 
 import java.time.ZonedDateTime;

--- a/src/main/java/uk/gov/pay/ledger/event/dao/entity/EventEntity.java
+++ b/src/main/java/uk/gov/pay/ledger/event/dao/entity/EventEntity.java
@@ -1,10 +1,11 @@
-package uk.gov.pay.ledger.event.model;
+package uk.gov.pay.ledger.event.dao.entity;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import io.swagger.v3.oas.annotations.media.Schema;
+import uk.gov.pay.ledger.event.model.ResourceType;
 import uk.gov.service.payments.commons.api.json.MicrosecondPrecisionDateTimeSerializer;
 
 import java.time.ZonedDateTime;

--- a/src/main/java/uk/gov/pay/ledger/event/dao/mapper/EventMapper.java
+++ b/src/main/java/uk/gov/pay/ledger/event/dao/mapper/EventMapper.java
@@ -2,7 +2,7 @@ package uk.gov.pay.ledger.event.dao.mapper;
 
 import org.jdbi.v3.core.mapper.RowMapper;
 import org.jdbi.v3.core.statement.StatementContext;
-import uk.gov.pay.ledger.event.model.Event;
+import uk.gov.pay.ledger.event.model.EventEntity;
 import uk.gov.pay.ledger.event.model.ResourceType;
 
 import java.sql.ResultSet;
@@ -12,11 +12,11 @@ import java.time.ZonedDateTime;
 
 import static uk.gov.pay.ledger.util.dao.MapperUtils.getBooleanWithNullCheck;
 
-public class EventMapper implements RowMapper<Event> {
+public class EventMapper implements RowMapper<EventEntity> {
 
     @Override
-    public Event map(ResultSet resultSet, StatementContext statementContext) throws SQLException {
-        return new Event(resultSet.getLong("id"),
+    public EventEntity map(ResultSet resultSet, StatementContext statementContext) throws SQLException {
+        return new EventEntity(resultSet.getLong("id"),
                 resultSet.getString("sqs_message_id"),
                 resultSet.getString("service_id"),
                 getBooleanWithNullCheck(resultSet, "live"),

--- a/src/main/java/uk/gov/pay/ledger/event/dao/mapper/EventMapper.java
+++ b/src/main/java/uk/gov/pay/ledger/event/dao/mapper/EventMapper.java
@@ -2,7 +2,7 @@ package uk.gov.pay.ledger.event.dao.mapper;
 
 import org.jdbi.v3.core.mapper.RowMapper;
 import org.jdbi.v3.core.statement.StatementContext;
-import uk.gov.pay.ledger.event.model.EventEntity;
+import uk.gov.pay.ledger.event.dao.entity.EventEntity;
 import uk.gov.pay.ledger.event.model.ResourceType;
 
 import java.sql.ResultSet;

--- a/src/main/java/uk/gov/pay/ledger/event/model/Event.java
+++ b/src/main/java/uk/gov/pay/ledger/event/model/Event.java
@@ -16,9 +16,9 @@ import java.time.ZonedDateTime;
 import java.util.Map;
 
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
-public class EventDto {
+public class Event {
 
-    private static final Logger logger = LoggerFactory.getLogger(EventDto.class);
+    private static final Logger logger = LoggerFactory.getLogger(Event.class);
     
     private final String resourceExternalId;
     @Schema(example = "AGREEMENT")
@@ -32,13 +32,13 @@ public class EventDto {
     private final String serviceId;
     private final Map<String, Object> data;
 
-    public EventDto(String resourceExternalId,
-                    ResourceType resourceType,
-                    String eventType,
-                    ZonedDateTime timestamp,
-                    Boolean live,
-                    String serviceId,
-                    Map<String, Object> data) {
+    public Event(String resourceExternalId,
+                 ResourceType resourceType,
+                 String eventType,
+                 ZonedDateTime timestamp,
+                 Boolean live,
+                 String serviceId,
+                 Map<String, Object> data) {
         this.resourceExternalId = resourceExternalId;
         this.resourceType = resourceType;
         this.eventType = eventType;
@@ -48,9 +48,9 @@ public class EventDto {
         this.data = data;
     }
 
-    public static EventDto from(EventEntity event, ObjectMapper objectMapper) {
+    public static Event from(EventEntity event, ObjectMapper objectMapper) {
         try {
-            return new EventDto(
+            return new Event(
                     event.getResourceExternalId(),
                     event.getResourceType(),
                     event.getEventType(),

--- a/src/main/java/uk/gov/pay/ledger/event/model/EventDigest.java
+++ b/src/main/java/uk/gov/pay/ledger/event/model/EventDigest.java
@@ -1,6 +1,7 @@
 package uk.gov.pay.ledger.event.model;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import uk.gov.pay.ledger.event.dao.entity.EventEntity;
 import uk.gov.pay.ledger.exception.EmptyEventsException;
 import uk.gov.pay.ledger.util.JsonParser;
 

--- a/src/main/java/uk/gov/pay/ledger/event/model/EventDigest.java
+++ b/src/main/java/uk/gov/pay/ledger/event/model/EventDigest.java
@@ -49,7 +49,7 @@ public class EventDigest {
         this.eventCreatedDate = eventCreatedDate;
     }
 
-    public static EventDigest fromEventList(List<Event> events) {
+    public static EventDigest fromEventList(List<EventEntity> events) {
         var eventPayload = buildEventAggregate(events);
 
         var latestEvent = events.stream()
@@ -57,14 +57,14 @@ public class EventDigest {
                 .orElseThrow(() -> new EmptyEventsException("No events found"));
 
         var latestSalientEventType = events.stream()
-                .map(Event::getEventType)
+                .map(EventEntity::getEventType)
                 .map(SalientEventType::from)
                 .flatMap(Optional::stream)
                 .findFirst()
                 .orElse(null);
 
         var earliestDate = events.stream()
-                .map(Event::getEventDate)
+                .map(EventEntity::getEventDate)
                 .min(ZonedDateTime::compareTo)
                 .orElseThrow();
 
@@ -73,7 +73,7 @@ public class EventDigest {
 
         Boolean isLive = events.stream()
                 .filter(event -> event.getLive() != null)
-                .map(Event::getLive)
+                .map(EventEntity::getLive)
                 .findFirst()
                 .orElse(null);
 
@@ -91,25 +91,25 @@ public class EventDigest {
         );
     }
 
-    private static String deriveServiceId(List<Event> events) {
+    private static String deriveServiceId(List<EventEntity> events) {
         return events.stream()
                 .filter(event -> isNotEmpty(event.getServiceId()))
-                .map(Event::getServiceId)
+                .map(EventEntity::getServiceId)
                 .findFirst()
                 .orElse(null);
     }
 
-    private static String deriveParentResourceExternalId(List<Event> events) {
+    private static String deriveParentResourceExternalId(List<EventEntity> events) {
         return events.stream()
                 .filter(event -> isNotEmpty(event.getParentResourceExternalId()))
-                .map(Event::getParentResourceExternalId)
+                .map(EventEntity::getParentResourceExternalId)
                 .findFirst()
                 .orElse(null);
     }
 
-    private static Map<String, Object> buildEventAggregate(List<Event> events) {
+    private static Map<String, Object> buildEventAggregate(List<EventEntity> events) {
         return events.stream()
-                .map(Event::getEventData)
+                .map(EventEntity::getEventData)
                 .map(JsonParser::jsonStringToMap)
                 .flatMap(m -> m.entrySet().stream())
                 .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue, (later, earlier) -> later));

--- a/src/main/java/uk/gov/pay/ledger/event/model/EventDto.java
+++ b/src/main/java/uk/gov/pay/ledger/event/model/EventDto.java
@@ -47,7 +47,7 @@ public class EventDto {
         this.data = data;
     }
 
-    public static EventDto from(Event event, ObjectMapper objectMapper) {
+    public static EventDto from(EventEntity event, ObjectMapper objectMapper) {
         try {
             return new EventDto(
                     event.getResourceExternalId(),

--- a/src/main/java/uk/gov/pay/ledger/event/model/EventDto.java
+++ b/src/main/java/uk/gov/pay/ledger/event/model/EventDto.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import io.swagger.v3.oas.annotations.media.Schema;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import uk.gov.pay.ledger.event.dao.entity.EventEntity;
 import uk.gov.service.payments.commons.api.json.ApiResponseDateTimeSerializer;
 
 import java.io.IOException;

--- a/src/main/java/uk/gov/pay/ledger/event/model/EventEntity.java
+++ b/src/main/java/uk/gov/pay/ledger/event/model/EventEntity.java
@@ -11,7 +11,7 @@ import java.time.ZonedDateTime;
 import java.util.Objects;
 
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
-public class Event {
+public class EventEntity {
 
     @JsonIgnore
     private Long id;
@@ -37,20 +37,20 @@ public class Event {
     @Schema(example = "true", defaultValue = "false")
     private boolean reprojectDomainObject;
 
-    public Event() {
+    public EventEntity() {
     }
 
-    public Event(Long id,
-                 String sqsMessageId,
-                 String serviceId,
-                 Boolean live,
-                 ResourceType resourceType,
-                 String resourceExternalId,
-                 String parentResourceExternalId,
-                 ZonedDateTime eventDate,
-                 String eventType,
-                 String eventData,
-                 boolean reprojectDomainObject) {
+    public EventEntity(Long id,
+                       String sqsMessageId,
+                       String serviceId,
+                       Boolean live,
+                       ResourceType resourceType,
+                       String resourceExternalId,
+                       String parentResourceExternalId,
+                       ZonedDateTime eventDate,
+                       String eventType,
+                       String eventData,
+                       boolean reprojectDomainObject) {
         this.id = id;
         this.sqsMessageId = sqsMessageId;
         this.serviceId = serviceId;
@@ -64,16 +64,16 @@ public class Event {
         this.reprojectDomainObject = reprojectDomainObject;
     }
 
-    public Event(String sqsMessageId,
-                 String serviceId,
-                 Boolean live,
-                 ResourceType resourceType,
-                 String resourceExternalId,
-                 String parentResourceExternalId,
-                 ZonedDateTime eventDate,
-                 String eventType,
-                 String eventData,
-                 boolean reprojectDomainObject) {
+    public EventEntity(String sqsMessageId,
+                       String serviceId,
+                       Boolean live,
+                       ResourceType resourceType,
+                       String resourceExternalId,
+                       String parentResourceExternalId,
+                       ZonedDateTime eventDate,
+                       String eventType,
+                       String eventData,
+                       boolean reprojectDomainObject) {
         this(null, sqsMessageId, serviceId, live, resourceType, resourceExternalId, parentResourceExternalId, eventDate, eventType,
                 eventData, reprojectDomainObject);
     }
@@ -142,7 +142,7 @@ public class Event {
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
-        Event event = (Event) o;
+        EventEntity event = (EventEntity) o;
         return live == event.live &&
                 reprojectDomainObject == event.reprojectDomainObject &&
                 Objects.equals(id, event.id) &&

--- a/src/main/java/uk/gov/pay/ledger/event/resource/EventResource.java
+++ b/src/main/java/uk/gov/pay/ledger/event/resource/EventResource.java
@@ -12,7 +12,6 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.pay.ledger.event.dao.EventDao;
-import uk.gov.pay.ledger.event.model.Event;
 import uk.gov.pay.ledger.event.model.EventTicker;
 import uk.gov.pay.ledger.exception.ErrorResponse;
 import uk.gov.pay.ledger.queue.EventMessage;
@@ -24,10 +23,8 @@ import javax.validation.constraints.NotEmpty;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
-import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Response;
 import java.time.ZonedDateTime;
 import java.util.List;
@@ -49,22 +46,6 @@ public class EventResource {
     public EventResource(EventDao eventDao, EventMessageHandler eventMessageHandler) {
         this.eventDao = eventDao;
         this.eventMessageHandler = eventMessageHandler;
-    }
-
-    @Path("/{eventId}")
-    @GET
-    @Timed
-    @Operation(
-            summary = "Find event by ID (id of event table)",
-            responses = {
-                    @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = Event.class))),
-                    @ApiResponse(responseCode = "404", description = "Not found")
-            }
-    )
-    public Event getEvent(@PathParam("eventId") Long eventId) {
-        LOGGER.info("Get event request: {}", eventId);
-        return eventDao.getById(eventId)
-                .orElseThrow(() -> new WebApplicationException(Response.Status.NOT_FOUND));
     }
 
     @POST

--- a/src/main/java/uk/gov/pay/ledger/event/service/EventService.java
+++ b/src/main/java/uk/gov/pay/ledger/event/service/EventService.java
@@ -2,7 +2,7 @@ package uk.gov.pay.ledger.event.service;
 
 import com.google.inject.Inject;
 import uk.gov.pay.ledger.event.dao.EventDao;
-import uk.gov.pay.ledger.event.model.Event;
+import uk.gov.pay.ledger.event.model.EventEntity;
 import uk.gov.pay.ledger.event.model.EventDigest;
 import uk.gov.pay.ledger.event.model.response.CreateEventResponse;
 
@@ -18,15 +18,15 @@ public class EventService {
     }
 
     public EventDigest getEventDigestForResource(String resourceExternalId) {
-        List<Event> events = getEventsForResource(resourceExternalId);
+        List<EventEntity> events = getEventsForResource(resourceExternalId);
         return EventDigest.fromEventList(events);
     }
 
-    public List<Event> getEventsForResource(String resourceExternalId) {
+    public List<EventEntity> getEventsForResource(String resourceExternalId) {
         return eventDao.getEventsByResourceExternalId(resourceExternalId);
     }
 
-    public CreateEventResponse createIfDoesNotExist(Event event) {
+    public CreateEventResponse createIfDoesNotExist(EventEntity event) {
         try {
             Optional<Long> status = eventDao.insertEventIfDoesNotExistWithResourceTypeId(event);
             return new CreateEventResponse(status);
@@ -35,7 +35,7 @@ public class EventService {
         }
     }
 
-    public EventDigest getEventDigestForResource(Event event) {
+    public EventDigest getEventDigestForResource(EventEntity event) {
         return getEventDigestForResource(event.getResourceExternalId());
     }
 }

--- a/src/main/java/uk/gov/pay/ledger/event/service/EventService.java
+++ b/src/main/java/uk/gov/pay/ledger/event/service/EventService.java
@@ -2,7 +2,7 @@ package uk.gov.pay.ledger.event.service;
 
 import com.google.inject.Inject;
 import uk.gov.pay.ledger.event.dao.EventDao;
-import uk.gov.pay.ledger.event.model.EventEntity;
+import uk.gov.pay.ledger.event.dao.entity.EventEntity;
 import uk.gov.pay.ledger.event.model.EventDigest;
 import uk.gov.pay.ledger.event.model.response.CreateEventResponse;
 

--- a/src/main/java/uk/gov/pay/ledger/queue/EventDigestHandler.java
+++ b/src/main/java/uk/gov/pay/ledger/queue/EventDigestHandler.java
@@ -3,7 +3,7 @@ package uk.gov.pay.ledger.queue;
 import com.google.inject.Inject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import uk.gov.pay.ledger.event.model.EventEntity;
+import uk.gov.pay.ledger.event.dao.entity.EventEntity;
 import uk.gov.pay.ledger.queue.eventprocessor.AgreementEventProcessor;
 import uk.gov.pay.ledger.queue.eventprocessor.ChildTransactionEventProcessor;
 import uk.gov.pay.ledger.queue.eventprocessor.EventProcessor;

--- a/src/main/java/uk/gov/pay/ledger/queue/EventDigestHandler.java
+++ b/src/main/java/uk/gov/pay/ledger/queue/EventDigestHandler.java
@@ -3,7 +3,7 @@ package uk.gov.pay.ledger.queue;
 import com.google.inject.Inject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import uk.gov.pay.ledger.event.model.Event;
+import uk.gov.pay.ledger.event.model.EventEntity;
 import uk.gov.pay.ledger.queue.eventprocessor.AgreementEventProcessor;
 import uk.gov.pay.ledger.queue.eventprocessor.ChildTransactionEventProcessor;
 import uk.gov.pay.ledger.queue.eventprocessor.EventProcessor;
@@ -35,7 +35,7 @@ public class EventDigestHandler {
         this.paymentInstrumentEventProcessor = paymentInstrumentEventProcessor;
     }
 
-    public EventProcessor processorFor(Event event) {
+    public EventProcessor processorFor(EventEntity event) {
         switch (event.getResourceType()) {
             case PAYMENT:
                 return paymentEventProcessor;
@@ -58,7 +58,7 @@ public class EventDigestHandler {
         }
     }
 
-    public void processEvent(Event event, boolean isANewEvent) {
+    public void processEvent(EventEntity event, boolean isANewEvent) {
         processorFor(event).process(event, isANewEvent);
     }
 }

--- a/src/main/java/uk/gov/pay/ledger/queue/EventMessage.java
+++ b/src/main/java/uk/gov/pay/ledger/queue/EventMessage.java
@@ -1,6 +1,6 @@
 package uk.gov.pay.ledger.queue;
 
-import uk.gov.pay.ledger.event.model.EventEntity;
+import uk.gov.pay.ledger.event.dao.entity.EventEntity;
 import uk.gov.service.payments.commons.queue.model.QueueMessage;
 
 import java.util.Optional;

--- a/src/main/java/uk/gov/pay/ledger/queue/EventMessage.java
+++ b/src/main/java/uk/gov/pay/ledger/queue/EventMessage.java
@@ -1,6 +1,6 @@
 package uk.gov.pay.ledger.queue;
 
-import uk.gov.pay.ledger.event.model.Event;
+import uk.gov.pay.ledger.event.model.EventEntity;
 import uk.gov.service.payments.commons.queue.model.QueueMessage;
 
 import java.util.Optional;
@@ -26,8 +26,8 @@ public class EventMessage {
         return queueMessage.getMessageBody();
     }
 
-    public Event getEvent() {
-        return new Event(
+    public EventEntity getEvent() {
+        return new EventEntity(
                 getQueueMessageId().orElse(null),
                 eventDto.getServiceId(),
                 eventDto.isLive(),

--- a/src/main/java/uk/gov/pay/ledger/queue/EventMessageHandler.java
+++ b/src/main/java/uk/gov/pay/ledger/queue/EventMessageHandler.java
@@ -7,7 +7,7 @@ import org.jdbi.v3.core.Jdbi;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.pay.ledger.app.LedgerConfig;
-import uk.gov.pay.ledger.event.model.EventEntity;
+import uk.gov.pay.ledger.event.dao.entity.EventEntity;
 import uk.gov.pay.ledger.event.model.ResourceType;
 import uk.gov.pay.ledger.event.model.response.CreateEventResponse;
 import uk.gov.pay.ledger.event.service.EventService;

--- a/src/main/java/uk/gov/pay/ledger/queue/EventMessageHandler.java
+++ b/src/main/java/uk/gov/pay/ledger/queue/EventMessageHandler.java
@@ -1,14 +1,13 @@
 package uk.gov.pay.ledger.queue;
 
 import com.codahale.metrics.MetricRegistry;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.inject.Inject;
 import io.sentry.Sentry;
 import org.jdbi.v3.core.Jdbi;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.pay.ledger.app.LedgerConfig;
-import uk.gov.pay.ledger.event.model.Event;
+import uk.gov.pay.ledger.event.model.EventEntity;
 import uk.gov.pay.ledger.event.model.ResourceType;
 import uk.gov.pay.ledger.event.model.response.CreateEventResponse;
 import uk.gov.pay.ledger.event.service.EventService;
@@ -81,7 +80,7 @@ public class EventMessageHandler {
     }
 
     private void processSingleMessage(EventMessage message) throws QueueException {
-        Event event = message.getEvent();
+        EventEntity event = message.getEvent();
 
         CreateEventResponse response;
 

--- a/src/main/java/uk/gov/pay/ledger/queue/eventprocessor/AgreementEventProcessor.java
+++ b/src/main/java/uk/gov/pay/ledger/queue/eventprocessor/AgreementEventProcessor.java
@@ -2,7 +2,7 @@ package uk.gov.pay.ledger.queue.eventprocessor;
 
 import com.google.inject.Inject;
 import uk.gov.pay.ledger.agreement.service.AgreementService;
-import uk.gov.pay.ledger.event.model.EventEntity;
+import uk.gov.pay.ledger.event.dao.entity.EventEntity;
 import uk.gov.pay.ledger.event.service.EventService;
 
 public class AgreementEventProcessor extends EventProcessor {

--- a/src/main/java/uk/gov/pay/ledger/queue/eventprocessor/AgreementEventProcessor.java
+++ b/src/main/java/uk/gov/pay/ledger/queue/eventprocessor/AgreementEventProcessor.java
@@ -2,7 +2,7 @@ package uk.gov.pay.ledger.queue.eventprocessor;
 
 import com.google.inject.Inject;
 import uk.gov.pay.ledger.agreement.service.AgreementService;
-import uk.gov.pay.ledger.event.model.Event;
+import uk.gov.pay.ledger.event.model.EventEntity;
 import uk.gov.pay.ledger.event.service.EventService;
 
 public class AgreementEventProcessor extends EventProcessor {
@@ -16,7 +16,7 @@ public class AgreementEventProcessor extends EventProcessor {
     }
 
     @Override
-    public void process(Event event, boolean isNewEvent) {
+    public void process(EventEntity event, boolean isNewEvent) {
         agreementService.upsertAgreementFor(eventService.getEventDigestForResource(event));
     }
 }

--- a/src/main/java/uk/gov/pay/ledger/queue/eventprocessor/ChildTransactionEventProcessor.java
+++ b/src/main/java/uk/gov/pay/ledger/queue/eventprocessor/ChildTransactionEventProcessor.java
@@ -1,7 +1,7 @@
 package uk.gov.pay.ledger.queue.eventprocessor;
 
 import com.google.inject.Inject;
-import uk.gov.pay.ledger.event.model.Event;
+import uk.gov.pay.ledger.event.model.EventEntity;
 import uk.gov.pay.ledger.event.model.EventDigest;
 import uk.gov.pay.ledger.event.model.TransactionEntityFactory;
 import uk.gov.pay.ledger.event.service.EventService;
@@ -33,7 +33,7 @@ public class ChildTransactionEventProcessor extends EventProcessor {
     }
 
     @Override
-    public void process(Event event, boolean isANewEvent) {
+    public void process(EventEntity event, boolean isANewEvent) {
         EventDigest childTransactionEventDigest = eventService.getEventDigestForResource(event);
 
         Optional<EventDigest> mayBePaymentEventDigest = Optional.empty();

--- a/src/main/java/uk/gov/pay/ledger/queue/eventprocessor/ChildTransactionEventProcessor.java
+++ b/src/main/java/uk/gov/pay/ledger/queue/eventprocessor/ChildTransactionEventProcessor.java
@@ -1,7 +1,7 @@
 package uk.gov.pay.ledger.queue.eventprocessor;
 
 import com.google.inject.Inject;
-import uk.gov.pay.ledger.event.model.EventEntity;
+import uk.gov.pay.ledger.event.dao.entity.EventEntity;
 import uk.gov.pay.ledger.event.model.EventDigest;
 import uk.gov.pay.ledger.event.model.TransactionEntityFactory;
 import uk.gov.pay.ledger.event.service.EventService;

--- a/src/main/java/uk/gov/pay/ledger/queue/eventprocessor/EventProcessor.java
+++ b/src/main/java/uk/gov/pay/ledger/queue/eventprocessor/EventProcessor.java
@@ -1,6 +1,6 @@
 package uk.gov.pay.ledger.queue.eventprocessor;
 
-import uk.gov.pay.ledger.event.model.EventEntity;
+import uk.gov.pay.ledger.event.dao.entity.EventEntity;
 
 public abstract class EventProcessor {
     public abstract void process(EventEntity event, boolean isANewEvent);

--- a/src/main/java/uk/gov/pay/ledger/queue/eventprocessor/EventProcessor.java
+++ b/src/main/java/uk/gov/pay/ledger/queue/eventprocessor/EventProcessor.java
@@ -1,7 +1,7 @@
 package uk.gov.pay.ledger.queue.eventprocessor;
 
-import uk.gov.pay.ledger.event.model.Event;
+import uk.gov.pay.ledger.event.model.EventEntity;
 
 public abstract class EventProcessor {
-    public abstract void process(Event event, boolean isANewEvent);
+    public abstract void process(EventEntity event, boolean isANewEvent);
 }

--- a/src/main/java/uk/gov/pay/ledger/queue/eventprocessor/PaymentEventProcessor.java
+++ b/src/main/java/uk/gov/pay/ledger/queue/eventprocessor/PaymentEventProcessor.java
@@ -1,7 +1,7 @@
 package uk.gov.pay.ledger.queue.eventprocessor;
 
 import com.google.inject.Inject;
-import uk.gov.pay.ledger.event.model.Event;
+import uk.gov.pay.ledger.event.model.EventEntity;
 import uk.gov.pay.ledger.event.model.EventDigest;
 import uk.gov.pay.ledger.event.model.SalientEventType;
 import uk.gov.pay.ledger.event.service.EventService;
@@ -41,8 +41,8 @@ public class PaymentEventProcessor extends EventProcessor {
 
 
     @Override
-    public void process(Event event, boolean isANewEvent) {
-        List<Event> events = eventService.getEventsForResource(event.getResourceExternalId());
+    public void process(EventEntity event, boolean isANewEvent) {
+        List<EventEntity> events = eventService.getEventsForResource(event.getResourceExternalId());
         EventDigest paymentEventDigest = EventDigest.fromEventList(events);
 
         TransactionEntity transactionEntity = transactionService.upsertTransactionFor(paymentEventDigest);
@@ -75,7 +75,7 @@ public class PaymentEventProcessor extends EventProcessor {
         }
     }
 
-    private boolean hasSuccessEvent(List<Event> events) {
+    private boolean hasSuccessEvent(List<EventEntity> events) {
         return events.stream().map(event -> SalientEventType.from(event.getEventType()))
                 .flatMap(Optional::stream)
                 .anyMatch(salientEventType -> fromEventType(salientEventType) == TransactionState.SUCCESS);

--- a/src/main/java/uk/gov/pay/ledger/queue/eventprocessor/PaymentEventProcessor.java
+++ b/src/main/java/uk/gov/pay/ledger/queue/eventprocessor/PaymentEventProcessor.java
@@ -1,7 +1,7 @@
 package uk.gov.pay.ledger.queue.eventprocessor;
 
 import com.google.inject.Inject;
-import uk.gov.pay.ledger.event.model.EventEntity;
+import uk.gov.pay.ledger.event.dao.entity.EventEntity;
 import uk.gov.pay.ledger.event.model.EventDigest;
 import uk.gov.pay.ledger.event.model.SalientEventType;
 import uk.gov.pay.ledger.event.service.EventService;

--- a/src/main/java/uk/gov/pay/ledger/queue/eventprocessor/PaymentInstrumentEventProcessor.java
+++ b/src/main/java/uk/gov/pay/ledger/queue/eventprocessor/PaymentInstrumentEventProcessor.java
@@ -4,7 +4,7 @@ import com.google.inject.Inject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.pay.ledger.agreement.service.AgreementService;
-import uk.gov.pay.ledger.event.model.EventEntity;
+import uk.gov.pay.ledger.event.dao.entity.EventEntity;
 import uk.gov.pay.ledger.event.service.EventService;
 
 public class PaymentInstrumentEventProcessor extends EventProcessor {

--- a/src/main/java/uk/gov/pay/ledger/queue/eventprocessor/PaymentInstrumentEventProcessor.java
+++ b/src/main/java/uk/gov/pay/ledger/queue/eventprocessor/PaymentInstrumentEventProcessor.java
@@ -4,7 +4,7 @@ import com.google.inject.Inject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.pay.ledger.agreement.service.AgreementService;
-import uk.gov.pay.ledger.event.model.Event;
+import uk.gov.pay.ledger.event.model.EventEntity;
 import uk.gov.pay.ledger.event.service.EventService;
 
 public class PaymentInstrumentEventProcessor extends EventProcessor {
@@ -19,7 +19,7 @@ public class PaymentInstrumentEventProcessor extends EventProcessor {
     }
 
     @Override
-    public void process(Event event, boolean isANewEvent) {
+    public void process(EventEntity event, boolean isANewEvent) {
         agreementService.upsertPaymentInstrumentFor(eventService.getEventDigestForResource(event));
     }
 }

--- a/src/main/java/uk/gov/pay/ledger/queue/eventprocessor/PayoutEventProcessor.java
+++ b/src/main/java/uk/gov/pay/ledger/queue/eventprocessor/PayoutEventProcessor.java
@@ -1,7 +1,7 @@
 package uk.gov.pay.ledger.queue.eventprocessor;
 
 import com.google.inject.Inject;
-import uk.gov.pay.ledger.event.model.EventEntity;
+import uk.gov.pay.ledger.event.dao.entity.EventEntity;
 import uk.gov.pay.ledger.event.service.EventService;
 import uk.gov.pay.ledger.payout.service.PayoutService;
 

--- a/src/main/java/uk/gov/pay/ledger/queue/eventprocessor/PayoutEventProcessor.java
+++ b/src/main/java/uk/gov/pay/ledger/queue/eventprocessor/PayoutEventProcessor.java
@@ -1,7 +1,7 @@
 package uk.gov.pay.ledger.queue.eventprocessor;
 
 import com.google.inject.Inject;
-import uk.gov.pay.ledger.event.model.Event;
+import uk.gov.pay.ledger.event.model.EventEntity;
 import uk.gov.pay.ledger.event.service.EventService;
 import uk.gov.pay.ledger.payout.service.PayoutService;
 
@@ -16,7 +16,7 @@ public class PayoutEventProcessor extends EventProcessor {
     }
 
     @Override
-    public void process(Event event, boolean isANewEvent) {
+    public void process(EventEntity event, boolean isANewEvent) {
         payoutService.upsertPayoutFor(eventService.getEventDigestForResource(event));
     }
 }

--- a/src/main/java/uk/gov/pay/ledger/transaction/model/TransactionEvent.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/model/TransactionEvent.java
@@ -10,7 +10,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.service.payments.commons.api.json.ApiResponseDateTimeSerializer;
-import uk.gov.pay.ledger.event.model.Event;
+import uk.gov.pay.ledger.event.model.EventEntity;
 import uk.gov.pay.ledger.event.model.ResourceType;
 import uk.gov.pay.ledger.event.model.SalientEventType;
 import uk.gov.pay.ledger.transaction.entity.TransactionEntity;
@@ -50,7 +50,7 @@ public class TransactionEvent {
         this.data = builder.data;
     }
 
-    public static TransactionEvent from(TransactionEntity transactionEntity, Event event, ObjectMapper objectMapper, int statusVersion) {
+    public static TransactionEvent from(TransactionEntity transactionEntity, EventEntity event, ObjectMapper objectMapper, int statusVersion) {
         try {
             ExternalTransactionState state = SalientEventType.from(event.getEventType())
                     .map(TransactionState::fromEventType)

--- a/src/main/java/uk/gov/pay/ledger/transaction/model/TransactionEvent.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/model/TransactionEvent.java
@@ -10,7 +10,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.service.payments.commons.api.json.ApiResponseDateTimeSerializer;
-import uk.gov.pay.ledger.event.model.EventEntity;
+import uk.gov.pay.ledger.event.dao.entity.EventEntity;
 import uk.gov.pay.ledger.event.model.ResourceType;
 import uk.gov.pay.ledger.event.model.SalientEventType;
 import uk.gov.pay.ledger.transaction.entity.TransactionEntity;

--- a/src/main/java/uk/gov/pay/ledger/transaction/service/TransactionMetadataService.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/service/TransactionMetadataService.java
@@ -7,7 +7,7 @@ import com.google.inject.Inject;
 import org.jdbi.v3.core.statement.UnableToExecuteStatementException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import uk.gov.pay.ledger.event.model.EventEntity;
+import uk.gov.pay.ledger.event.dao.entity.EventEntity;
 import uk.gov.pay.ledger.event.model.EventDigest;
 import uk.gov.pay.ledger.gatewayaccountmetadata.service.GatewayAccountMetadataService;
 import uk.gov.pay.ledger.metadatakey.dao.MetadataKeyDao;

--- a/src/main/java/uk/gov/pay/ledger/transaction/service/TransactionMetadataService.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/service/TransactionMetadataService.java
@@ -7,7 +7,7 @@ import com.google.inject.Inject;
 import org.jdbi.v3.core.statement.UnableToExecuteStatementException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import uk.gov.pay.ledger.event.model.Event;
+import uk.gov.pay.ledger.event.model.EventEntity;
 import uk.gov.pay.ledger.event.model.EventDigest;
 import uk.gov.pay.ledger.gatewayaccountmetadata.service.GatewayAccountMetadataService;
 import uk.gov.pay.ledger.metadatakey.dao.MetadataKeyDao;
@@ -40,7 +40,7 @@ public class TransactionMetadataService {
 
     }
 
-    public void upsertMetadataFor(Event event) {
+    public void upsertMetadataFor(EventEntity event) {
         JsonNode eventDataNode;
         try {
             eventDataNode = new ObjectMapper().readTree(event.getEventData());

--- a/src/main/java/uk/gov/pay/ledger/transaction/service/TransactionService.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/service/TransactionService.java
@@ -3,7 +3,7 @@ package uk.gov.pay.ledger.transaction.service;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.inject.Inject;
 import uk.gov.pay.ledger.event.dao.EventDao;
-import uk.gov.pay.ledger.event.model.EventEntity;
+import uk.gov.pay.ledger.event.dao.entity.EventEntity;
 import uk.gov.pay.ledger.event.model.EventDigest;
 import uk.gov.pay.ledger.event.model.TransactionEntityFactory;
 import uk.gov.pay.ledger.transaction.dao.TransactionDao;

--- a/src/main/java/uk/gov/pay/ledger/transaction/service/TransactionService.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/service/TransactionService.java
@@ -3,7 +3,7 @@ package uk.gov.pay.ledger.transaction.service;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.inject.Inject;
 import uk.gov.pay.ledger.event.dao.EventDao;
-import uk.gov.pay.ledger.event.model.Event;
+import uk.gov.pay.ledger.event.model.EventEntity;
 import uk.gov.pay.ledger.event.model.EventDigest;
 import uk.gov.pay.ledger.event.model.TransactionEntityFactory;
 import uk.gov.pay.ledger.transaction.dao.TransactionDao;
@@ -200,11 +200,11 @@ public class TransactionService {
     }
 
     private List<TransactionEvent> getTransactionEventsFor(Map<String, TransactionEntity> transactionEntityMap, int statusVersion) {
-        List<Event> events = eventDao.findEventsForExternalIds(transactionEntityMap.keySet());
+        List<EventEntity> events = eventDao.findEventsForExternalIds(transactionEntityMap.keySet());
         return mapToTransactionEvent(transactionEntityMap, events, statusVersion);
     }
 
-    private List<TransactionEvent> mapToTransactionEvent(Map<String, TransactionEntity> transactionEntityMap, List<Event> eventList, int statusVersion) {
+    private List<TransactionEvent> mapToTransactionEvent(Map<String, TransactionEntity> transactionEntityMap, List<EventEntity> eventList, int statusVersion) {
         return eventList.stream()
                 .map(event -> TransactionEvent.from(transactionEntityMap.get(event.getResourceExternalId()), event, objectMapper, statusVersion))
                 .collect(Collectors.toList());

--- a/src/main/java/uk/gov/pay/ledger/transactionsummary/service/TransactionSummaryService.java
+++ b/src/main/java/uk/gov/pay/ledger/transactionsummary/service/TransactionSummaryService.java
@@ -1,7 +1,7 @@
 package uk.gov.pay.ledger.transactionsummary.service;
 
 import com.google.inject.Inject;
-import uk.gov.pay.ledger.event.model.EventEntity;
+import uk.gov.pay.ledger.event.dao.entity.EventEntity;
 import uk.gov.pay.ledger.event.model.SalientEventType;
 import uk.gov.pay.ledger.transaction.entity.TransactionEntity;
 import uk.gov.pay.ledger.transaction.model.TransactionType;

--- a/src/test/java/uk/gov/pay/ledger/event/dao/EventDaoIT.java
+++ b/src/test/java/uk/gov/pay/ledger/event/dao/EventDaoIT.java
@@ -5,7 +5,7 @@ import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
-import uk.gov.pay.ledger.event.model.EventEntity;
+import uk.gov.pay.ledger.event.dao.entity.EventEntity;
 import uk.gov.pay.ledger.event.model.EventTicker;
 import uk.gov.pay.ledger.extension.AppWithPostgresAndSqsExtension;
 import uk.gov.pay.ledger.util.DatabaseTestHelper;

--- a/src/test/java/uk/gov/pay/ledger/event/dao/EventDaoIT.java
+++ b/src/test/java/uk/gov/pay/ledger/event/dao/EventDaoIT.java
@@ -5,7 +5,7 @@ import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
-import uk.gov.pay.ledger.event.model.Event;
+import uk.gov.pay.ledger.event.model.EventEntity;
 import uk.gov.pay.ledger.event.model.EventTicker;
 import uk.gov.pay.ledger.extension.AppWithPostgresAndSqsExtension;
 import uk.gov.pay.ledger.util.DatabaseTestHelper;
@@ -63,7 +63,7 @@ public class EventDaoIT {
         eventDao.insertEventWithResourceTypeId(paymentCreatedEvent.toEntity());
         eventDao.insertEventWithResourceTypeId(paymentSucceededEvent.toEntity());
 
-        List<Event> events = eventDao.getEventsByResourceExternalId(resourceExternalId);
+        List<EventEntity> events = eventDao.getEventsByResourceExternalId(resourceExternalId);
         assertThat(events, hasSize(2));
         events.forEach(event -> assertThat(event.getEventData(), is(eventData)));
 
@@ -77,7 +77,7 @@ public class EventDaoIT {
 
     @Test
     public void shouldInsertEvent() throws IOException {
-        Event event = anEventFixture()
+        EventEntity event = anEventFixture()
                 .withEventDate(CREATED_AT)
                 .withParentResourceExternalId("parent-resource-id")
                 .toEntity();
@@ -97,7 +97,7 @@ public class EventDaoIT {
 
     @Test
     public void shouldInsertNotExistingEvent() throws IOException {
-        Event event = anEventFixture()
+        EventEntity event = anEventFixture()
                 .withEventDate(CREATED_AT)
                 .toEntity();
 
@@ -117,10 +117,10 @@ public class EventDaoIT {
 
     @Test
     public void shouldInsertDuplicateEventWithDifferentTimestamp() {
-        Event event = anEventFixture()
+        EventEntity event = anEventFixture()
                 .insert(rule.getJdbi())
                 .toEntity();
-        Event duplicateEvent = anEventFixture()
+        EventEntity duplicateEvent = anEventFixture()
                 .from(event)
                 .withEventDate(CREATED_AT)
                 .toEntity();
@@ -137,11 +137,11 @@ public class EventDaoIT {
 
     @Test
     public void shouldNotInsertDuplicateEvent() throws IOException {
-        Event event = anEventFixture()
+        EventEntity event = anEventFixture()
                 .withEventDate(CREATED_AT)
                 .insert(rule.getJdbi())
                 .toEntity();
-        Event duplicateEvent = anEventFixture()
+        EventEntity duplicateEvent = anEventFixture()
                 .from(event)
                 .withSQSMessageId(RandomStringUtils.randomAlphanumeric(50))
                 .withEventDate(CREATED_AT)
@@ -166,13 +166,13 @@ public class EventDaoIT {
 
     @Test
     public void shouldFindEvent() {
-        Event event = anEventFixture()
+        EventEntity event = anEventFixture()
                 .insert(rule.getJdbi())
                 .toEntity();
 
-        Optional<Event> optionalEvent = eventDao.getById(event.getId());
+        Optional<EventEntity> optionalEvent = eventDao.getById(event.getId());
         assertThat(optionalEvent.isPresent(), is(true));
-        Event retrievedEvent = optionalEvent.get();
+        EventEntity retrievedEvent = optionalEvent.get();
         assertThat(retrievedEvent.getId(), is(event.getId()));
         assertThat(retrievedEvent.getResourceExternalId(), is(event.getResourceExternalId()));
         assertThat(retrievedEvent.getResourceType().name(), is(event.getResourceType().name()));
@@ -186,25 +186,25 @@ public class EventDaoIT {
     public void shouldGetAllEventsForResourceExternalIdInDescendingDateOrder() {
         final String resourceExternalId = "resourceExternalId";
 
-        Event earliestEvent = anEventFixture()
+        EventEntity earliestEvent = anEventFixture()
                 .withResourceExternalId(resourceExternalId)
                 .withEventDate(ZonedDateTime.now().minusHours(4))
                 .insert(rule.getJdbi())
                 .toEntity();
 
-        Event latestEvent = anEventFixture()
+        EventEntity latestEvent = anEventFixture()
                 .withResourceExternalId(resourceExternalId)
                 .withEventDate(ZonedDateTime.now().minusHours(1))
                 .insert(rule.getJdbi())
                 .toEntity();
 
-        Event middleEvent = anEventFixture()
+        EventEntity middleEvent = anEventFixture()
                 .withResourceExternalId(resourceExternalId)
                 .withEventDate(ZonedDateTime.now().minusHours(2))
                 .insert(rule.getJdbi())
                 .toEntity();
 
-        List<Event> events = eventDao.getEventsByResourceExternalId(resourceExternalId);
+        List<EventEntity> events = eventDao.getEventsByResourceExternalId(resourceExternalId);
 
         assertThat(events.size(), is(3));
         assertThat(events.get(0).getId(), is(latestEvent.getId()));
@@ -214,18 +214,18 @@ public class EventDaoIT {
 
     @Test
     public void shouldGetEmptyListWhenNoEventsWithResourceExternalId() {
-        List<Event> events = eventDao.getEventsByResourceExternalId("no_events_for_this_id");
+        List<EventEntity> events = eventDao.getEventsByResourceExternalId("no_events_for_this_id");
 
         assertThat(events.size(), is(0));
     }
 
     @Test
     public void findEventsForExternalIdsShouldFilterEventsByMultipleExternalIds() {
-        Event event1 = anEventFixture()
+        EventEntity event1 = anEventFixture()
                 .withResourceExternalId("external-id-1")
                 .insert(rule.getJdbi())
                 .toEntity();
-        Event event2 = anEventFixture()
+        EventEntity event2 = anEventFixture()
                 .withResourceExternalId("external-id-2")
                 .withEventDate(event1.getEventDate().plusDays(1))
                 .insert(rule.getJdbi())
@@ -235,7 +235,7 @@ public class EventDaoIT {
                 .withEventDate(event2.getEventDate().plusDays(1))
                 .insert(rule.getJdbi());
 
-        List<Event> eventList = eventDao.findEventsForExternalIds(Set.of("external-id-1", "external-id-2"));
+        List<EventEntity> eventList = eventDao.findEventsForExternalIds(Set.of("external-id-1", "external-id-2"));
 
         assertThat(eventList.size(), is(2));
 
@@ -245,7 +245,7 @@ public class EventDaoIT {
 
     @Test
     public void findEventsForExternalIds_ShouldReturnEmptyListIfNoRecordsFound() {
-        List<Event> eventList = eventDao.findEventsForExternalIds(Set.of("some-ext-id-1", "some-ext-id-2"));
+        List<EventEntity> eventList = eventDao.findEventsForExternalIds(Set.of("some-ext-id-1", "some-ext-id-2"));
         assertThat(eventList.size(), is(0));
     }
 
@@ -259,12 +259,12 @@ public class EventDaoIT {
                 .insert(rule.getJdbi())
                 .toEntity();
 
-        Event event1 = anEventFixture()
+        EventEntity event1 = anEventFixture()
                 .withResourceExternalId("external-id-1")
                 .withEventType("PAYMENT_CREATED")
                 .insert(rule.getJdbi())
                 .toEntity();
-        Event event2 = anEventFixture()
+        EventEntity event2 = anEventFixture()
                 .withResourceExternalId("external-id-1")
                 .withEventDate(event1.getEventDate().minusDays(1))
                 .insert(rule.getJdbi())

--- a/src/test/java/uk/gov/pay/ledger/event/model/EventDigestTest.java
+++ b/src/test/java/uk/gov/pay/ledger/event/model/EventDigestTest.java
@@ -1,6 +1,7 @@
 package uk.gov.pay.ledger.event.model;
 
 import org.junit.jupiter.api.Test;
+import uk.gov.pay.ledger.event.dao.entity.EventEntity;
 
 import java.time.ZonedDateTime;
 import java.util.List;

--- a/src/test/java/uk/gov/pay/ledger/event/model/EventDigestTest.java
+++ b/src/test/java/uk/gov/pay/ledger/event/model/EventDigestTest.java
@@ -14,17 +14,17 @@ public class EventDigestTest {
 
     @Test
     public void shouldDeriveNonNullParentExternalIdCorrectlyFromEventDigest() {
-        Event eventWithParentExternalId = anEventFixture()
+        EventEntity eventWithParentExternalId = anEventFixture()
                 .withEventDate(ZonedDateTime.now().minusHours(2L))
                 .withParentResourceExternalId("parent_external_id")
                 .toEntity();
 
-        Event eventWithOutParentExternalId = anEventFixture()
+        EventEntity eventWithOutParentExternalId = anEventFixture()
                 .withEventDate(ZonedDateTime.now())
                 .withParentResourceExternalId(null)
                 .toEntity();
 
-        Event latestEventWithOutParentExternalId = anEventFixture()
+        EventEntity latestEventWithOutParentExternalId = anEventFixture()
                 .withEventDate(ZonedDateTime.now().plusDays(2))
                 .withParentResourceExternalId(null)
                 .toEntity();
@@ -37,15 +37,15 @@ public class EventDigestTest {
 
     @Test
     public void shouldDeriveParentExternalIdToNullIfNoEventsHasParentExternalId() {
-        Event eventWithoutParentExternalId = anEventFixture()
+        EventEntity eventWithoutParentExternalId = anEventFixture()
                 .withParentResourceExternalId(null)
                 .toEntity();
 
-        Event event2WithoutParentExternalId = anEventFixture()
+        EventEntity event2WithoutParentExternalId = anEventFixture()
                 .withParentResourceExternalId(null)
                 .toEntity();
 
-        Event event3WithoutParentExternalId = anEventFixture()
+        EventEntity event3WithoutParentExternalId = anEventFixture()
                 .withParentResourceExternalId(null)
                 .toEntity();
 
@@ -57,16 +57,16 @@ public class EventDigestTest {
 
     @Test
     public void shouldDeriveNonNullServiceIdCorrectlyFromEventDigest() {
-        Event eventWithServiceId = anEventFixture()
+        EventEntity eventWithServiceId = anEventFixture()
                 .withEventDate(ZonedDateTime.now().minusHours(2L))
                 .withServiceId("service-id")
                 .toEntity();
 
-        Event eventWithOutServiceId = anEventFixture()
+        EventEntity eventWithOutServiceId = anEventFixture()
                 .withEventDate(ZonedDateTime.now())
                 .toEntity();
 
-        Event latestEventWithOutServiceId = anEventFixture()
+        EventEntity latestEventWithOutServiceId = anEventFixture()
                 .withEventDate(ZonedDateTime.now().plusDays(2))
                 .withServiceId(null)
                 .toEntity();
@@ -79,15 +79,15 @@ public class EventDigestTest {
 
     @Test
     public void shouldDeriveServiceIdToNullIfNoEventsHasServiceId() {
-        Event eventWithoutServiceId = anEventFixture()
+        EventEntity eventWithoutServiceId = anEventFixture()
                 .withParentResourceExternalId(null)
                 .toEntity();
 
-        Event event2WithoutServiceId = anEventFixture()
+        EventEntity event2WithoutServiceId = anEventFixture()
                 .withParentResourceExternalId(null)
                 .toEntity();
 
-        Event event3WithoutServiceId = anEventFixture()
+        EventEntity event3WithoutServiceId = anEventFixture()
                 .withParentResourceExternalId(null)
                 .toEntity();
 
@@ -99,8 +99,8 @@ public class EventDigestTest {
 
     @Test
     public void shouldBeLiveTrueIfContainsTrueEvent() {
-        Event eventWithNullLiveValue = anEventFixture().withLive(null).toEntity();
-        Event eventWithTrueLiveValue = anEventFixture().withLive(true).toEntity();
+        EventEntity eventWithNullLiveValue = anEventFixture().withLive(null).toEntity();
+        EventEntity eventWithTrueLiveValue = anEventFixture().withLive(true).toEntity();
 
         EventDigest eventDigest = EventDigest.fromEventList(
                 List.of(eventWithTrueLiveValue, eventWithNullLiveValue));
@@ -110,8 +110,8 @@ public class EventDigestTest {
 
     @Test
     public void shouldBeLiveFalseIfContainsFalseEvent() {
-        Event eventWithNullLiveValue = anEventFixture().withLive(null).toEntity();
-        Event eventWithFalseLiveValue = anEventFixture().withLive(false).toEntity();
+        EventEntity eventWithNullLiveValue = anEventFixture().withLive(null).toEntity();
+        EventEntity eventWithFalseLiveValue = anEventFixture().withLive(false).toEntity();
 
         EventDigest eventDigest = EventDigest.fromEventList(
                 List.of(eventWithFalseLiveValue, eventWithNullLiveValue));
@@ -121,7 +121,7 @@ public class EventDigestTest {
     
     @Test
     public void shouldBeLiveNullIfContainsOnlyNullEvents() {
-        Event eventWithNullLiveValue = anEventFixture().withLive(null).toEntity();
+        EventEntity eventWithNullLiveValue = anEventFixture().withLive(null).toEntity();
 
         EventDigest eventDigest = EventDigest.fromEventList(
                 List.of(eventWithNullLiveValue));

--- a/src/test/java/uk/gov/pay/ledger/event/model/TransactionEntityFactoryTest.java
+++ b/src/test/java/uk/gov/pay/ledger/event/model/TransactionEntityFactoryTest.java
@@ -31,24 +31,24 @@ public class TransactionEntityFactoryTest {
 
     @Test
     public void fromShouldConvertEventDigestToTransactionEntity() {
-        Event paymentCreatedEvent = aQueuePaymentEventFixture()
+        EventEntity paymentCreatedEvent = aQueuePaymentEventFixture()
                 .withLive(true)
                 .withEventType(SalientEventType.PAYMENT_CREATED.name())
                 .withDefaultEventDataForEventType(SalientEventType.PAYMENT_CREATED.name())
                 .withResourceType(ResourceType.PAYMENT)
                 .withSource(Source.CARD_API)
                 .toEntity();
-        Event paymentDetailsEvent = aQueuePaymentEventFixture()
+        EventEntity paymentDetailsEvent = aQueuePaymentEventFixture()
                 .withEventType("PAYMENT_DETAILS_ENTERED")
                 .withDefaultEventDataForEventType("PAYMENT_DETAILS_ENTERED")
                 .withResourceType(ResourceType.PAYMENT)
                 .toEntity();
-        Event captureConfirmedEvent = aQueuePaymentEventFixture()
+        EventEntity captureConfirmedEvent = aQueuePaymentEventFixture()
                 .withEventType("CAPTURE_CONFIRMED")
                 .withEventData("{\"net_amount\": 55, \"total_amount\": 105, \"fee\": 33}")
                 .withResourceType(ResourceType.PAYMENT)
                 .toEntity();
-        Event paymentIncludedInPayoutEvent = aQueuePaymentEventFixture()
+        EventEntity paymentIncludedInPayoutEvent = aQueuePaymentEventFixture()
                 .withEventType("PAYMENT_INCLUDED_IN_PAYOUT")
                 .withEventData("{\"gateway_payout_id\": \"payout-id\"}")
                 .withResourceType(ResourceType.PAYMENT)
@@ -99,14 +99,14 @@ public class TransactionEntityFactoryTest {
     @Test
     public void fromShouldConvertEventDigestToTransactionForChildResource() throws IOException {
         String parentResourceExternalId = "parent-resource-external-id";
-        Event refundCreatedEvent = aQueuePaymentEventFixture()
+        EventEntity refundCreatedEvent = aQueuePaymentEventFixture()
                 .withEventType("REFUND_CREATED_BY_USER")
                 .withResourceExternalId("resource-external-id")
                 .withParentResourceExternalId(parentResourceExternalId)
                 .withResourceType(ResourceType.REFUND)
                 .withEventData("{\"refunded_by\": \"refunded-by-id\", \"amount\": 1000}")
                 .toEntity();
-        Event refundSubmittedEvent = aQueuePaymentEventFixture()
+        EventEntity refundSubmittedEvent = aQueuePaymentEventFixture()
                 .withEventType("REFUND_SUBMITTED")
                 .withResourceExternalId("resource-external-id")
                 .withParentResourceExternalId(parentResourceExternalId)
@@ -129,10 +129,10 @@ public class TransactionEntityFactoryTest {
 
     @Test
     public void create_ShouldCorrectlySetStateForMostRecentSalientEventType() {
-        Event paymentCreatedEvent = aQueuePaymentEventFixture().withEventType("PAYMENT_CREATED").toEntity();
-        Event nonSalientEvent = aQueuePaymentEventFixture().withEventType("NON_STATE_TRANSITION_EVENT").toEntity();
-        Event paymentStartedEvent = aQueuePaymentEventFixture().withEventType("PAYMENT_STARTED").toEntity();
-        Event secondNonSalientEvent = aQueuePaymentEventFixture().withEventType("SECOND_NON_STATE_TRANSITION_EVENT").toEntity();
+        EventEntity paymentCreatedEvent = aQueuePaymentEventFixture().withEventType("PAYMENT_CREATED").toEntity();
+        EventEntity nonSalientEvent = aQueuePaymentEventFixture().withEventType("NON_STATE_TRANSITION_EVENT").toEntity();
+        EventEntity paymentStartedEvent = aQueuePaymentEventFixture().withEventType("PAYMENT_STARTED").toEntity();
+        EventEntity secondNonSalientEvent = aQueuePaymentEventFixture().withEventType("SECOND_NON_STATE_TRANSITION_EVENT").toEntity();
 
         EventDigest eventDigest = EventDigest.fromEventList(List.of(secondNonSalientEvent, paymentStartedEvent, nonSalientEvent, paymentCreatedEvent));
         TransactionEntity transactionEntity = transactionEntityFactory.create(eventDigest);
@@ -142,7 +142,7 @@ public class TransactionEntityFactoryTest {
 
     @Test
     public void create_ShouldSetUndefinedStateForNoSalientEventTypes() {
-        Event paymentDetailsEntered = aQueuePaymentEventFixture().withEventType("PAYMENT_DETAILS_ENTERED").toEntity();
+        EventEntity paymentDetailsEntered = aQueuePaymentEventFixture().withEventType("PAYMENT_DETAILS_ENTERED").toEntity();
 
         EventDigest eventDigest = EventDigest.fromEventList(List.of(paymentDetailsEntered));
         TransactionEntity transactionEntity = transactionEntityFactory.create(eventDigest);
@@ -152,7 +152,7 @@ public class TransactionEntityFactoryTest {
 
     @Test
     public void createWithNoSourceParameter_ShouldHandleNullValueCorrectly() {
-        Event paymentCreatedEvent = aQueuePaymentEventFixture()
+        EventEntity paymentCreatedEvent = aQueuePaymentEventFixture()
                 .withEventType("PAYMENT_CREATED")
                 .withEventData("{\"amount\":50}")
                 .toEntity();

--- a/src/test/java/uk/gov/pay/ledger/event/model/TransactionEntityFactoryTest.java
+++ b/src/test/java/uk/gov/pay/ledger/event/model/TransactionEntityFactoryTest.java
@@ -5,6 +5,7 @@ import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import uk.gov.pay.ledger.event.dao.entity.EventEntity;
 import uk.gov.service.payments.commons.model.Source;
 import uk.gov.pay.ledger.transaction.entity.TransactionEntity;
 

--- a/src/test/java/uk/gov/pay/ledger/event/resource/EventResourceIT.java
+++ b/src/test/java/uk/gov/pay/ledger/event/resource/EventResourceIT.java
@@ -5,7 +5,7 @@ import org.json.JSONObject;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
-import uk.gov.pay.ledger.event.model.Event;
+import uk.gov.pay.ledger.event.model.EventEntity;
 import uk.gov.pay.ledger.extension.AppWithPostgresAndSqsExtension;
 import uk.gov.pay.ledger.util.DatabaseTestHelper;
 
@@ -31,25 +31,6 @@ public class EventResourceIT {
     public void setUp() {
         databaseTestHelper = DatabaseTestHelper.aDatabaseTestHelper(rule.getJdbi());
         databaseTestHelper.truncateAllData();
-    }
-
-    @Test
-    public void shouldGetEventFromDB() {
-        Event event = anEventFixture()
-                .insert(rule.getJdbi())
-                .toEntity();
-
-        given().port(port)
-                .contentType(JSON)
-                .get("/v1/event/" + event.getId())
-                .then()
-                .statusCode(Response.Status.OK.getStatusCode())
-                .contentType(JSON)
-                .body("resource_external_id", is(event.getResourceExternalId()))
-                .body("resource_type", is(event.getResourceType().name().toLowerCase()))
-                .body("sqs_message_id", is(event.getSqsMessageId()))
-                .body("event_type", is(event.getEventType()))
-                .body("event_data", is(event.getEventData()));
     }
 
     @Test
@@ -122,7 +103,7 @@ public class EventResourceIT {
                 .insert(rule.getJdbi())
                 .toEntity();
 
-        Event event = anEventFixture()
+        EventEntity event = anEventFixture()
                 .withResourceExternalId("an-external-id")
                 .insert(rule.getJdbi())
                 .toEntity();

--- a/src/test/java/uk/gov/pay/ledger/event/resource/EventResourceIT.java
+++ b/src/test/java/uk/gov/pay/ledger/event/resource/EventResourceIT.java
@@ -5,7 +5,7 @@ import org.json.JSONObject;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
-import uk.gov.pay.ledger.event.model.EventEntity;
+import uk.gov.pay.ledger.event.dao.entity.EventEntity;
 import uk.gov.pay.ledger.extension.AppWithPostgresAndSqsExtension;
 import uk.gov.pay.ledger.util.DatabaseTestHelper;
 

--- a/src/test/java/uk/gov/pay/ledger/event/resource/EventResourceTest.java
+++ b/src/test/java/uk/gov/pay/ledger/event/resource/EventResourceTest.java
@@ -7,7 +7,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.pay.ledger.event.dao.EventDao;
-import uk.gov.pay.ledger.event.model.Event;
+import uk.gov.pay.ledger.event.model.EventEntity;
 import uk.gov.pay.ledger.queue.EventMessageHandler;
 import uk.gov.pay.ledger.util.fixture.EventFixture;
 
@@ -26,7 +26,7 @@ public class EventResourceTest {
     private static final EventMessageHandler eventMessageHandler = mock(EventMessageHandler.class);
     private static final Long eventId = 1L;
     private static final String nonExistentId = "I'm not really here";
-    private final Event event = EventFixture.anEventFixture()
+    private final EventEntity event = EventFixture.anEventFixture()
             .withId(eventId)
             .toEntity();
 
@@ -38,18 +38,7 @@ public class EventResourceTest {
     public void setup() {
         when(dao.getById(eventId)).thenReturn(Optional.of(event));
     }
-
-    @Test
-    public void shouldReturnEventIfItExists() {
-        Event returnedEvent = resources.target("/v1/event/" + eventId).request().get(Event.class);
-        assertThat(returnedEvent.getResourceExternalId(), is(event.getResourceExternalId()));
-    }
-
-    @Test
-    public void shouldReturn404IfEventDoesNotExist() {
-        Response response = resources.target("/v1/event/" + nonExistentId).request().get();
-        assertThat(response.getStatus(), is(404));
-    }
+    
 
     @Test
     public void shouldReturn400IfFromAndToDatesNotSuppliedToTickerEndpoint() {

--- a/src/test/java/uk/gov/pay/ledger/event/resource/EventResourceTest.java
+++ b/src/test/java/uk/gov/pay/ledger/event/resource/EventResourceTest.java
@@ -7,7 +7,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.pay.ledger.event.dao.EventDao;
-import uk.gov.pay.ledger.event.model.EventEntity;
+import uk.gov.pay.ledger.event.dao.entity.EventEntity;
 import uk.gov.pay.ledger.queue.EventMessageHandler;
 import uk.gov.pay.ledger.util.fixture.EventFixture;
 

--- a/src/test/java/uk/gov/pay/ledger/event/service/EventServiceTest.java
+++ b/src/test/java/uk/gov/pay/ledger/event/service/EventServiceTest.java
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.pay.ledger.event.dao.EventDao;
-import uk.gov.pay.ledger.event.model.EventEntity;
+import uk.gov.pay.ledger.event.dao.entity.EventEntity;
 import uk.gov.pay.ledger.event.model.EventDigest;
 import uk.gov.pay.ledger.event.model.SalientEventType;
 import uk.gov.pay.ledger.event.model.response.CreateEventResponse;

--- a/src/test/java/uk/gov/pay/ledger/event/service/EventServiceTest.java
+++ b/src/test/java/uk/gov/pay/ledger/event/service/EventServiceTest.java
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.pay.ledger.event.dao.EventDao;
-import uk.gov.pay.ledger.event.model.Event;
+import uk.gov.pay.ledger.event.model.EventEntity;
 import uk.gov.pay.ledger.event.model.EventDigest;
 import uk.gov.pay.ledger.event.model.SalientEventType;
 import uk.gov.pay.ledger.event.model.response.CreateEventResponse;
@@ -34,12 +34,12 @@ public class EventServiceTest {
 
     private EventService eventService;
 
-    private Event event;
+    private EventEntity event;
 
     private ZonedDateTime latestEventTime;
     private final String resourceExternalId = "resource_external_id";
-    private Event event1;
-    private Event event2;
+    private EventEntity event1;
+    private EventEntity event2;
 
     @BeforeEach
     public void setUp() {
@@ -80,13 +80,13 @@ public class EventServiceTest {
     @Test
     public void shouldGetCorrectLatestSalientEventType() {
         String eventDetails1 = "{ \"amount\": 1000}";
-        Event event1 = EventFixture.anEventFixture()
+        EventEntity event1 = EventFixture.anEventFixture()
                 .withEventData(eventDetails1)
                 .withResourceExternalId(resourceExternalId)
                 .withEventDate(latestEventTime)
                 .toEntity();
         String eventDetails2 = "{ \"amount\": 2000, \"description\": \"a payment\"}";
-        Event event2 = EventFixture.anEventFixture()
+        EventEntity event2 = EventFixture.anEventFixture()
                 .withEventData(eventDetails2)
                 .withEventType("A_WEIRD_EVENT_THAT_SHOULD_NOT_BE_CONSIDERED_SALIENT")
                 .withResourceExternalId(resourceExternalId)

--- a/src/test/java/uk/gov/pay/ledger/pact/event/CaptureConfirmedEventQueueConsumerIT.java
+++ b/src/test/java/uk/gov/pay/ledger/pact/event/CaptureConfirmedEventQueueConsumerIT.java
@@ -11,7 +11,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import uk.gov.pay.ledger.app.LedgerConfig;
 import uk.gov.pay.ledger.event.dao.EventDao;
-import uk.gov.pay.ledger.event.model.EventEntity;
+import uk.gov.pay.ledger.event.dao.entity.EventEntity;
 import uk.gov.pay.ledger.rule.AppWithPostgresAndSqsRule;
 import uk.gov.pay.ledger.rule.SqsTestDocker;
 import uk.gov.pay.ledger.transaction.dao.TransactionDao;

--- a/src/test/java/uk/gov/pay/ledger/pact/event/CaptureConfirmedEventQueueConsumerIT.java
+++ b/src/test/java/uk/gov/pay/ledger/pact/event/CaptureConfirmedEventQueueConsumerIT.java
@@ -11,7 +11,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import uk.gov.pay.ledger.app.LedgerConfig;
 import uk.gov.pay.ledger.event.dao.EventDao;
-import uk.gov.pay.ledger.event.model.Event;
+import uk.gov.pay.ledger.event.model.EventEntity;
 import uk.gov.pay.ledger.rule.AppWithPostgresAndSqsRule;
 import uk.gov.pay.ledger.rule.SqsTestDocker;
 import uk.gov.pay.ledger.transaction.dao.TransactionDao;
@@ -89,7 +89,7 @@ public class CaptureConfirmedEventQueueConsumerIT {
         Map<String, Object> transactionDetails = new Gson().fromJson(transaction.get().getTransactionDetails(), Map.class);
         assertThat(transactionDetails.get("captured_date"), is("2018-03-12T16:25:01.123456Z"));
 
-        Event event = eventDao.getEventsByResourceExternalId(externalId).get(0);
+        EventEntity event = eventDao.getEventsByResourceExternalId(externalId).get(0);
         Map<String, Object> eventDetails = new Gson().fromJson(event.getEventData(), Map.class);
         assertThat(eventDetails.get("gateway_event_date"),  is("2018-03-12T16:25:01.123456Z"));
         assertThat(eventDetails.get("captured_date"),  is("2018-03-12T16:25:01.123456Z"));

--- a/src/test/java/uk/gov/pay/ledger/pact/event/DisputeCreatedEventQueueConsumerIT.java
+++ b/src/test/java/uk/gov/pay/ledger/pact/event/DisputeCreatedEventQueueConsumerIT.java
@@ -14,7 +14,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import uk.gov.pay.ledger.app.LedgerConfig;
 import uk.gov.pay.ledger.event.dao.EventDao;
-import uk.gov.pay.ledger.event.model.Event;
+import uk.gov.pay.ledger.event.model.EventEntity;
 import uk.gov.pay.ledger.event.model.SalientEventType;
 import uk.gov.pay.ledger.rule.AppWithPostgresAndSqsRule;
 import uk.gov.pay.ledger.rule.SqsTestDocker;
@@ -102,9 +102,9 @@ public class DisputeCreatedEventQueueConsumerIT {
                 () -> !eventDao.findEventsForExternalIds(Set.of(resourceExternalId)).isEmpty()
         );
 
-        List<Event> events = eventDao.findEventsForExternalIds(Set.of(resourceExternalId));
+        List<EventEntity> events = eventDao.findEventsForExternalIds(Set.of(resourceExternalId));
         assertThat(events.isEmpty(), is(false));
-        Event event = events.get(0);
+        EventEntity event = events.get(0);
         assertThat(event.getEventType(), is("DISPUTE_CREATED"));
         assertThat(event.getEventDate(), is(eventDate));
         assertThat(event.getResourceType(), is(DISPUTE));

--- a/src/test/java/uk/gov/pay/ledger/pact/event/DisputeCreatedEventQueueConsumerIT.java
+++ b/src/test/java/uk/gov/pay/ledger/pact/event/DisputeCreatedEventQueueConsumerIT.java
@@ -14,7 +14,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import uk.gov.pay.ledger.app.LedgerConfig;
 import uk.gov.pay.ledger.event.dao.EventDao;
-import uk.gov.pay.ledger.event.model.EventEntity;
+import uk.gov.pay.ledger.event.dao.entity.EventEntity;
 import uk.gov.pay.ledger.event.model.SalientEventType;
 import uk.gov.pay.ledger.rule.AppWithPostgresAndSqsRule;
 import uk.gov.pay.ledger.rule.SqsTestDocker;

--- a/src/test/java/uk/gov/pay/ledger/pact/event/DisputeEvidenceSubmittedEventQueueConsumerIT.java
+++ b/src/test/java/uk/gov/pay/ledger/pact/event/DisputeEvidenceSubmittedEventQueueConsumerIT.java
@@ -14,7 +14,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import uk.gov.pay.ledger.app.LedgerConfig;
 import uk.gov.pay.ledger.event.dao.EventDao;
-import uk.gov.pay.ledger.event.model.Event;
+import uk.gov.pay.ledger.event.model.EventEntity;
 import uk.gov.pay.ledger.rule.AppWithPostgresAndSqsRule;
 import uk.gov.pay.ledger.rule.SqsTestDocker;
 import uk.gov.pay.ledger.transaction.dao.TransactionDao;
@@ -102,9 +102,9 @@ public class DisputeEvidenceSubmittedEventQueueConsumerIT {
                 () -> !eventDao.findEventsForExternalIds(Set.of(resourceExternalId)).isEmpty()
         );
 
-        List<Event> events = eventDao.findEventsForExternalIds(Set.of(resourceExternalId));
+        List<EventEntity> events = eventDao.findEventsForExternalIds(Set.of(resourceExternalId));
         assertThat(events.isEmpty(), is(false));
-        Event event = events.get(0);
+        EventEntity event = events.get(0);
         assertThat(event.getEventType(), is("DISPUTE_EVIDENCE_SUBMITTED"));
         assertThat(event.getEventDate(), is(eventDate));
         assertThat(event.getResourceType(), is(DISPUTE));

--- a/src/test/java/uk/gov/pay/ledger/pact/event/DisputeEvidenceSubmittedEventQueueConsumerIT.java
+++ b/src/test/java/uk/gov/pay/ledger/pact/event/DisputeEvidenceSubmittedEventQueueConsumerIT.java
@@ -14,7 +14,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import uk.gov.pay.ledger.app.LedgerConfig;
 import uk.gov.pay.ledger.event.dao.EventDao;
-import uk.gov.pay.ledger.event.model.EventEntity;
+import uk.gov.pay.ledger.event.dao.entity.EventEntity;
 import uk.gov.pay.ledger.rule.AppWithPostgresAndSqsRule;
 import uk.gov.pay.ledger.rule.SqsTestDocker;
 import uk.gov.pay.ledger.transaction.dao.TransactionDao;

--- a/src/test/java/uk/gov/pay/ledger/pact/event/DisputeLostEventQueueConsumerIT.java
+++ b/src/test/java/uk/gov/pay/ledger/pact/event/DisputeLostEventQueueConsumerIT.java
@@ -13,7 +13,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import uk.gov.pay.ledger.app.LedgerConfig;
 import uk.gov.pay.ledger.event.dao.EventDao;
-import uk.gov.pay.ledger.event.model.Event;
+import uk.gov.pay.ledger.event.model.EventEntity;
 import uk.gov.pay.ledger.event.model.SalientEventType;
 import uk.gov.pay.ledger.rule.AppWithPostgresAndSqsRule;
 import uk.gov.pay.ledger.rule.SqsTestDocker;
@@ -102,9 +102,9 @@ public class DisputeLostEventQueueConsumerIT {
                 () -> !eventDao.findEventsForExternalIds(Set.of(resourceExternalId)).isEmpty()
         );
 
-        List<Event> events = eventDao.findEventsForExternalIds(Set.of(resourceExternalId));
+        List<EventEntity> events = eventDao.findEventsForExternalIds(Set.of(resourceExternalId));
         assertThat(events.isEmpty(), is(false));
-        Event event = events.get(0);
+        EventEntity event = events.get(0);
         assertThat(event.getEventType(), is("DISPUTE_LOST"));
         assertThat(event.getEventDate(), is(disputeCreated));
         assertThat(event.getResourceType(), is(DISPUTE));

--- a/src/test/java/uk/gov/pay/ledger/pact/event/DisputeLostEventQueueConsumerIT.java
+++ b/src/test/java/uk/gov/pay/ledger/pact/event/DisputeLostEventQueueConsumerIT.java
@@ -13,7 +13,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import uk.gov.pay.ledger.app.LedgerConfig;
 import uk.gov.pay.ledger.event.dao.EventDao;
-import uk.gov.pay.ledger.event.model.EventEntity;
+import uk.gov.pay.ledger.event.dao.entity.EventEntity;
 import uk.gov.pay.ledger.event.model.SalientEventType;
 import uk.gov.pay.ledger.rule.AppWithPostgresAndSqsRule;
 import uk.gov.pay.ledger.rule.SqsTestDocker;

--- a/src/test/java/uk/gov/pay/ledger/pact/event/DisputeWonEventQueueConsumerIT.java
+++ b/src/test/java/uk/gov/pay/ledger/pact/event/DisputeWonEventQueueConsumerIT.java
@@ -14,7 +14,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import uk.gov.pay.ledger.app.LedgerConfig;
 import uk.gov.pay.ledger.event.dao.EventDao;
-import uk.gov.pay.ledger.event.model.EventEntity;
+import uk.gov.pay.ledger.event.dao.entity.EventEntity;
 import uk.gov.pay.ledger.rule.AppWithPostgresAndSqsRule;
 import uk.gov.pay.ledger.rule.SqsTestDocker;
 import uk.gov.pay.ledger.transaction.dao.TransactionDao;

--- a/src/test/java/uk/gov/pay/ledger/pact/event/DisputeWonEventQueueConsumerIT.java
+++ b/src/test/java/uk/gov/pay/ledger/pact/event/DisputeWonEventQueueConsumerIT.java
@@ -14,7 +14,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import uk.gov.pay.ledger.app.LedgerConfig;
 import uk.gov.pay.ledger.event.dao.EventDao;
-import uk.gov.pay.ledger.event.model.Event;
+import uk.gov.pay.ledger.event.model.EventEntity;
 import uk.gov.pay.ledger.rule.AppWithPostgresAndSqsRule;
 import uk.gov.pay.ledger.rule.SqsTestDocker;
 import uk.gov.pay.ledger.transaction.dao.TransactionDao;
@@ -102,9 +102,9 @@ public class DisputeWonEventQueueConsumerIT {
                 () -> !eventDao.findEventsForExternalIds(Set.of(resourceExternalId)).isEmpty()
         );
 
-        List<Event> events = eventDao.findEventsForExternalIds(Set.of(resourceExternalId));
+        List<EventEntity> events = eventDao.findEventsForExternalIds(Set.of(resourceExternalId));
         assertThat(events.isEmpty(), is(false));
-        Event event = events.get(0);
+        EventEntity event = events.get(0);
         assertThat(event.getEventType(), is("DISPUTE_WON"));
         assertThat(event.getEventDate(), is(eventDate));
         assertThat(event.getResourceType(), is(DISPUTE));

--- a/src/test/java/uk/gov/pay/ledger/pact/event/StatusCorrectedToCapturedToMatchGatewayStatusEventQueueConsumerIT.java
+++ b/src/test/java/uk/gov/pay/ledger/pact/event/StatusCorrectedToCapturedToMatchGatewayStatusEventQueueConsumerIT.java
@@ -11,7 +11,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import uk.gov.pay.ledger.app.LedgerConfig;
 import uk.gov.pay.ledger.event.dao.EventDao;
-import uk.gov.pay.ledger.event.model.Event;
+import uk.gov.pay.ledger.event.model.EventEntity;
 import uk.gov.pay.ledger.rule.AppWithPostgresAndSqsRule;
 import uk.gov.pay.ledger.rule.SqsTestDocker;
 import uk.gov.pay.ledger.transaction.dao.TransactionDao;
@@ -88,7 +88,7 @@ public class StatusCorrectedToCapturedToMatchGatewayStatusEventQueueConsumerIT {
         Map<String, Object> transactionDetails = new Gson().fromJson(transaction.get().getTransactionDetails(), Map.class);
         assertThat(transactionDetails.get("captured_date"), is("2018-03-12T16:25:01.123456Z"));
 
-        Event event = eventDao.getEventsByResourceExternalId(externalId).get(0);
+        EventEntity event = eventDao.getEventsByResourceExternalId(externalId).get(0);
         Map<String, Object> eventDetails = new Gson().fromJson(event.getEventData(), Map.class);
         assertThat(eventDetails.get("gateway_event_date"),  is("2018-03-12T16:25:01.123456Z"));
         assertThat(eventDetails.get("captured_date"),  is("2018-03-12T16:25:01.123456Z"));

--- a/src/test/java/uk/gov/pay/ledger/pact/event/StatusCorrectedToCapturedToMatchGatewayStatusEventQueueConsumerIT.java
+++ b/src/test/java/uk/gov/pay/ledger/pact/event/StatusCorrectedToCapturedToMatchGatewayStatusEventQueueConsumerIT.java
@@ -11,7 +11,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import uk.gov.pay.ledger.app.LedgerConfig;
 import uk.gov.pay.ledger.event.dao.EventDao;
-import uk.gov.pay.ledger.event.model.EventEntity;
+import uk.gov.pay.ledger.event.dao.entity.EventEntity;
 import uk.gov.pay.ledger.rule.AppWithPostgresAndSqsRule;
 import uk.gov.pay.ledger.rule.SqsTestDocker;
 import uk.gov.pay.ledger.transaction.dao.TransactionDao;

--- a/src/test/java/uk/gov/pay/ledger/payout/model/PayoutEntityFactoryTest.java
+++ b/src/test/java/uk/gov/pay/ledger/payout/model/PayoutEntityFactoryTest.java
@@ -6,7 +6,7 @@ import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import uk.gov.pay.ledger.event.model.Event;
+import uk.gov.pay.ledger.event.model.EventEntity;
 import uk.gov.pay.ledger.event.model.EventDigest;
 import uk.gov.pay.ledger.payout.entity.PayoutEntity;
 import uk.gov.pay.ledger.payout.state.PayoutState;
@@ -35,7 +35,7 @@ public class PayoutEntityFactoryTest {
     @Test
     public void shouldConvertEventDigestToPayoutEntity() {
         ZonedDateTime paidOutDate = ZonedDateTime.parse("2020-05-04T00:20:00.123456Z");
-        Event payoutCreatedEvent = aQueuePaymentEventFixture()
+        EventEntity payoutCreatedEvent = aQueuePaymentEventFixture()
                 .withEventType("PAYOUT_CREATED")
                 .withEventData(gsonBuilder.create()
                         .toJson(Map.of(
@@ -44,7 +44,7 @@ public class PayoutEntityFactoryTest {
                         ))
                 )
                 .toEntity();
-        Event payoutPaidOutEvent = aQueuePaymentEventFixture()
+        EventEntity payoutPaidOutEvent = aQueuePaymentEventFixture()
                 .withEventType("PAYOUT_PAID_OUT")
                 .withEventData(gsonBuilder.create()
                         .toJson(Map.of(
@@ -71,8 +71,8 @@ public class PayoutEntityFactoryTest {
 
     @Test
     public void shouldDigestStateFromEvents() {
-        Event payoutCreatedEvent = aQueuePaymentEventFixture().withEventType("PAYOUT_CREATED").toEntity();
-        Event payoutPaidOutEvent = aQueuePaymentEventFixture().withEventType("PAYOUT_PAID").toEntity();
+        EventEntity payoutCreatedEvent = aQueuePaymentEventFixture().withEventType("PAYOUT_CREATED").toEntity();
+        EventEntity payoutPaidOutEvent = aQueuePaymentEventFixture().withEventType("PAYOUT_PAID").toEntity();
         EventDigest eventDigest = EventDigest.fromEventList(List.of(payoutPaidOutEvent, payoutCreatedEvent));
         PayoutEntity payoutEntity = payoutEntityFactory.create(eventDigest);
 

--- a/src/test/java/uk/gov/pay/ledger/payout/model/PayoutEntityFactoryTest.java
+++ b/src/test/java/uk/gov/pay/ledger/payout/model/PayoutEntityFactoryTest.java
@@ -6,7 +6,7 @@ import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import uk.gov.pay.ledger.event.model.EventEntity;
+import uk.gov.pay.ledger.event.dao.entity.EventEntity;
 import uk.gov.pay.ledger.event.model.EventDigest;
 import uk.gov.pay.ledger.payout.entity.PayoutEntity;
 import uk.gov.pay.ledger.payout.state.PayoutState;

--- a/src/test/java/uk/gov/pay/ledger/queue/EventDigestHandlerTest.java
+++ b/src/test/java/uk/gov/pay/ledger/queue/EventDigestHandlerTest.java
@@ -12,7 +12,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.slf4j.LoggerFactory;
-import uk.gov.pay.ledger.event.model.EventEntity;
+import uk.gov.pay.ledger.event.dao.entity.EventEntity;
 import uk.gov.pay.ledger.queue.eventprocessor.AgreementEventProcessor;
 import uk.gov.pay.ledger.queue.eventprocessor.ChildTransactionEventProcessor;
 import uk.gov.pay.ledger.queue.eventprocessor.PaymentEventProcessor;

--- a/src/test/java/uk/gov/pay/ledger/queue/EventDigestHandlerTest.java
+++ b/src/test/java/uk/gov/pay/ledger/queue/EventDigestHandlerTest.java
@@ -12,7 +12,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.slf4j.LoggerFactory;
-import uk.gov.pay.ledger.event.model.Event;
+import uk.gov.pay.ledger.event.model.EventEntity;
 import uk.gov.pay.ledger.queue.eventprocessor.AgreementEventProcessor;
 import uk.gov.pay.ledger.queue.eventprocessor.ChildTransactionEventProcessor;
 import uk.gov.pay.ledger.queue.eventprocessor.PaymentEventProcessor;
@@ -59,42 +59,42 @@ class EventDigestHandlerTest {
 
     @Test
     void shouldProcessPaymentEvent() {
-        Event event = anEventFixture().withResourceType(PAYMENT).toEntity();
+        EventEntity event = anEventFixture().withResourceType(PAYMENT).toEntity();
         eventDigestHandler.processEvent(event, true);
         verify(mockPaymentEventProcessor).process(event, true);
     }
 
     @Test
     void shouldProcessRefundEvent() {
-        Event event = anEventFixture().withResourceType(REFUND).toEntity();
+        EventEntity event = anEventFixture().withResourceType(REFUND).toEntity();
         eventDigestHandler.processEvent(event, true);
         verify(mockChildTransactionEventProcessor).process(event, true);
     }
 
     @Test
     void shouldProcessDisputeEvent() {
-        Event event = anEventFixture().withResourceType(DISPUTE).toEntity();
+        EventEntity event = anEventFixture().withResourceType(DISPUTE).toEntity();
         eventDigestHandler.processEvent(event, true);
         verify(mockChildTransactionEventProcessor).process(event, true);
     }
 
     @Test
     void shouldProcessPayoutEvent() {
-        Event event = anEventFixture().withResourceType(PAYOUT).toEntity();
+        EventEntity event = anEventFixture().withResourceType(PAYOUT).toEntity();
         eventDigestHandler.processEvent(event, true);
         verify(mockPayoutEventProcessor).process(event, true);
     }
 
     @Test
     void shouldProcessAgreementEvent() {
-        Event event = anEventFixture().withResourceType(AGREEMENT).toEntity();
+        EventEntity event = anEventFixture().withResourceType(AGREEMENT).toEntity();
         eventDigestHandler.processEvent(event, true);
         verify(mockAgreementEventProcessor).process(event, true);
     }
 
     @Test
     void shouldProcessPaymentInstrumentEvent() {
-        Event event = anEventFixture().withResourceType(PAYMENT_INSTRUMENT).toEntity();
+        EventEntity event = anEventFixture().withResourceType(PAYMENT_INSTRUMENT).toEntity();
         eventDigestHandler.processEvent(event, true);
         verify(mockPaymentInstrumentEventProcessor).process(event, true);
     }
@@ -104,7 +104,7 @@ class EventDigestHandlerTest {
         Logger root = (Logger) LoggerFactory.getLogger(EventDigestHandler.class);
         root.addAppender(mockAppender);
 
-        Event event = anEventFixture().withResourceType(SERVICE).toEntity();
+        EventEntity event = anEventFixture().withResourceType(SERVICE).toEntity();
 
         assertThrows(RuntimeException.class, () -> eventDigestHandler.processEvent(event, true));
 

--- a/src/test/java/uk/gov/pay/ledger/queue/EventMessageHandlerTest.java
+++ b/src/test/java/uk/gov/pay/ledger/queue/EventMessageHandlerTest.java
@@ -18,7 +18,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.slf4j.LoggerFactory;
 import uk.gov.pay.ledger.app.LedgerConfig;
 import uk.gov.pay.ledger.app.config.SnsConfig;
-import uk.gov.pay.ledger.event.model.Event;
+import uk.gov.pay.ledger.event.model.EventEntity;
 import uk.gov.pay.ledger.event.model.ResourceType;
 import uk.gov.pay.ledger.event.model.response.CreateEventResponse;
 import uk.gov.pay.ledger.event.service.EventService;
@@ -96,7 +96,7 @@ class EventMessageHandlerTest {
 
     @Test
     void shouldMarkMessageAsProcessed_WhenEventIsProcessedSuccessfully() throws QueueException {
-        Event event = aQueuePaymentEventFixture().toEntity();
+        EventEntity event = aQueuePaymentEventFixture().toEntity();
         when(eventMessage.getEvent()).thenReturn(event);
         when(eventMessage.getQueueMessageReceiptHandle()).thenReturn(Optional.of("a-valid-recipient-handle"));
         when(eventService.createIfDoesNotExist(any())).thenReturn(createEventResponse);
@@ -116,7 +116,7 @@ class EventMessageHandlerTest {
         root.addAppender(mockAppender);
 
         String eventType = "AN_EVENT_TYPE";
-        Event event = aQueuePaymentEventFixture()
+        EventEntity event = aQueuePaymentEventFixture()
                 .withIsReprojectDomainObject(true)
                 .withEventType(eventType)
                 .toEntity();
@@ -136,7 +136,7 @@ class EventMessageHandlerTest {
 
     @Test
     void shouldScheduleMessageForRetry_WhenEventIsNotProcessedSuccessfully() throws QueueException {
-        Event event = aQueuePaymentEventFixture().toEntity();
+        EventEntity event = aQueuePaymentEventFixture().toEntity();
         when(eventMessage.getEvent()).thenReturn(event);
         when(eventMessage.getQueueMessageId()).thenReturn(Optional.of("a-valid-queue-message-id"));
         when(eventService.createIfDoesNotExist(any())).thenReturn(createEventResponse);
@@ -149,7 +149,7 @@ class EventMessageHandlerTest {
 
     @Test
     void shouldNotScheduleMessageForRetryGivenNoSQSQueueMessage_WhenEventIsNotProcessedSuccessfully() throws QueueException {
-        Event event = aQueuePaymentEventFixture().toEntity();
+        EventEntity event = aQueuePaymentEventFixture().toEntity();
         when(eventMessage.getEvent()).thenReturn(event);
         when(eventMessage.getQueueMessageId()).thenReturn(null);
         when(eventService.createIfDoesNotExist(any())).thenReturn(createEventResponse);
@@ -164,7 +164,7 @@ class EventMessageHandlerTest {
     void shouldPublishCardPaymentMessageWhenSnsEnabled() throws Exception {
         String messageBody = "{ \"foo\": \"bar\"}";
 
-        Event event = aQueuePaymentEventFixture().toEntity();
+        EventEntity event = aQueuePaymentEventFixture().toEntity();
         when(eventMessage.getEvent()).thenReturn(event);
         when(eventMessage.getRawMessageBody()).thenReturn(messageBody);
         when(ledgerConfig.getSnsConfig()).thenReturn(snsConfig);
@@ -180,7 +180,7 @@ class EventMessageHandlerTest {
     void shouldPublishDisputeMessageWhenSnsEnabled() throws Exception {;
         String messageBody = "{ \"foo\": \"bar\"}";
 
-        Event event = aQueuePaymentEventFixture().withResourceType(ResourceType.DISPUTE).toEntity();
+        EventEntity event = aQueuePaymentEventFixture().withResourceType(ResourceType.DISPUTE).toEntity();
         when(eventMessage.getEvent()).thenReturn(event);
         when(eventMessage.getRawMessageBody()).thenReturn(messageBody);
         when(ledgerConfig.getSnsConfig()).thenReturn(snsConfig);
@@ -194,7 +194,7 @@ class EventMessageHandlerTest {
 
     @Test
     void shouldNotTryToPublishMessagesWhenSnsNotEnabled() throws QueueException {
-        Event event = aQueuePaymentEventFixture().toEntity();
+        EventEntity event = aQueuePaymentEventFixture().toEntity();
         when(eventMessage.getEvent()).thenReturn(event);
         when(ledgerConfig.getSnsConfig()).thenReturn(snsConfig);
         when(snsConfig.isSnsEnabled()).thenReturn(false);
@@ -206,7 +206,7 @@ class EventMessageHandlerTest {
 
     @Test
     void shouldNotTryToPublishWhenPublishCardPaymentEventsToSnsDisabled() throws QueueException {
-        Event event = aQueuePaymentEventFixture().toEntity();
+        EventEntity event = aQueuePaymentEventFixture().toEntity();
         when(eventMessage.getEvent()).thenReturn(event);
         when(ledgerConfig.getSnsConfig()).thenReturn(snsConfig);
         when(snsConfig.isSnsEnabled()).thenReturn(true);
@@ -219,7 +219,7 @@ class EventMessageHandlerTest {
 
     @Test
     void shouldNotTryToPublishWhenPublishCardPaymentDisputeEventsToSnsDisabled() throws QueueException {
-        Event event = aQueuePaymentEventFixture().withResourceType(ResourceType.DISPUTE).toEntity();
+        EventEntity event = aQueuePaymentEventFixture().withResourceType(ResourceType.DISPUTE).toEntity();
         when(eventMessage.getEvent()).thenReturn(event);
         when(ledgerConfig.getSnsConfig()).thenReturn(snsConfig);
         when(snsConfig.isSnsEnabled()).thenReturn(true);

--- a/src/test/java/uk/gov/pay/ledger/queue/EventMessageHandlerTest.java
+++ b/src/test/java/uk/gov/pay/ledger/queue/EventMessageHandlerTest.java
@@ -18,7 +18,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.slf4j.LoggerFactory;
 import uk.gov.pay.ledger.app.LedgerConfig;
 import uk.gov.pay.ledger.app.config.SnsConfig;
-import uk.gov.pay.ledger.event.model.EventEntity;
+import uk.gov.pay.ledger.event.dao.entity.EventEntity;
 import uk.gov.pay.ledger.event.model.ResourceType;
 import uk.gov.pay.ledger.event.model.response.CreateEventResponse;
 import uk.gov.pay.ledger.event.service.EventService;

--- a/src/test/java/uk/gov/pay/ledger/queue/eventprocessor/AgreementEventProcessorTest.java
+++ b/src/test/java/uk/gov/pay/ledger/queue/eventprocessor/AgreementEventProcessorTest.java
@@ -6,7 +6,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.pay.ledger.agreement.service.AgreementService;
-import uk.gov.pay.ledger.event.model.Event;
+import uk.gov.pay.ledger.event.model.EventEntity;
 import uk.gov.pay.ledger.event.model.EventDigest;
 import uk.gov.pay.ledger.event.service.EventService;
 
@@ -31,7 +31,7 @@ class AgreementEventProcessorTest {
 
     @Test
     void shouldUpsertAgreement() {
-        Event event = anEventFixture().withResourceType(AGREEMENT).toEntity();
+        EventEntity event = anEventFixture().withResourceType(AGREEMENT).toEntity();
         var eventDigest = EventDigest.fromEventList(List.of(anEventFixture().toEntity()));
         when(mockEventService.getEventDigestForResource(event)).thenReturn(eventDigest);
 

--- a/src/test/java/uk/gov/pay/ledger/queue/eventprocessor/AgreementEventProcessorTest.java
+++ b/src/test/java/uk/gov/pay/ledger/queue/eventprocessor/AgreementEventProcessorTest.java
@@ -6,7 +6,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.pay.ledger.agreement.service.AgreementService;
-import uk.gov.pay.ledger.event.model.EventEntity;
+import uk.gov.pay.ledger.event.dao.entity.EventEntity;
 import uk.gov.pay.ledger.event.model.EventDigest;
 import uk.gov.pay.ledger.event.service.EventService;
 

--- a/src/test/java/uk/gov/pay/ledger/queue/eventprocessor/ChildTransactionEventProcessorTest.java
+++ b/src/test/java/uk/gov/pay/ledger/queue/eventprocessor/ChildTransactionEventProcessorTest.java
@@ -12,7 +12,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import uk.gov.pay.ledger.event.model.EventEntity;
+import uk.gov.pay.ledger.event.dao.entity.EventEntity;
 import uk.gov.pay.ledger.event.model.EventDigest;
 import uk.gov.pay.ledger.event.model.ResourceType;
 import uk.gov.pay.ledger.event.model.TransactionEntityFactory;

--- a/src/test/java/uk/gov/pay/ledger/queue/eventprocessor/ChildTransactionEventProcessorTest.java
+++ b/src/test/java/uk/gov/pay/ledger/queue/eventprocessor/ChildTransactionEventProcessorTest.java
@@ -12,7 +12,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import uk.gov.pay.ledger.event.model.Event;
+import uk.gov.pay.ledger.event.model.EventEntity;
 import uk.gov.pay.ledger.event.model.EventDigest;
 import uk.gov.pay.ledger.event.model.ResourceType;
 import uk.gov.pay.ledger.event.model.TransactionEntityFactory;
@@ -60,7 +60,7 @@ class ChildTransactionEventProcessorTest {
         String refundExternalId = "refund-external-id";
         String paymentExternalId = "payment-external-id";
 
-        Event refundEvent = anEventFixture()
+        EventEntity refundEvent = anEventFixture()
                 .withResourceType(REFUND)
                 .withEventType("REFUND_SUCCEEDED")
                 .withEventDate(ZonedDateTime.parse("2022-07-01T10:00:00Z"))
@@ -73,19 +73,19 @@ class ChildTransactionEventProcessorTest {
                                 .build()))
                 .toEntity();
 
-        Event paymentEvent1 = aQueuePaymentEventFixture()
+        EventEntity paymentEvent1 = aQueuePaymentEventFixture()
                 .withResourceExternalId(paymentExternalId)
                 .withEventType("PAYMENT_CREATED")
                 .withEventDate(ZonedDateTime.parse("2022-06-01T10:00:00Z"))
                 .withDefaultEventDataForEventType("PAYMENT_CREATED")
                 .toEntity();
-        Event paymentEvent2 = aQueuePaymentEventFixture()
+        EventEntity paymentEvent2 = aQueuePaymentEventFixture()
                 .withResourceExternalId(paymentExternalId)
                 .withEventType("PAYMENT_DETAILS_ENTERED")
                 .withEventDate(ZonedDateTime.parse("2022-06-01T10:01:00Z"))
                 .withDefaultEventDataForEventType("PAYMENT_DETAILS_ENTERED")
                 .toEntity();
-        Event paymentEvent3 = aQueuePaymentEventFixture()
+        EventEntity paymentEvent3 = aQueuePaymentEventFixture()
                 .withResourceExternalId(paymentExternalId)
                 .withEventType("FEE_INCURRED")
                 .withEventDate(ZonedDateTime.parse("2022-06-01T10:02:00Z"))
@@ -132,7 +132,7 @@ class ChildTransactionEventProcessorTest {
         String refundExternalId = "refund-external-id";
         String paymentExternalId = "payment-external-id";
 
-        Event refundEvent = anEventFixture()
+        EventEntity refundEvent = anEventFixture()
                 .withResourceType(REFUND)
                 .withEventType("REFUND_SUCCEEDED")
                 .withResourceExternalId(refundExternalId)
@@ -157,7 +157,7 @@ class ChildTransactionEventProcessorTest {
                         .put("reference", "payment-ref")
                         .put("card_type", "visa")
                         .build());
-        Event paymentEvent = anEventFixture().withEventData(paymentEventData).toEntity();
+        EventEntity paymentEvent = anEventFixture().withEventData(paymentEventData).toEntity();
         EventDigest paymentEventDigest = EventDigest.fromEventList(List.of(paymentEvent));
 
         String refundEventData = new GsonBuilder().create()
@@ -165,7 +165,7 @@ class ChildTransactionEventProcessorTest {
                         .put("amount", -50)
                         .put("some_refund_info", "blah")
                         .build());
-        Event refundEvent = anEventFixture().withEventData(refundEventData).toEntity();
+        EventEntity refundEvent = anEventFixture().withEventData(refundEventData).toEntity();
         EventDigest refundEventDigest = EventDigest.fromEventList(List.of(refundEvent));
 
         String refundExternalId = "refund-external-id";
@@ -188,7 +188,7 @@ class ChildTransactionEventProcessorTest {
 
     @Test
     void shouldProjectDisputeTransaction() {
-        Event disputeEvent = anEventFixture().withResourceType(ResourceType.DISPUTE).withLive(true).toEntity();
+        EventEntity disputeEvent = anEventFixture().withResourceType(ResourceType.DISPUTE).withLive(true).toEntity();
         EventDigest eventDigest = EventDigest.fromEventList(List.of(disputeEvent));
         when(mockEventService.getEventDigestForResource(disputeEvent)).thenReturn(eventDigest);
         childTransactionEventProcessor.process(disputeEvent, true);

--- a/src/test/java/uk/gov/pay/ledger/queue/eventprocessor/PaymentEventProcessorTest.java
+++ b/src/test/java/uk/gov/pay/ledger/queue/eventprocessor/PaymentEventProcessorTest.java
@@ -5,7 +5,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import uk.gov.pay.ledger.event.model.EventEntity;
+import uk.gov.pay.ledger.event.dao.entity.EventEntity;
 import uk.gov.pay.ledger.event.model.EventDigest;
 import uk.gov.pay.ledger.event.service.EventService;
 import uk.gov.pay.ledger.transaction.entity.TransactionEntity;

--- a/src/test/java/uk/gov/pay/ledger/queue/eventprocessor/PaymentEventProcessorTest.java
+++ b/src/test/java/uk/gov/pay/ledger/queue/eventprocessor/PaymentEventProcessorTest.java
@@ -5,7 +5,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import uk.gov.pay.ledger.event.model.Event;
+import uk.gov.pay.ledger.event.model.EventEntity;
 import uk.gov.pay.ledger.event.model.EventDigest;
 import uk.gov.pay.ledger.event.service.EventService;
 import uk.gov.pay.ledger.transaction.entity.TransactionEntity;
@@ -50,13 +50,13 @@ class PaymentEventProcessorTest {
     @Test
     void shouldReprojectRefundTransactionsWhenPaymentHasRefunds() {
         String paymentExternalId = "payment-external-id";
-        Event event = anEventFixture().withResourceType(PAYMENT)
+        EventEntity event = anEventFixture().withResourceType(PAYMENT)
                 .withResourceExternalId(paymentExternalId)
                 .withEventType("ADMIN_MANUALLY_DID_AN_UPDATE")
                 .withEventData("{\"reference\": \"payment-ref\"}")
                 .toEntity();
 
-        Event previousEvent = anEventFixture().withResourceType(PAYMENT)
+        EventEntity previousEvent = anEventFixture().withResourceType(PAYMENT)
                 .withEventType("USER_APPROVED_FOR_CAPTURE")
                 .toEntity();
 
@@ -77,13 +77,13 @@ class PaymentEventProcessorTest {
     @Test
     void shouldNotQueryForRefundsIfPaymentHasntBeenInSuccessState() {
         String paymentExternalId = "payment-external-id";
-        Event event = anEventFixture().withResourceType(PAYMENT)
+        EventEntity event = anEventFixture().withResourceType(PAYMENT)
                 .withResourceExternalId(paymentExternalId)
                 .withEventType("ADMIN_MANUALLY_DID_AN_UPDATE")
                 .withEventData("{\"reference\": \"payment-ref\"}")
                 .toEntity();
 
-        Event previousEvent = anEventFixture().withResourceType(PAYMENT)
+        EventEntity previousEvent = anEventFixture().withResourceType(PAYMENT)
                 .withEventType("PAYMENT_STARTED")
                 .toEntity();
 
@@ -99,13 +99,13 @@ class PaymentEventProcessorTest {
     @Test
     void shouldNotQueryForRefundsIfNoEventData() {
         String paymentExternalId = "payment-external-id";
-        Event event = anEventFixture().withResourceType(PAYMENT)
+        EventEntity event = anEventFixture().withResourceType(PAYMENT)
                 .withResourceExternalId(paymentExternalId)
                 .withEventType("ADMIN_MANUALLY_DID_AN_UPDATE")
                 .withEventData("{}")
                 .toEntity();
 
-        Event previousEvent = anEventFixture().withResourceType(PAYMENT)
+        EventEntity previousEvent = anEventFixture().withResourceType(PAYMENT)
                 .withEventType("USER_APPROVED_FOR_CAPTURE")
                 .toEntity();
 
@@ -121,12 +121,12 @@ class PaymentEventProcessorTest {
     @Test
     void shouldProjectTransactionSummary() {
         String paymentExternalId = "payment-external-id";
-        Event event = anEventFixture().withResourceType(PAYMENT)
+        EventEntity event = anEventFixture().withResourceType(PAYMENT)
                 .withResourceExternalId(paymentExternalId)
                 .withEventType("PAYMENT_CREATED")
                 .toEntity();
 
-        List<Event> events = List.of(event);
+        List<EventEntity> events = List.of(event);
         TransactionEntity transactionEntity = aTransactionFixture().toEntity();
 
         when(eventService.getEventsForResource(event.getResourceExternalId())).thenReturn(events);
@@ -139,7 +139,7 @@ class PaymentEventProcessorTest {
     @Test
     void shouldNotProjectTransactionSummaryForAReprojectionEvent() {
         String refundExternalId = "refund-external-id";
-        Event event = anEventFixture().withResourceType(PAYMENT)
+        EventEntity event = anEventFixture().withResourceType(PAYMENT)
                 .withResourceExternalId(refundExternalId)
                 .withEventType("PAYMENT_CREATED")
                 .withIsReprojectDomainObject(true)
@@ -154,7 +154,7 @@ class PaymentEventProcessorTest {
     @Test
     void shouldNotProjectTransactionSummaryForAnExistingEvent() {
         String refundExternalId = "refund-external-id";
-        Event event = anEventFixture().withResourceType(PAYMENT)
+        EventEntity event = anEventFixture().withResourceType(PAYMENT)
                 .withResourceExternalId(refundExternalId)
                 .withEventType("PAYMENT_CREATED")
                 .withIsReprojectDomainObject(false)
@@ -168,7 +168,7 @@ class PaymentEventProcessorTest {
 
     @Test
     void shouldReprojectTransactionMetadataIfReprojectEvent() {
-        Event event = anEventFixture()
+        EventEntity event = anEventFixture()
                 .withResourceType(PAYMENT)
                 .withIsReprojectDomainObject(true)
                 .toEntity();

--- a/src/test/java/uk/gov/pay/ledger/queue/eventprocessor/PaymentInstrumentEventProcessorTest.java
+++ b/src/test/java/uk/gov/pay/ledger/queue/eventprocessor/PaymentInstrumentEventProcessorTest.java
@@ -6,7 +6,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.pay.ledger.agreement.service.AgreementService;
-import uk.gov.pay.ledger.event.model.Event;
+import uk.gov.pay.ledger.event.model.EventEntity;
 import uk.gov.pay.ledger.event.model.EventDigest;
 import uk.gov.pay.ledger.event.service.EventService;
 
@@ -30,7 +30,7 @@ class PaymentInstrumentEventProcessorTest {
 
     @Test
     void shouldUpsertPaymentInstrument() {
-        Event event = anEventFixture().withResourceType(PAYMENT_INSTRUMENT).toEntity();
+        EventEntity event = anEventFixture().withResourceType(PAYMENT_INSTRUMENT).toEntity();
         var eventDigest = EventDigest.fromEventList(List.of(anEventFixture().toEntity()));
         when(mockEventService.getEventDigestForResource(event)).thenReturn(eventDigest);
 

--- a/src/test/java/uk/gov/pay/ledger/queue/eventprocessor/PaymentInstrumentEventProcessorTest.java
+++ b/src/test/java/uk/gov/pay/ledger/queue/eventprocessor/PaymentInstrumentEventProcessorTest.java
@@ -6,7 +6,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.pay.ledger.agreement.service.AgreementService;
-import uk.gov.pay.ledger.event.model.EventEntity;
+import uk.gov.pay.ledger.event.dao.entity.EventEntity;
 import uk.gov.pay.ledger.event.model.EventDigest;
 import uk.gov.pay.ledger.event.service.EventService;
 

--- a/src/test/java/uk/gov/pay/ledger/queue/eventprocessor/PayoutEventProcessorTest.java
+++ b/src/test/java/uk/gov/pay/ledger/queue/eventprocessor/PayoutEventProcessorTest.java
@@ -5,7 +5,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import uk.gov.pay.ledger.event.model.Event;
+import uk.gov.pay.ledger.event.model.EventEntity;
 import uk.gov.pay.ledger.event.model.EventDigest;
 import uk.gov.pay.ledger.event.service.EventService;
 import uk.gov.pay.ledger.payout.service.PayoutService;
@@ -31,7 +31,7 @@ class PayoutEventProcessorTest {
 
     @Test
     void shouldUpsertPayout() {
-        Event event = anEventFixture().withResourceType(PAYOUT).toEntity();
+        EventEntity event = anEventFixture().withResourceType(PAYOUT).toEntity();
         var eventDigest = EventDigest.fromEventList(List.of(anEventFixture().toEntity()));
         when(mockEventService.getEventDigestForResource(event)).thenReturn(eventDigest);
 

--- a/src/test/java/uk/gov/pay/ledger/queue/eventprocessor/PayoutEventProcessorTest.java
+++ b/src/test/java/uk/gov/pay/ledger/queue/eventprocessor/PayoutEventProcessorTest.java
@@ -5,7 +5,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import uk.gov.pay.ledger.event.model.EventEntity;
+import uk.gov.pay.ledger.event.dao.entity.EventEntity;
 import uk.gov.pay.ledger.event.model.EventDigest;
 import uk.gov.pay.ledger.event.service.EventService;
 import uk.gov.pay.ledger.payout.service.PayoutService;

--- a/src/test/java/uk/gov/pay/ledger/queue/sqs/EventQueueIT.java
+++ b/src/test/java/uk/gov/pay/ledger/queue/sqs/EventQueueIT.java
@@ -9,7 +9,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import uk.gov.pay.ledger.app.LedgerConfig;
 import uk.gov.pay.ledger.app.config.QueueMessageReceiverConfig;
 import uk.gov.pay.ledger.app.config.SqsConfig;
-import uk.gov.pay.ledger.event.model.EventEntity;
+import uk.gov.pay.ledger.event.dao.entity.EventEntity;
 import uk.gov.pay.ledger.extension.AppWithPostgresAndSqsExtension;
 import uk.gov.pay.ledger.queue.EventMessage;
 import uk.gov.pay.ledger.queue.EventQueue;

--- a/src/test/java/uk/gov/pay/ledger/queue/sqs/EventQueueIT.java
+++ b/src/test/java/uk/gov/pay/ledger/queue/sqs/EventQueueIT.java
@@ -9,7 +9,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import uk.gov.pay.ledger.app.LedgerConfig;
 import uk.gov.pay.ledger.app.config.QueueMessageReceiverConfig;
 import uk.gov.pay.ledger.app.config.SqsConfig;
-import uk.gov.pay.ledger.event.model.Event;
+import uk.gov.pay.ledger.event.model.EventEntity;
 import uk.gov.pay.ledger.extension.AppWithPostgresAndSqsExtension;
 import uk.gov.pay.ledger.queue.EventMessage;
 import uk.gov.pay.ledger.queue.EventQueue;
@@ -49,7 +49,7 @@ public class EventQueueIT {
 
     @Test
     public void shouldGetEventMessageFromTheQueue() throws QueueException {
-        Event event = aQueuePaymentEventFixture()
+        EventEntity event = aQueuePaymentEventFixture()
                 .insert(client)
                 .toEntity();
 

--- a/src/test/java/uk/gov/pay/ledger/transaction/resource/TransactionResourceIT.java
+++ b/src/test/java/uk/gov/pay/ledger/transaction/resource/TransactionResourceIT.java
@@ -6,7 +6,7 @@ import org.hamcrest.Matchers;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
-import uk.gov.pay.ledger.event.model.Event;
+import uk.gov.pay.ledger.event.model.EventEntity;
 import uk.gov.pay.ledger.extension.AppWithPostgresAndSqsExtension;
 import uk.gov.pay.ledger.transaction.entity.TransactionEntity;
 import uk.gov.pay.ledger.transaction.state.TransactionState;
@@ -284,7 +284,7 @@ public class TransactionResourceIT {
                 .withDefaultTransactionDetails();
         transactionFixture.insert(rule.getJdbi());
 
-        Event event = EventFixture.anEventFixture()
+        EventEntity event = EventFixture.anEventFixture()
                 .withResourceExternalId(transactionFixture.getExternalId())
                 .withEventDate(ZonedDateTime.parse("2019-07-31T09:52:43.451Z"))
                 .insert(rule.getJdbi())

--- a/src/test/java/uk/gov/pay/ledger/transaction/resource/TransactionResourceIT.java
+++ b/src/test/java/uk/gov/pay/ledger/transaction/resource/TransactionResourceIT.java
@@ -6,7 +6,7 @@ import org.hamcrest.Matchers;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
-import uk.gov.pay.ledger.event.model.EventEntity;
+import uk.gov.pay.ledger.event.dao.entity.EventEntity;
 import uk.gov.pay.ledger.extension.AppWithPostgresAndSqsExtension;
 import uk.gov.pay.ledger.transaction.entity.TransactionEntity;
 import uk.gov.pay.ledger.transaction.state.TransactionState;

--- a/src/test/java/uk/gov/pay/ledger/transaction/service/TransactionMetadataServiceTest.java
+++ b/src/test/java/uk/gov/pay/ledger/transaction/service/TransactionMetadataServiceTest.java
@@ -6,7 +6,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.pay.ledger.gatewayaccountmetadata.service.GatewayAccountMetadataService;
 import uk.gov.service.payments.commons.model.Source;
-import uk.gov.pay.ledger.event.model.Event;
+import uk.gov.pay.ledger.event.model.EventEntity;
 import uk.gov.pay.ledger.event.model.EventDigest;
 import uk.gov.pay.ledger.event.model.SalientEventType;
 import uk.gov.pay.ledger.metadatakey.dao.MetadataKeyDao;
@@ -49,7 +49,7 @@ class TransactionMetadataServiceTest {
 
         when(mockTransactionDao.findTransactionByExternalId(externalId)).thenReturn(Optional.of(transaction));
 
-        Event paymentCreatedEvent = aQueuePaymentEventFixture()
+        EventEntity paymentCreatedEvent = aQueuePaymentEventFixture()
                 .withResourceExternalId(externalId)
                 .withEventType(SalientEventType.PAYMENT_CREATED.name())
                 .withResourceType(PAYMENT)
@@ -79,7 +79,7 @@ class TransactionMetadataServiceTest {
         TransactionEntity transaction = aTransactionFixture().withState(TransactionState.STARTED).toEntity();
         service = new TransactionMetadataService(mockMetadataKeyDao, mockTransactionMetadataDao, mockTransactionDao, mockGatewayAccountMetadataService);
 
-        Event paymentCreatedEvent = aQueuePaymentEventFixture()
+        EventEntity paymentCreatedEvent = aQueuePaymentEventFixture()
                 .withResourceExternalId(externalId)
                 .withEventType(SalientEventType.CAPTURE_SUBMITTED.name())
                 .withResourceType(PAYMENT)
@@ -100,12 +100,12 @@ class TransactionMetadataServiceTest {
         TransactionEntity transaction = aTransactionFixture().withState(TransactionState.STARTED).toEntity();
         service = new TransactionMetadataService(mockMetadataKeyDao, mockTransactionMetadataDao, mockTransactionDao, mockGatewayAccountMetadataService);
 
-        Event event = aQueuePaymentEventFixture()
+        EventEntity event = aQueuePaymentEventFixture()
                 .withResourceExternalId(externalId)
                 .withEventType("ADMIN_TRIGGERED_REPROJECTION")
                 .toEntity();
 
-        Event previousEvent = aQueuePaymentEventFixture().withResourceType(PAYMENT)
+        EventEntity previousEvent = aQueuePaymentEventFixture().withResourceType(PAYMENT)
                 .withEventType(SalientEventType.PAYMENT_CREATED.name())
                 .withResourceType(PAYMENT)
                 .withSource(Source.CARD_API)
@@ -135,7 +135,7 @@ class TransactionMetadataServiceTest {
         TransactionEntity transaction = aTransactionFixture().withState(TransactionState.STARTED).toEntity();
         service = new TransactionMetadataService(mockMetadataKeyDao, mockTransactionMetadataDao, mockTransactionDao, mockGatewayAccountMetadataService);
 
-        Event event = aQueuePaymentEventFixture()
+        EventEntity event = aQueuePaymentEventFixture()
                 .withResourceExternalId(externalId)
                 .toEntity();
 

--- a/src/test/java/uk/gov/pay/ledger/transaction/service/TransactionMetadataServiceTest.java
+++ b/src/test/java/uk/gov/pay/ledger/transaction/service/TransactionMetadataServiceTest.java
@@ -6,7 +6,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.pay.ledger.gatewayaccountmetadata.service.GatewayAccountMetadataService;
 import uk.gov.service.payments.commons.model.Source;
-import uk.gov.pay.ledger.event.model.EventEntity;
+import uk.gov.pay.ledger.event.dao.entity.EventEntity;
 import uk.gov.pay.ledger.event.model.EventDigest;
 import uk.gov.pay.ledger.event.model.SalientEventType;
 import uk.gov.pay.ledger.metadatakey.dao.MetadataKeyDao;

--- a/src/test/java/uk/gov/pay/ledger/transaction/service/TransactionServiceTest.java
+++ b/src/test/java/uk/gov/pay/ledger/transaction/service/TransactionServiceTest.java
@@ -10,7 +10,7 @@ import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.pay.ledger.event.dao.EventDao;
-import uk.gov.pay.ledger.event.model.Event;
+import uk.gov.pay.ledger.event.model.EventEntity;
 import uk.gov.pay.ledger.event.model.ResourceType;
 import uk.gov.pay.ledger.event.model.SalientEventType;
 import uk.gov.pay.ledger.event.model.TransactionEntityFactory;
@@ -222,9 +222,9 @@ public class TransactionServiceTest {
         when(mockTransactionDao.findTransactionByExternalOrParentIdAndGatewayAccountId(anyString(), anyString()))
                 .thenReturn(transactionEntityList);
 
-        Event event = EventFixture.anEventFixture().withEventType(SalientEventType.AUTHORISATION_CANCELLED.toString())
+        EventEntity event = EventFixture.anEventFixture().withEventType(SalientEventType.AUTHORISATION_CANCELLED.toString())
                 .withResourceExternalId(transactionEntityList.get(0).getExternalId()).toEntity();
-        List<Event> eventList = List.of(event);
+        List<EventEntity> eventList = List.of(event);
         when(mockEventDao.findEventsForExternalIds(any())).thenReturn(eventList);
 
         TransactionEventResponse transactionEventResponse
@@ -243,9 +243,9 @@ public class TransactionServiceTest {
         when(mockTransactionDao.findTransactionByExternalOrParentIdAndGatewayAccountId(anyString(), anyString()))
                 .thenReturn(transactionEntityList);
 
-        Event event = EventFixture.anEventFixture().withEventType(SalientEventType.AUTHORISATION_CANCELLED.toString())
+        EventEntity event = EventFixture.anEventFixture().withEventType(SalientEventType.AUTHORISATION_CANCELLED.toString())
                 .withResourceExternalId(transactionEntityList.get(0).getExternalId()).toEntity();
-        List<Event> eventList = List.of(event);
+        List<EventEntity> eventList = List.of(event);
         when(mockEventDao.findEventsForExternalIds(any())).thenReturn(eventList);
 
         TransactionEventResponse transactionEventResponse
@@ -264,11 +264,11 @@ public class TransactionServiceTest {
         when(mockTransactionDao.findTransactionByExternalOrParentIdAndGatewayAccountId(anyString(), anyString()))
                 .thenReturn(transactionEntityList);
 
-        Event event = EventFixture.anEventFixture().withResourceExternalId(transactionEntityList.get(0).getExternalId()).toEntity();
-        Event eventWithoutStateMapping = EventFixture.anEventFixture()
+        EventEntity event = EventFixture.anEventFixture().withResourceExternalId(transactionEntityList.get(0).getExternalId()).toEntity();
+        EventEntity eventWithoutStateMapping = EventFixture.anEventFixture()
                 .withEventType("EVENT_WITHOUT_ANY_STATE_MAPPING")
                 .withResourceExternalId(transactionEntityList.get(1).getExternalId()).toEntity();
-        List<Event> eventList = List.of(event, eventWithoutStateMapping);
+        List<EventEntity> eventList = List.of(event, eventWithoutStateMapping);
 
         when(mockEventDao.findEventsForExternalIds(any())).thenReturn(eventList);
 
@@ -300,21 +300,21 @@ public class TransactionServiceTest {
         when(mockTransactionDao.findTransactionByExternalOrParentIdAndGatewayAccountId(anyString(), anyString()))
                 .thenReturn(transactionEntityList);
 
-        Event event1ForStateSubmitted = EventFixture.anEventFixture()
+        EventEntity event1ForStateSubmitted = EventFixture.anEventFixture()
                 .withEventType("PAYMENT_STARTED")
                 .withEventDate(ZonedDateTime.now())
                 .withResourceExternalId(transactionEntityList.get(0).getExternalId()).toEntity();
-        Event event2ForStateSubmitted = EventFixture.anEventFixture()
+        EventEntity event2ForStateSubmitted = EventFixture.anEventFixture()
                 .withEventType("GATEWAY_REQUIRES_3DS_AUTHORISATION")
                 .withEventDate(ZonedDateTime.now().plusDays(1))
                 .withResourceExternalId(transactionEntityList.get(0).getExternalId()).toEntity();
-        Event event1ForStateError = EventFixture.anEventFixture()
+        EventEntity event1ForStateError = EventFixture.anEventFixture()
                 .withEventType("REFUND_SUBMITTED")
                 .withResourceType(ResourceType.REFUND)
                 .withEventDate(ZonedDateTime.now().plusDays(2))
                 .withResourceExternalId(transactionEntityList.get(0).getExternalId()).toEntity();
 
-        List<Event> eventList = List.of(event1ForStateSubmitted, event2ForStateSubmitted, event1ForStateError);
+        List<EventEntity> eventList = List.of(event1ForStateSubmitted, event2ForStateSubmitted, event1ForStateError);
         when(mockEventDao.findEventsForExternalIds(any())).thenReturn(eventList);
 
         TransactionEventResponse transactionEventResponse
@@ -335,20 +335,20 @@ public class TransactionServiceTest {
         when(mockTransactionDao.findTransactionByExternalOrParentIdAndGatewayAccountId(anyString(), anyString()))
                 .thenReturn(transactionEntityList);
 
-        Event event1ForStateSubmitted = EventFixture.anEventFixture()
+        EventEntity event1ForStateSubmitted = EventFixture.anEventFixture()
                 .withEventType("AUTHORISATION_SUCCEEDED")
                 .withEventDate(ZonedDateTime.now())
                 .withResourceExternalId(transactionEntityList.get(0).getExternalId()).toEntity();
-        Event event2ForStateSubmitted = EventFixture.anEventFixture()
+        EventEntity event2ForStateSubmitted = EventFixture.anEventFixture()
                 .withEventType("USER_APPROVED_FOR_CAPTURE_AWAITING_SERVICE_APPROVAL")
                 .withEventDate(ZonedDateTime.now().plusDays(1))
                 .withResourceExternalId(transactionEntityList.get(0).getExternalId()).toEntity();
-        Event eventForUnknownType = EventFixture.anEventFixture()
+        EventEntity eventForUnknownType = EventFixture.anEventFixture()
                 .withEventType("UNKNOWN_EVENT")
                 .withEventDate(ZonedDateTime.now().plusDays(1))
                 .withResourceExternalId(transactionEntityList.get(0).getExternalId()).toEntity();
 
-        List<Event> eventList = List.of(event1ForStateSubmitted, event2ForStateSubmitted, eventForUnknownType);
+        List<EventEntity> eventList = List.of(event1ForStateSubmitted, event2ForStateSubmitted, eventForUnknownType);
         when(mockEventDao.findEventsForExternalIds(any())).thenReturn(eventList);
 
         TransactionEventResponse transactionEventResponse
@@ -388,7 +388,7 @@ public class TransactionServiceTest {
         assertThat(mayBeTransactionView.get().getPaymentProvider(), is("sandbox"));
     }
 
-    private void assertTransactionEvent(Event event, TransactionEvent transactionEvent, Long amount, String state) {
+    private void assertTransactionEvent(EventEntity event, TransactionEvent transactionEvent, Long amount, String state) {
         try {
             assertThat(transactionEvent.getState() == null ? null : transactionEvent.getState().getStatus(), is(state));
             assertThat(transactionEvent.getAmount(), is(amount));

--- a/src/test/java/uk/gov/pay/ledger/transaction/service/TransactionServiceTest.java
+++ b/src/test/java/uk/gov/pay/ledger/transaction/service/TransactionServiceTest.java
@@ -10,7 +10,7 @@ import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.pay.ledger.event.dao.EventDao;
-import uk.gov.pay.ledger.event.model.EventEntity;
+import uk.gov.pay.ledger.event.dao.entity.EventEntity;
 import uk.gov.pay.ledger.event.model.ResourceType;
 import uk.gov.pay.ledger.event.model.SalientEventType;
 import uk.gov.pay.ledger.event.model.TransactionEntityFactory;

--- a/src/test/java/uk/gov/pay/ledger/transactionsummary/service/TransactionSummaryServiceTest.java
+++ b/src/test/java/uk/gov/pay/ledger/transactionsummary/service/TransactionSummaryServiceTest.java
@@ -5,7 +5,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import uk.gov.pay.ledger.event.model.EventEntity;
+import uk.gov.pay.ledger.event.dao.entity.EventEntity;
 import uk.gov.pay.ledger.transaction.entity.TransactionEntity;
 import uk.gov.pay.ledger.transactionsummary.dao.TransactionSummaryDao;
 import uk.gov.pay.ledger.util.fixture.EventFixture;

--- a/src/test/java/uk/gov/pay/ledger/transactionsummary/service/TransactionSummaryServiceTest.java
+++ b/src/test/java/uk/gov/pay/ledger/transactionsummary/service/TransactionSummaryServiceTest.java
@@ -5,7 +5,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import uk.gov.pay.ledger.event.model.Event;
+import uk.gov.pay.ledger.event.model.EventEntity;
 import uk.gov.pay.ledger.transaction.entity.TransactionEntity;
 import uk.gov.pay.ledger.transactionsummary.dao.TransactionSummaryDao;
 import uk.gov.pay.ledger.util.fixture.EventFixture;
@@ -25,7 +25,6 @@ import static uk.gov.pay.ledger.event.model.SalientEventType.CAPTURE_SUBMITTED;
 import static uk.gov.pay.ledger.event.model.SalientEventType.PAYMENT_CREATED;
 import static uk.gov.pay.ledger.event.model.SalientEventType.PAYMENT_STATUS_CORRECTED_TO_SUCCESS_BY_ADMIN;
 import static uk.gov.pay.ledger.event.model.SalientEventType.REFUND_SUBMITTED;
-import static uk.gov.pay.ledger.event.model.SalientEventType.SERVICE_APPROVED_FOR_CAPTURE;
 import static uk.gov.pay.ledger.event.model.SalientEventType.USER_APPROVED_FOR_CAPTURE;
 import static uk.gov.pay.ledger.transaction.state.TransactionState.CREATED;
 import static uk.gov.pay.ledger.transaction.state.TransactionState.SUBMITTED;
@@ -49,16 +48,16 @@ public class TransactionSummaryServiceTest {
         TransactionEntity transactionEntity = aTransactionFixture()
                 .withState(SUCCESS)
                 .toEntity();
-        Event paymentCreatedEvent = EventFixture.anEventFixture()
+        EventEntity paymentCreatedEvent = EventFixture.anEventFixture()
                 .withEventDate(ZonedDateTime.now())
                 .withEventType(PAYMENT_CREATED.name()).toEntity();
-        Event nonSalientEvent = EventFixture.anEventFixture()
+        EventEntity nonSalientEvent = EventFixture.anEventFixture()
                 .withEventDate(ZonedDateTime.now())
                 .withEventType("BACKFILLER_RECREATED_USER_EMAIL_COLLECTED").toEntity();
-        Event userApprovedForCaptureEvent = EventFixture.anEventFixture()
+        EventEntity userApprovedForCaptureEvent = EventFixture.anEventFixture()
                 .withEventDate(ZonedDateTime.now().plusSeconds(11))
                 .withEventType(CAPTURE_SUBMITTED.name()).toEntity();
-        List<Event> events = List.of(paymentCreatedEvent, nonSalientEvent, userApprovedForCaptureEvent);
+        List<EventEntity> events = List.of(paymentCreatedEvent, nonSalientEvent, userApprovedForCaptureEvent);
 
         transactionSummaryService.projectTransactionSummary(transactionEntity, paymentCreatedEvent, events);
 
@@ -74,14 +73,14 @@ public class TransactionSummaryServiceTest {
         TransactionEntity transactionEntity = aTransactionFixture()
                 .withState(SUCCESS)
                 .toEntity();
-        Event paymentCreatedEvent = EventFixture.anEventFixture()
+        EventEntity paymentCreatedEvent = EventFixture.anEventFixture()
                 .withEventDate(ZonedDateTime.now())
                 .withEventType("PAYMENT_NOTIFICATION_CREATED").toEntity();
-        Event userApprovedForCaptureEvent = EventFixture.anEventFixture()
+        EventEntity userApprovedForCaptureEvent = EventFixture.anEventFixture()
                 .withEventDate(ZonedDateTime.now())
                 .withEventType(CAPTURE_SUBMITTED.name()).toEntity();
 
-        List<Event> events = List.of(paymentCreatedEvent, userApprovedForCaptureEvent);
+        List<EventEntity> events = List.of(paymentCreatedEvent, userApprovedForCaptureEvent);
 
         transactionSummaryService.projectTransactionSummary(transactionEntity, userApprovedForCaptureEvent, events);
 
@@ -97,14 +96,14 @@ public class TransactionSummaryServiceTest {
         TransactionEntity transactionEntity = aTransactionFixture()
                 .withState(SUCCESS)
                 .toEntity();
-        Event event = EventFixture.anEventFixture().withEventDate(ZonedDateTime.now())
+        EventEntity event = EventFixture.anEventFixture().withEventDate(ZonedDateTime.now())
                 .withEventType(PAYMENT_CREATED.name()).toEntity();
-        Event event2 = EventFixture.anEventFixture().withEventDate(ZonedDateTime.now().plusSeconds(1))
+        EventEntity event2 = EventFixture.anEventFixture().withEventDate(ZonedDateTime.now().plusSeconds(1))
                 .withEventType(CAPTURE_SUBMITTED.name()).toEntity();
-        Event event3 = EventFixture.anEventFixture().withEventDate(ZonedDateTime.now().plusSeconds(2))
+        EventEntity event3 = EventFixture.anEventFixture().withEventDate(ZonedDateTime.now().plusSeconds(2))
                 .withEventType(CAPTURE_ERRORED.name()).toEntity();
 
-        List<Event> events = List.of(event, event2, event3);
+        List<EventEntity> events = List.of(event, event2, event3);
 
         transactionSummaryService.projectTransactionSummary(transactionEntity, event3, events);
 
@@ -123,13 +122,13 @@ public class TransactionSummaryServiceTest {
         TransactionEntity transactionEntity = aTransactionFixture()
                 .withState(SUCCESS)
                 .toEntity();
-        Event event = EventFixture.anEventFixture().withEventDate(ZonedDateTime.now())
+        EventEntity event = EventFixture.anEventFixture().withEventDate(ZonedDateTime.now())
                 .withEventType(PAYMENT_CREATED.name()).toEntity();
-        Event event2 = EventFixture.anEventFixture().withEventDate(ZonedDateTime.now().plusSeconds(1))
+        EventEntity event2 = EventFixture.anEventFixture().withEventDate(ZonedDateTime.now().plusSeconds(1))
                 .withEventType(USER_APPROVED_FOR_CAPTURE.name()).toEntity();
-        Event event3 = EventFixture.anEventFixture().withEventDate(ZonedDateTime.now().plusSeconds(2))
+        EventEntity event3 = EventFixture.anEventFixture().withEventDate(ZonedDateTime.now().plusSeconds(2))
                 .withEventType(CAPTURE_ERRORED.name()).toEntity();
-        List<Event> events = List.of(event, event2, event3);
+        List<EventEntity> events = List.of(event, event2, event3);
 
         transactionSummaryService.projectTransactionSummary(transactionEntity, event, events);
 
@@ -146,14 +145,14 @@ public class TransactionSummaryServiceTest {
                 .withState(SUCCESS)
                 .withFee(10L)
                 .toEntity();
-        Event paymentCreatedEvent = EventFixture.anEventFixture().withEventDate(ZonedDateTime.now())
+        EventEntity paymentCreatedEvent = EventFixture.anEventFixture().withEventDate(ZonedDateTime.now())
                 .withEventType(PAYMENT_CREATED.name()).toEntity();
-        Event captureConfirmedEvent = EventFixture.anEventFixture().withEventDate(ZonedDateTime.now().plusSeconds(1))
+        EventEntity captureConfirmedEvent = EventFixture.anEventFixture().withEventDate(ZonedDateTime.now().plusSeconds(1))
                 .withEventType(CAPTURE_CONFIRMED.name()).toEntity();
-        Event captureSubmittedEvent = EventFixture.anEventFixture().withEventDate(ZonedDateTime.now().plusSeconds(1))
+        EventEntity captureSubmittedEvent = EventFixture.anEventFixture().withEventDate(ZonedDateTime.now().plusSeconds(1))
                 .withEventType(CAPTURE_SUBMITTED.name()).toEntity();
 
-        List<Event> events = List.of(paymentCreatedEvent, captureSubmittedEvent, captureConfirmedEvent);
+        List<EventEntity> events = List.of(paymentCreatedEvent, captureSubmittedEvent, captureConfirmedEvent);
 
         transactionSummaryService.projectTransactionSummary(transactionEntity, paymentCreatedEvent, events);
 
@@ -174,14 +173,14 @@ public class TransactionSummaryServiceTest {
                 .withState(SUCCESS)
                 .withFee(null)
                 .toEntity();
-        Event paymentCreatedEvent = EventFixture.anEventFixture().withEventDate(ZonedDateTime.now())
+        EventEntity paymentCreatedEvent = EventFixture.anEventFixture().withEventDate(ZonedDateTime.now())
                 .withEventType(PAYMENT_CREATED.name()).toEntity();
-        Event captureSubmittedEvent = EventFixture.anEventFixture().withEventDate(ZonedDateTime.now().plusSeconds(1))
+        EventEntity captureSubmittedEvent = EventFixture.anEventFixture().withEventDate(ZonedDateTime.now().plusSeconds(1))
                 .withEventType(CAPTURE_SUBMITTED.name()).toEntity();
-        Event captureConfirmedEvent = EventFixture.anEventFixture().withEventDate(ZonedDateTime.now().plusSeconds(1))
+        EventEntity captureConfirmedEvent = EventFixture.anEventFixture().withEventDate(ZonedDateTime.now().plusSeconds(1))
                 .withEventType(CAPTURE_CONFIRMED.name()).toEntity();
 
-        List<Event> events = List.of(paymentCreatedEvent, captureSubmittedEvent, captureConfirmedEvent);
+        List<EventEntity> events = List.of(paymentCreatedEvent, captureSubmittedEvent, captureConfirmedEvent);
 
         transactionSummaryService.projectTransactionSummary(transactionEntity, paymentCreatedEvent, events);
 
@@ -199,14 +198,14 @@ public class TransactionSummaryServiceTest {
                 .withState(SUCCESS)
                 .withFee(10L)
                 .toEntity();
-        Event event = EventFixture.anEventFixture().withEventDate(ZonedDateTime.now())
+        EventEntity event = EventFixture.anEventFixture().withEventDate(ZonedDateTime.now())
                 .withEventType(PAYMENT_CREATED.name()).toEntity();
-        Event event2 = EventFixture.anEventFixture().withEventDate(ZonedDateTime.now().plusSeconds(1))
+        EventEntity event2 = EventFixture.anEventFixture().withEventDate(ZonedDateTime.now().plusSeconds(1))
                 .withEventType(CAPTURE_CONFIRMED.name()).toEntity();
-        Event event3 = EventFixture.anEventFixture().withEventDate(ZonedDateTime.now().plusSeconds(2))
+        EventEntity event3 = EventFixture.anEventFixture().withEventDate(ZonedDateTime.now().plusSeconds(2))
                 .withEventType(CAPTURE_CONFIRMED.name()).toEntity();
 
-        List<Event> events = List.of(event, event2, event3);
+        List<EventEntity> events = List.of(event, event2, event3);
 
         transactionSummaryService.projectTransactionSummary(transactionEntity, event3, events);
 
@@ -218,15 +217,15 @@ public class TransactionSummaryServiceTest {
         TransactionEntity transactionEntity = aTransactionFixture()
                 .withState(SUCCESS)
                 .toEntity();
-        Event event = EventFixture.anEventFixture().withEventDate(ZonedDateTime.now())
+        EventEntity event = EventFixture.anEventFixture().withEventDate(ZonedDateTime.now())
                 .withEventType(PAYMENT_CREATED.name()).toEntity();
-        Event event2 = EventFixture.anEventFixture()
+        EventEntity event2 = EventFixture.anEventFixture()
                 .withEventDate(ZonedDateTime.now().plusSeconds(1))
                 .withEventType(CAPTURE_SUBMITTED.name()).toEntity();
-        Event event3 = EventFixture.anEventFixture()
+        EventEntity event3 = EventFixture.anEventFixture()
                 .withEventDate(ZonedDateTime.now().plusSeconds(2))
                 .withEventType(PAYMENT_STATUS_CORRECTED_TO_SUCCESS_BY_ADMIN.name()).toEntity();
-        List<Event> events = List.of(event, event2, event3);
+        List<EventEntity> events = List.of(event, event2, event3);
 
         transactionSummaryService.projectTransactionSummary(transactionEntity, event3, events);
 
@@ -238,7 +237,7 @@ public class TransactionSummaryServiceTest {
         TransactionEntity transactionEntity = aTransactionFixture()
                 .withState(CREATED)
                 .toEntity();
-        Event event = EventFixture.anEventFixture().withEventType(PAYMENT_CREATED.name()).toEntity();
+        EventEntity event = EventFixture.anEventFixture().withEventType(PAYMENT_CREATED.name()).toEntity();
 
         transactionSummaryService.projectTransactionSummary(transactionEntity, event, List.of(event));
 
@@ -250,7 +249,7 @@ public class TransactionSummaryServiceTest {
         TransactionEntity transactionEntity = aTransactionFixture()
                 .withState(SUCCESS)
                 .toEntity();
-        Event event = EventFixture.anEventFixture().withEventType(USER_APPROVED_FOR_CAPTURE.name()).toEntity();
+        EventEntity event = EventFixture.anEventFixture().withEventType(USER_APPROVED_FOR_CAPTURE.name()).toEntity();
 
         transactionSummaryService.projectTransactionSummary(transactionEntity, event, List.of(event));
 
@@ -262,7 +261,7 @@ public class TransactionSummaryServiceTest {
         TransactionEntity transactionEntity = aTransactionFixture()
                 .withState(SUBMITTED)
                 .toEntity();
-        Event event = EventFixture.anEventFixture().withEventType(AUTHORISATION_SUCCEEDED.name()).toEntity();
+        EventEntity event = EventFixture.anEventFixture().withEventType(AUTHORISATION_SUCCEEDED.name()).toEntity();
 
         transactionSummaryService.projectTransactionSummary(transactionEntity, event, List.of(event));
 
@@ -274,7 +273,7 @@ public class TransactionSummaryServiceTest {
         TransactionEntity transactionEntity = aTransactionFixture()
                 .withState(SUCCESS)
                 .toEntity();
-        Event nonSalientEvent = EventFixture.anEventFixture()
+        EventEntity nonSalientEvent = EventFixture.anEventFixture()
                 .withEventDate(ZonedDateTime.now())
                 .withEventType("BACKFILLER_RECREATED_USER_EMAIL_COLLECTED").toEntity();
 
@@ -288,7 +287,7 @@ public class TransactionSummaryServiceTest {
         TransactionEntity transactionEntity = aTransactionFixture()
                 .withState(SUBMITTED)
                 .toEntity();
-        Event event = EventFixture.anEventFixture().withEventType(REFUND_SUBMITTED.name()).toEntity();
+        EventEntity event = EventFixture.anEventFixture().withEventType(REFUND_SUBMITTED.name()).toEntity();
 
         transactionSummaryService.projectTransactionSummary(transactionEntity, event, List.of(event));
 

--- a/src/test/java/uk/gov/pay/ledger/util/fixture/EventFixture.java
+++ b/src/test/java/uk/gov/pay/ledger/util/fixture/EventFixture.java
@@ -4,13 +4,13 @@ import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.RandomUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.jdbi.v3.core.Jdbi;
-import uk.gov.pay.ledger.event.model.Event;
+import uk.gov.pay.ledger.event.model.EventEntity;
 import uk.gov.pay.ledger.event.model.ResourceType;
 
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 
-public class EventFixture implements DbFixture<EventFixture, Event> {
+public class EventFixture implements DbFixture<EventFixture, EventEntity> {
     private Long id = RandomUtils.nextLong(1, 99999);
     private String sqsMessageId = RandomStringUtils.randomAlphanumeric(50);
     private String serviceId;
@@ -119,8 +119,8 @@ public class EventFixture implements DbFixture<EventFixture, Event> {
     }
 
     @Override
-    public Event toEntity() {
-        return new Event(id, sqsMessageId, serviceId, live, resourceType, resourceExternalId, parentResourceExternalId, eventDate, eventType, eventData, reprojectDomainObject);
+    public EventEntity toEntity() {
+        return new EventEntity(id, sqsMessageId, serviceId, live, resourceType, resourceExternalId, parentResourceExternalId, eventDate, eventType, eventData, reprojectDomainObject);
     }
 
     public Long getId() {
@@ -151,7 +151,7 @@ public class EventFixture implements DbFixture<EventFixture, Event> {
         return eventData;
     }
 
-    public EventFixture from(Event event) {
+    public EventFixture from(EventEntity event) {
         id = event.getId();
         sqsMessageId = event.getSqsMessageId();
         resourceType = event.getResourceType();

--- a/src/test/java/uk/gov/pay/ledger/util/fixture/EventFixture.java
+++ b/src/test/java/uk/gov/pay/ledger/util/fixture/EventFixture.java
@@ -4,7 +4,7 @@ import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.RandomUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.jdbi.v3.core.Jdbi;
-import uk.gov.pay.ledger.event.model.EventEntity;
+import uk.gov.pay.ledger.event.dao.entity.EventEntity;
 import uk.gov.pay.ledger.event.model.ResourceType;
 
 import java.time.ZoneOffset;

--- a/src/test/java/uk/gov/pay/ledger/util/fixture/QueueDisputeEventFixture.java
+++ b/src/test/java/uk/gov/pay/ledger/util/fixture/QueueDisputeEventFixture.java
@@ -4,7 +4,7 @@ import au.com.dius.pact.consumer.dsl.PactDslJsonBody;
 import com.amazonaws.services.sqs.AmazonSQS;
 import com.google.common.collect.ImmutableMap;
 import com.google.gson.GsonBuilder;
-import uk.gov.pay.ledger.event.model.EventEntity;
+import uk.gov.pay.ledger.event.dao.entity.EventEntity;
 import uk.gov.pay.ledger.event.model.ResourceType;
 
 import java.time.ZonedDateTime;

--- a/src/test/java/uk/gov/pay/ledger/util/fixture/QueueDisputeEventFixture.java
+++ b/src/test/java/uk/gov/pay/ledger/util/fixture/QueueDisputeEventFixture.java
@@ -4,7 +4,7 @@ import au.com.dius.pact.consumer.dsl.PactDslJsonBody;
 import com.amazonaws.services.sqs.AmazonSQS;
 import com.google.common.collect.ImmutableMap;
 import com.google.gson.GsonBuilder;
-import uk.gov.pay.ledger.event.model.Event;
+import uk.gov.pay.ledger.event.model.EventEntity;
 import uk.gov.pay.ledger.event.model.ResourceType;
 
 import java.time.ZonedDateTime;
@@ -12,7 +12,7 @@ import java.time.ZonedDateTime;
 import static org.apache.commons.lang3.RandomStringUtils.randomAlphanumeric;
 import static uk.gov.pay.ledger.event.model.ResourceType.DISPUTE;
 
-public class QueueDisputeEventFixture implements QueueFixture<QueueDisputeEventFixture, Event> {
+public class QueueDisputeEventFixture implements QueueFixture<QueueDisputeEventFixture, EventEntity> {
     private String sqsMessageId;
     private String serviceId = randomAlphanumeric(10);
     private Boolean live = true;
@@ -98,8 +98,8 @@ public class QueueDisputeEventFixture implements QueueFixture<QueueDisputeEventF
     }
 
     @Override
-    public Event toEntity() {
-        return new Event(0L, sqsMessageId, serviceId, live, resourceType, resourceExternalId, parentResourceExternalId, eventDate, eventType, eventData, false);
+    public EventEntity toEntity() {
+        return new EventEntity(0L, sqsMessageId, serviceId, live, resourceType, resourceExternalId, parentResourceExternalId, eventDate, eventType, eventData, false);
     }
 
     @Override

--- a/src/test/java/uk/gov/pay/ledger/util/fixture/QueuePaymentEventFixture.java
+++ b/src/test/java/uk/gov/pay/ledger/util/fixture/QueuePaymentEventFixture.java
@@ -7,7 +7,7 @@ import com.google.gson.GsonBuilder;
 import com.google.gson.JsonObject;
 import org.apache.commons.lang3.StringUtils;
 import uk.gov.service.payments.commons.model.Source;
-import uk.gov.pay.ledger.event.model.Event;
+import uk.gov.pay.ledger.event.model.EventEntity;
 import uk.gov.pay.ledger.event.model.ResourceType;
 
 import java.time.ZonedDateTime;
@@ -16,7 +16,7 @@ import java.util.Map;
 
 import static uk.gov.service.payments.commons.model.Source.CARD_API;
 
-public class QueuePaymentEventFixture implements QueueFixture<QueuePaymentEventFixture, Event> {
+public class QueuePaymentEventFixture implements QueueFixture<QueuePaymentEventFixture, EventEntity> {
     private String sqsMessageId;
     private String serviceId = "a-service-id";
     private Boolean live;
@@ -233,8 +233,8 @@ public class QueuePaymentEventFixture implements QueueFixture<QueuePaymentEventF
     }
 
     @Override
-    public Event toEntity() {
-        return new Event(0L, sqsMessageId, serviceId, live, resourceType, resourceExternalId, parentResourceExternalId, eventDate, eventType, eventData, reprojectDomainObject);
+    public EventEntity toEntity() {
+        return new EventEntity(0L, sqsMessageId, serviceId, live, resourceType, resourceExternalId, parentResourceExternalId, eventDate, eventType, eventData, reprojectDomainObject);
     }
 
     public String getSqsMessageId() {

--- a/src/test/java/uk/gov/pay/ledger/util/fixture/QueuePaymentEventFixture.java
+++ b/src/test/java/uk/gov/pay/ledger/util/fixture/QueuePaymentEventFixture.java
@@ -7,7 +7,7 @@ import com.google.gson.GsonBuilder;
 import com.google.gson.JsonObject;
 import org.apache.commons.lang3.StringUtils;
 import uk.gov.service.payments.commons.model.Source;
-import uk.gov.pay.ledger.event.model.EventEntity;
+import uk.gov.pay.ledger.event.dao.entity.EventEntity;
 import uk.gov.pay.ledger.event.model.ResourceType;
 
 import java.time.ZonedDateTime;

--- a/src/test/java/uk/gov/pay/ledger/util/fixture/QueuePayoutEventFixture.java
+++ b/src/test/java/uk/gov/pay/ledger/util/fixture/QueuePayoutEventFixture.java
@@ -4,7 +4,7 @@ import au.com.dius.pact.consumer.dsl.PactDslJsonBody;
 import com.amazonaws.services.sqs.AmazonSQS;
 import com.google.common.collect.ImmutableMap;
 import com.google.gson.GsonBuilder;
-import uk.gov.pay.ledger.event.model.Event;
+import uk.gov.pay.ledger.event.model.EventEntity;
 import uk.gov.pay.ledger.event.model.ResourceType;
 
 import java.time.ZonedDateTime;
@@ -12,7 +12,7 @@ import java.time.ZonedDateTime;
 import static org.apache.commons.lang3.StringUtils.EMPTY;
 import static uk.gov.pay.ledger.event.model.ResourceType.PAYOUT;
 
-public class QueuePayoutEventFixture implements QueueFixture<QueuePayoutEventFixture, Event> {
+public class QueuePayoutEventFixture implements QueueFixture<QueuePayoutEventFixture, EventEntity> {
     private String sqsMessageId;
     private String serviceId;
     private Boolean live;
@@ -87,8 +87,8 @@ public class QueuePayoutEventFixture implements QueueFixture<QueuePayoutEventFix
     }
 
     @Override
-    public Event toEntity() {
-        return new Event(0L, sqsMessageId, serviceId, live, resourceType, resourceExternalId, EMPTY, eventDate, eventType, eventData, false);
+    public EventEntity toEntity() {
+        return new EventEntity(0L, sqsMessageId, serviceId, live, resourceType, resourceExternalId, EMPTY, eventDate, eventType, eventData, false);
     }
 
     @Override

--- a/src/test/java/uk/gov/pay/ledger/util/fixture/QueuePayoutEventFixture.java
+++ b/src/test/java/uk/gov/pay/ledger/util/fixture/QueuePayoutEventFixture.java
@@ -4,7 +4,7 @@ import au.com.dius.pact.consumer.dsl.PactDslJsonBody;
 import com.amazonaws.services.sqs.AmazonSQS;
 import com.google.common.collect.ImmutableMap;
 import com.google.gson.GsonBuilder;
-import uk.gov.pay.ledger.event.model.EventEntity;
+import uk.gov.pay.ledger.event.dao.entity.EventEntity;
 import uk.gov.pay.ledger.event.model.ResourceType;
 
 import java.time.ZonedDateTime;

--- a/src/test/java/uk/gov/pay/ledger/util/fixture/QueueRefundEventFixture.java
+++ b/src/test/java/uk/gov/pay/ledger/util/fixture/QueueRefundEventFixture.java
@@ -4,7 +4,7 @@ import au.com.dius.pact.consumer.dsl.PactDslJsonBody;
 import com.amazonaws.services.sqs.AmazonSQS;
 import com.google.common.collect.ImmutableMap;
 import com.google.gson.GsonBuilder;
-import uk.gov.pay.ledger.event.model.EventEntity;
+import uk.gov.pay.ledger.event.dao.entity.EventEntity;
 import uk.gov.pay.ledger.event.model.ResourceType;
 
 import java.time.ZonedDateTime;

--- a/src/test/java/uk/gov/pay/ledger/util/fixture/QueueRefundEventFixture.java
+++ b/src/test/java/uk/gov/pay/ledger/util/fixture/QueueRefundEventFixture.java
@@ -4,12 +4,12 @@ import au.com.dius.pact.consumer.dsl.PactDslJsonBody;
 import com.amazonaws.services.sqs.AmazonSQS;
 import com.google.common.collect.ImmutableMap;
 import com.google.gson.GsonBuilder;
-import uk.gov.pay.ledger.event.model.Event;
+import uk.gov.pay.ledger.event.model.EventEntity;
 import uk.gov.pay.ledger.event.model.ResourceType;
 
 import java.time.ZonedDateTime;
 
-public class QueueRefundEventFixture implements QueueFixture<QueueRefundEventFixture, Event> {
+public class QueueRefundEventFixture implements QueueFixture<QueueRefundEventFixture, EventEntity> {
     private String sqsMessageId;
     private ResourceType resourceType = ResourceType.REFUND;
     private String serviceId;
@@ -102,8 +102,8 @@ public class QueueRefundEventFixture implements QueueFixture<QueueRefundEventFix
     }
 
     @Override
-    public Event toEntity() {
-        return new Event(0L, sqsMessageId, serviceId, live, resourceType, resourceExternalId, parentResourceExternalId, eventDate, eventType, eventData, false);
+    public EventEntity toEntity() {
+        return new EventEntity(0L, sqsMessageId, serviceId, live, resourceType, resourceExternalId, parentResourceExternalId, eventDate, eventType, eventData, false);
     }
 
     public String getSqsMessageId() {


### PR DESCRIPTION
* Delete unused endpoint `/v1/event/{eventId}`
* Rename `Event` to `EventEntity` and move it to a more suitable package
* Rename `EventDto` to `Event`