### PR TITLE
PP-10982 add can_retry to external transaction state

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -125,14 +125,14 @@
         "filename": "openapi/ledger_spec.yaml",
         "hashed_secret": "9baeb3f7db14ddab5d172149762035c0c022d76d",
         "is_verified": false,
-        "line_number": 1581
+        "line_number": 1587
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/ledger_spec.yaml",
         "hashed_secret": "920734ed7628ef47739eed5571412e2c8271790f",
         "is_verified": false,
-        "line_number": 1655
+        "line_number": 1661
       }
     ],
     "src/main/java/uk/gov/pay/ledger/event/model/Event.java": [
@@ -163,5 +163,5 @@
       }
     ]
   },
-  "generated_at": "2023-05-16T11:04:24Z"
+  "generated_at": "2023-05-23T11:54:13Z"
 }

--- a/openapi/ledger_spec.yaml
+++ b/openapi/ledger_spec.yaml
@@ -1281,6 +1281,12 @@ components:
     ExternalTransactionState:
       type: object
       properties:
+        can_retry:
+          type: boolean
+          description: Only applicable for failed recurring payments. Default value
+            is null
+          example: true
+          nullable: true
         code:
           type: string
           example: P0030

--- a/src/main/java/uk/gov/pay/ledger/transaction/model/TransactionFactory.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/model/TransactionFactory.java
@@ -127,7 +127,7 @@ public class TransactionFactory {
                     .withAuthorisationMode(authorisationMode)
                     .withAgreementId(entity.getAgreementId())
                     .withDisputed(safeGetAsBoolean(transactionDetails, "disputed", false))
-                    .withCanRetry(safeGetAsBoolean(transactionDetails, "canRetry", null))
+                    .withCanRetry(safeGetAsBoolean(transactionDetails, "can_retry", null))
                     .build();
         } catch (IOException e) {
             LOGGER.error("Error during the parsing transaction entity data [{}] [errorMessage={}]", entity.getExternalId(), e.getMessage());

--- a/src/main/java/uk/gov/pay/ledger/transaction/search/model/TransactionView.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/search/model/TransactionView.java
@@ -184,8 +184,7 @@ public class TransactionView {
                     .withAgreementId(payment.getAgreementId())
                     .withDisputed(payment.getDisputed());
             if (payment.getState() != null) {
-                paymentBuilder = paymentBuilder
-                        .withState(ExternalTransactionState.from(payment.getState(), statusVersion));
+                paymentBuilder = paymentBuilder.withState(ExternalTransactionState.from(payment.getState(), statusVersion, payment.getCanRetry()));
             }
             return paymentBuilder.build();
         }

--- a/src/main/java/uk/gov/pay/ledger/transaction/state/ExternalTransactionState.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/state/ExternalTransactionState.java
@@ -13,18 +13,26 @@ public class ExternalTransactionState {
     private final boolean finished;
     private final String code;
     private final String message;
+    private final Boolean canRetry;
 
     public static ExternalTransactionState from(TransactionState state, int statusVersion) {
         String status = statusVersion == 2 ? state.getStatus() : state.getOldStatus();
         return new ExternalTransactionState(status, state.isFinished(),
-                state.getCode(), state.getMessage());
+                state.getCode(), state.getMessage(), null);
     }
 
-    private ExternalTransactionState(String value, boolean finished, String code, String message) {
+    public static ExternalTransactionState from(TransactionState state, int statusVersion, Boolean canRetry) {
+        String status = statusVersion == 2 ? state.getStatus() : state.getOldStatus();
+        return new ExternalTransactionState(status, state.isFinished(),
+                state.getCode(), state.getMessage(), canRetry);
+    }
+
+    private ExternalTransactionState(String value, boolean finished, String code, String message, Boolean canRetry) {
         this.value = value;
         this.finished = finished;
         this.code = code;
         this.message = message;
+        this.canRetry = canRetry;
     }
 
     @Schema(example = "cancelled")
@@ -47,6 +55,11 @@ public class ExternalTransactionState {
         return message;
     }
 
+    @Schema(example = "true", nullable = true, description = "Only applicable for failed recurring payments. Default value is null")
+    public Boolean getCanRetry() {
+        return canRetry;
+    }
+
     @Override
     public String toString() {
         return "ExternalTransactionState{" +
@@ -54,6 +67,7 @@ public class ExternalTransactionState {
                 ", finished=" + finished +
                 ", code='" + code + '\'' +
                 ", message='" + message + '\'' +
+                (canRetry != null ? ", can_retry=" + canRetry : "") +
                 '}';
     }
 }

--- a/src/test/java/uk/gov/pay/ledger/transaction/model/TransactionFactoryTest.java
+++ b/src/test/java/uk/gov/pay/ledger/transaction/model/TransactionFactoryTest.java
@@ -84,7 +84,7 @@ public class TransactionFactoryTest {
         fullTransactionDetails.addProperty("wallet", walletType);
         fullTransactionDetails.addProperty("authorisation_mode", "moto_api");
         fullTransactionDetails.addProperty("disputed", true);
-        fullTransactionDetails.addProperty("canRetry", false);
+        fullTransactionDetails.addProperty("can_retry", false);
 
         var payoutObject = aPayoutEntity()
                 .withPaidOutDate(paidOutDate)

--- a/src/test/java/uk/gov/pay/ledger/util/fixture/TransactionFixture.java
+++ b/src/test/java/uk/gov/pay/ledger/util/fixture/TransactionFixture.java
@@ -80,6 +80,7 @@ public class TransactionFixture implements DbFixture<TransactionFixture, Transac
     private String agreementId;
     private Boolean disputed;
     private AuthorisationMode authorisationMode = AuthorisationMode.WEB;
+    private Boolean canRetry;
 
     private TransactionFixture() {
     }
@@ -353,6 +354,11 @@ public class TransactionFixture implements DbFixture<TransactionFixture, Transac
         return this;
     }
 
+    public TransactionFixture withCanRetry(Boolean canRetry) {
+        this.canRetry = canRetry;
+        return this;
+    }
+
     public TransactionFixture withAuthorisationMode(AuthorisationMode authorisationMode) {
         this.authorisationMode = authorisationMode;
         return this;
@@ -506,6 +512,9 @@ public class TransactionFixture implements DbFixture<TransactionFixture, Transac
                 });
         Optional.ofNullable(disputed).ifPresent(
                 disputed -> transactionDetails.addProperty("disputed", disputed)
+        );
+        Optional.ofNullable(canRetry).ifPresent(
+                canRetry -> transactionDetails.addProperty("can_retry", canRetry)
         );
         return transactionDetails;
     }


### PR DESCRIPTION
- add canRetry to `ExternalTransactionState`
- implement including canRetry when getting/searching transactions (if applicable)
- add tests