### PR TITLE
PP-10509 Don't publish agreement events to SNS

### DIFF
--- a/src/test/java/uk/gov/pay/ledger/queue/EventMessageHandlerTest.java
+++ b/src/test/java/uk/gov/pay/ledger/queue/EventMessageHandlerTest.java
@@ -178,7 +178,7 @@ class EventMessageHandlerTest {
     }
 
     @Test
-    void shouldPublishDisputeMessageWhenSnsEnabled() throws Exception {;
+    void shouldPublishDisputeMessageWhenSnsEnabled() throws Exception {
         String messageBody = "{ \"foo\": \"bar\"}";
 
         EventEntity event = aQueuePaymentEventFixture().withResourceType(ResourceType.DISPUTE).toEntity();
@@ -191,6 +191,20 @@ class EventMessageHandlerTest {
         eventMessageHandler.handle();
 
         verify(eventPublisher).publishMessageToTopic(messageBody, TopicName.CARD_PAYMENT_DISPUTE_EVENTS);
+    }
+
+    @Test
+    void shouldNotPublishAgreementEventsToSNS() throws Exception {
+        String messageBody = "{ \"foo\": \"bar\"}";
+
+        EventEntity event = aQueuePaymentEventFixture().withResourceType(ResourceType.AGREEMENT).toEntity();
+        when(eventMessage.getEvent()).thenReturn(event);
+        when(ledgerConfig.getSnsConfig()).thenReturn(snsConfig);
+        when(snsConfig.isSnsEnabled()).thenReturn(true);
+
+        eventMessageHandler.handle();
+
+        verifyNoInteractions(eventPublisher);
     }
 
     @Test


### PR DESCRIPTION
## WHAT 
- Currently, Ledger is attempting to publish events other than disputes to `card_payment_events` SNS topic. We can restrict this to PAYMENT/REFUNDS events as consumers (webhooks/adminusers) of SNS do not handle events other than PAYMENT/REFUND/DISPUTE.
- Also Ledger currently fails to publish agreement events to SNS and logs `Failed to publish event for message` due to `NullPointerException` when getting `rawMessageBody` (as it is only available for events from SQS but not agreements which are sent synchronously)