### PR TITLE
PP-10538 Log when ledger publishes to SNS

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
         <jackson.version>2.15.0</jackson.version>
         <testcontainers.version>1.18.0</testcontainers.version>
         <postgresql.version>42.6.0</postgresql.version>
-        <pay-java-commons.version>1.0.20230509124715</pay-java-commons.version>
+        <pay-java-commons.version>1.0.20230511100444</pay-java-commons.version>
         <junit5.version>5.9.2</junit5.version>
         <surefire.version>3.0.0</surefire.version>
         <guice.version>5.1.0</guice.version>

--- a/src/test/java/uk/gov/pay/ledger/queue/EventMessageHandlerTest.java
+++ b/src/test/java/uk/gov/pay/ledger/queue/EventMessageHandlerTest.java
@@ -41,6 +41,7 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 import static uk.gov.pay.ledger.util.fixture.QueuePaymentEventFixture.aQueuePaymentEventFixture;
+import static uk.gov.service.payments.logging.LoggingKeys.LEDGER_EVENT_TYPE;
 
 @ExtendWith(MockitoExtension.class)
 class EventMessageHandlerTest {
@@ -131,7 +132,7 @@ class EventMessageHandlerTest {
 
         verify(mockAppender, times(1)).doAppend(loggingEventArgumentCaptor.capture());
         assertThat(loggingEventArgumentCaptor.getValue().getArgumentArray(), hasItemInArray(kv("reproject_domain_object_event", true)));
-        assertThat(loggingEventArgumentCaptor.getValue().getArgumentArray(), hasItemInArray(kv("event_type", eventType)));
+        assertThat(loggingEventArgumentCaptor.getValue().getArgumentArray(), hasItemInArray(kv(LEDGER_EVENT_TYPE, eventType)));
     }
 
     @Test


### PR DESCRIPTION
Add logging so that we can determine whether ledger is successfully publishing messages to SNS.

Use shared logging keys "resource_external_id", "sqs_message_id" and "ledger_event_type". This means that logs lines that previously had key "event_type" will now have key "ledger_event_type".