### PR TITLE
PP-10982 add canRetry field to Payment model

### DIFF
--- a/src/main/java/uk/gov/pay/ledger/transaction/model/Payment.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/model/Payment.java
@@ -50,6 +50,7 @@ public class Payment extends Transaction {
     private AuthorisationMode authorisationMode;
     private String agreementId;
     private Boolean disputed;
+    private Boolean canRetry;
 
     public Payment() {
 
@@ -85,6 +86,7 @@ public class Payment extends Transaction {
         this.authorisationMode = builder.authorisationMode;
         this.agreementId = builder.agreementId;
         this.disputed = builder.disputed;
+        this.canRetry = builder.canRetry;
     }
 
     @Override
@@ -210,6 +212,10 @@ public class Payment extends Transaction {
         return disputed;
     }
 
+    public Boolean getCanRetry() {
+        return canRetry;
+    }
+
     public static class Builder {
         public String serviceId;
         private Long id;
@@ -245,6 +251,7 @@ public class Payment extends Transaction {
         private AuthorisationMode authorisationMode;
         private String agreementId;
         private Boolean disputed;
+        public Boolean canRetry;
 
         public Builder() {
         }
@@ -420,6 +427,11 @@ public class Payment extends Transaction {
 
         public Builder withDisputed(Boolean disputed) {
             this.disputed = disputed;
+            return this;
+        }
+
+        public Builder withCanRetry(Boolean canRetry) {
+            this.canRetry = canRetry;
             return this;
         }
     }

--- a/src/main/java/uk/gov/pay/ledger/transaction/model/TransactionFactory.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/model/TransactionFactory.java
@@ -127,6 +127,7 @@ public class TransactionFactory {
                     .withAuthorisationMode(authorisationMode)
                     .withAgreementId(entity.getAgreementId())
                     .withDisputed(safeGetAsBoolean(transactionDetails, "disputed", false))
+                    .withCanRetry(safeGetAsBoolean(transactionDetails, "canRetry", null))
                     .build();
         } catch (IOException e) {
             LOGGER.error("Error during the parsing transaction entity data [{}] [errorMessage={}]", entity.getExternalId(), e.getMessage());

--- a/src/test/java/uk/gov/pay/ledger/transaction/model/TransactionFactoryTest.java
+++ b/src/test/java/uk/gov/pay/ledger/transaction/model/TransactionFactoryTest.java
@@ -10,8 +10,6 @@ import uk.gov.pay.ledger.transaction.entity.TransactionEntity;
 import uk.gov.pay.ledger.transaction.state.TransactionState;
 import uk.gov.service.payments.commons.model.AuthorisationMode;
 
-import java.time.Instant;
-import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.Optional;
 
@@ -55,6 +53,7 @@ public class TransactionFactoryTest {
     private String cardExpiryDate = "10/27";
     private String walletType = "APPLE_PAY";
     private ZonedDateTime paidOutDate = ZonedDateTime.parse("2017-09-19T08:46:01.123456Z");
+    private Boolean canRetry = false;
 
     @BeforeEach
     public void setUp() {
@@ -85,6 +84,7 @@ public class TransactionFactoryTest {
         fullTransactionDetails.addProperty("wallet", walletType);
         fullTransactionDetails.addProperty("authorisation_mode", "moto_api");
         fullTransactionDetails.addProperty("disputed", true);
+        fullTransactionDetails.addProperty("canRetry", false);
 
         var payoutObject = aPayoutEntity()
                 .withPaidOutDate(paidOutDate)
@@ -194,6 +194,7 @@ public class TransactionFactoryTest {
         assertThat(payment.getSettlementSummary().getSettledDate(), is(Optional.empty()));
         assertThat(payment.getAuthorisationMode(), is(AuthorisationMode.WEB));
         assertThat(payment.getDisputed(), is(false));
+        assertThat(payment.getCanRetry(), is(nullValue()));
     }
 
     @Test
@@ -395,5 +396,6 @@ public class TransactionFactoryTest {
         assertThat(payment.getWalletType(), is(walletType));
         assertThat(payment.getAuthorisationMode(), is(AuthorisationMode.MOTO_API));
         assertThat(payment.getDisputed(), is(true));
+        assertThat(payment.getCanRetry(), is(Boolean.FALSE));
     }
 }


### PR DESCRIPTION
- add canRetry field to `Payment` model (it will be used to build `ExternalTransactionState`)