### PR TITLE
PP-10762: Allow ledger to use an overriden SNS endpoint for local testing

### DIFF
--- a/src/main/java/uk/gov/pay/ledger/app/config/SnsConfig.java
+++ b/src/main/java/uk/gov/pay/ledger/app/config/SnsConfig.java
@@ -2,6 +2,8 @@ package uk.gov.pay.ledger.app.config;
 
 import io.dropwizard.Configuration;
 
+import java.net.URI;
+
 import javax.validation.constraints.NotNull;
 
 public class SnsConfig extends Configuration {
@@ -10,6 +12,8 @@ public class SnsConfig extends Configuration {
     private boolean snsEnabled;
     @NotNull
     private String region;
+    private String accessKey;
+    private String secretKey;
     private String cardPaymentEventsTopicArn;
     private String cardPaymentDisputeEventsTopicArn;
     @NotNull
@@ -17,12 +21,31 @@ public class SnsConfig extends Configuration {
     @NotNull
     private boolean publishCardPaymentDisputeEventsToSns;
 
+    private boolean nonStandardServiceEndpoint;
+    private URI endpoint;
+
     public boolean isSnsEnabled() {
         return snsEnabled;
     }
 
     public String getRegion() {
         return region;
+    }
+
+    public URI getEndpoint() {
+        return endpoint;
+    }
+
+    public String getSecretKey() {
+        return secretKey;
+    }
+
+    public String getAccessKey() {
+        return accessKey;
+    }
+
+    public boolean isNonStandardServiceEndpoint() {
+        return nonStandardServiceEndpoint;
     }
 
     public String getCardPaymentEventsTopicArn() {

--- a/src/main/resources/config/config.yaml
+++ b/src/main/resources/config/config.yaml
@@ -71,6 +71,10 @@ sqsConfig:
 
 snsConfig:
   snsEnabled: ${SNS_ENABLED:-false}
+  nonStandardServiceEndpoint: ${AWS_SNS_NON_STANDARD_SERVICE_ENDPOINT:-false}
+  endpoint: ${AWS_SNS_ENDPOINT:-}
+  secretKey: ${AWS_SECRET_KEY}
+  accessKey: ${AWS_ACCESS_KEY}
   region: ${AWS_SNS_REGION:-eu-west-1}
   cardPaymentEventsTopicArn: ${SNS_TOPIC_CARD_PAYMENT_EVENTS_ARN}
   cardPaymentDisputeEventsTopicArn: ${SNS_TOPIC_CARD_PAYMENT_DISPUTE_EVENTS_ARN}

--- a/src/test/resources/config/test-config.yaml
+++ b/src/test/resources/config/test-config.yaml
@@ -65,6 +65,10 @@ queueMessageReceiverConfig:
 
 snsConfig:
   snsEnabled: ${SNS_ENABLED:-false}
+  nonStandardServiceEndpoint: ${AWS_SNS_NON_STANDARD_SERVICE_ENDPOINT:-false}
+  endpoint: ${AWS_SNS_ENDPOINT:-}
+  secretKey: ${AWS_SECRET_KEY}
+  accessKey: ${AWS_ACCESS_KEY}
   region: ${AWS_SNS_REGION:-eu-west-1}
   cardPaymentEventsTopicArn: ${SNS_TOPIC_CARD_PAYMENT_EVENTS_ARN}
 


### PR DESCRIPTION
Allow the SNS client to be built with an overridden endpoint to allow local testing.

Note that I have matched the naming used in the very similar SQS config, and have also matched the indentation style to that even though it feels very strange to me (but then I'm not a java person 😄)

One big difference is SNS is using (and is already using) aws-sdk v2, and SQS is using aws-sdk v1, so the actual client construction and configuration is quite different.