### PR TITLE
PP-10509 Get EventDigest by resource ID and type

### DIFF
--- a/src/main/java/uk/gov/pay/ledger/agreement/service/AgreementService.java
+++ b/src/main/java/uk/gov/pay/ledger/agreement/service/AgreementService.java
@@ -9,8 +9,8 @@ import uk.gov.pay.ledger.agreement.entity.AgreementsFactory;
 import uk.gov.pay.ledger.agreement.model.Agreement;
 import uk.gov.pay.ledger.agreement.model.AgreementSearchResponse;
 import uk.gov.pay.ledger.agreement.resource.AgreementSearchParams;
-import uk.gov.pay.ledger.event.model.EventDigest;
 import uk.gov.pay.ledger.event.model.Event;
+import uk.gov.pay.ledger.event.model.EventDigest;
 import uk.gov.pay.ledger.event.service.EventService;
 import uk.gov.pay.ledger.exception.EmptyEventsException;
 import uk.gov.pay.ledger.util.pagination.PaginationBuilder;
@@ -24,6 +24,7 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 
 import static java.lang.String.format;
+import static uk.gov.pay.ledger.event.model.ResourceType.AGREEMENT;
 
 public class AgreementService {
     private final AgreementDao agreementDao;
@@ -66,7 +67,7 @@ public class AgreementService {
         if (isConsistent) {
             EventDigest eventDigest;
             try {
-                eventDigest = eventService.getEventDigestForResource(externalId);
+                eventDigest = eventService.getEventDigestForResourceAndType(externalId, AGREEMENT);
             }
             catch (EmptyEventsException e) {
                 return Optional.empty();

--- a/src/main/java/uk/gov/pay/ledger/event/service/EventService.java
+++ b/src/main/java/uk/gov/pay/ledger/event/service/EventService.java
@@ -4,10 +4,12 @@ import com.google.inject.Inject;
 import uk.gov.pay.ledger.event.dao.EventDao;
 import uk.gov.pay.ledger.event.entity.EventEntity;
 import uk.gov.pay.ledger.event.model.EventDigest;
+import uk.gov.pay.ledger.event.model.ResourceType;
 import uk.gov.pay.ledger.event.model.response.CreateEventResponse;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 public class EventService {
     private EventDao eventDao;
@@ -15,6 +17,13 @@ public class EventService {
     @Inject
     public EventService(EventDao eventDao) {
         this.eventDao = eventDao;
+    }
+
+    public EventDigest getEventDigestForResourceAndType(String resourceExternalId, ResourceType resourceType) {
+        List<EventEntity> events = getEventsForResource(resourceExternalId)
+                .stream().filter(eventEntity -> resourceType == eventEntity.getResourceType())
+                .collect(Collectors.toList());
+        return EventDigest.fromEventList(events);
     }
 
     public EventDigest getEventDigestForResource(String resourceExternalId) {

--- a/src/test/java/uk/gov/pay/ledger/agreement/resource/AgreementResourceIT.java
+++ b/src/test/java/uk/gov/pay/ledger/agreement/resource/AgreementResourceIT.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+import uk.gov.pay.ledger.event.model.ResourceType;
 import uk.gov.pay.ledger.extension.AppWithPostgresAndSqsExtension;
 import uk.gov.pay.ledger.transaction.model.CardType;
 import uk.gov.pay.ledger.util.fixture.AgreementFixture;
@@ -15,7 +16,6 @@ import uk.gov.service.payments.commons.model.agreement.AgreementStatus;
 import uk.gov.service.payments.commons.model.agreement.PaymentInstrumentType;
 
 import javax.ws.rs.core.Response;
-
 import java.time.ZonedDateTime;
 
 import static io.restassured.RestAssured.given;
@@ -23,8 +23,9 @@ import static io.restassured.http.ContentType.JSON;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.nullValue;
-import static uk.gov.pay.ledger.util.DatabaseTestHelper.aDatabaseTestHelper;
 import static uk.gov.pay.ledger.agreement.resource.AgreementSearchParams.DEFAULT_DISPLAY_SIZE;
+import static uk.gov.pay.ledger.event.model.ResourceType.AGREEMENT;
+import static uk.gov.pay.ledger.util.DatabaseTestHelper.aDatabaseTestHelper;
 
 class AgreementResourceIT {
     @RegisterExtension
@@ -220,6 +221,7 @@ class AgreementResourceIT {
                 .withResourceExternalId("agreement-id")
                 .withServiceId(serviceId)
                 .withEventType("AGREEMENT_CREATED")
+                .withResourceType(AGREEMENT)
                 .withEventData(
                         new JSONObject()
                                 .put("reference", "event-stream-reference")
@@ -255,6 +257,7 @@ class AgreementResourceIT {
                 .withResourceExternalId("agreement-id")
                 .withServiceId(serviceId)
                 .withEventType("AGREEMENT_CREATED")
+                .withResourceType(AGREEMENT)
                 .withEventData(
                         new JSONObject()
                                 .put("reference", "event-stream-reference")
@@ -267,6 +270,7 @@ class AgreementResourceIT {
                 .withResourceExternalId("agreement-id")
                 .withServiceId(serviceId)
                 .withEventType("AGREEMENT_SET_UP")
+                .withResourceType(AGREEMENT)
                 .withEventData(
                         new JSONObject()
                                 .put("status", "ACTIVE")
@@ -294,6 +298,7 @@ class AgreementResourceIT {
                 .withResourceExternalId("agreement-id")
                 .withServiceId(serviceId)
                 .withEventType("AGREEMENT_CREATED")
+                .withResourceType(AGREEMENT)
                 .withEventData(
                         new JSONObject()
                                 .put("reference", "event-stream-reference")
@@ -380,6 +385,7 @@ class AgreementResourceIT {
                 .withResourceExternalId(agreementId)
                 .withServiceId(serviceId)
                 .withEventType("AGREEMENT_SET_UP")
+                .withResourceType(AGREEMENT)
                 .withEventDate(ZonedDateTime.parse("2007-12-03T13:15:30+00:00[Europe/London]"))
                 .withLive(true)
                 .withEventData(

--- a/src/test/java/uk/gov/pay/ledger/agreement/service/AgreementServiceTest.java
+++ b/src/test/java/uk/gov/pay/ledger/agreement/service/AgreementServiceTest.java
@@ -24,10 +24,11 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
+import static uk.gov.pay.ledger.event.model.ResourceType.AGREEMENT;
 import static uk.gov.pay.ledger.util.fixture.EventFixture.anEventFixture;
 
 @ExtendWith(MockitoExtension.class)
-public class AgreementServiceTest {
+class AgreementServiceTest {
 
     private static final AgreementDao agreementDao = mock(AgreementDao.class);
     private static final PaymentInstrumentDao paymentInstrumentDao = mock(PaymentInstrumentDao.class);
@@ -38,13 +39,13 @@ public class AgreementServiceTest {
     private AgreementService agreementService;
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         reset(agreementDao, paymentInstrumentDao, agreementEntityFactory, eventService);
         agreementService = new AgreementService(agreementDao, paymentInstrumentDao, agreementEntityFactory, eventService, objectMapper);
     }
 
     @Test
-    public void findShouldReturnProjectionDirectlyIfConsistentFalse() {
+    void findShouldReturnProjectionDirectlyIfConsistentFalse() {
         var resourceId = "agreement-id";
         var agreement = stubAgreement(resourceId, 1);
         when(agreementDao.findByExternalId(resourceId))
@@ -57,10 +58,10 @@ public class AgreementServiceTest {
     }
 
     @Test
-    public void findShouldReturnProjectionDirectlyIfConsistentTrueButThereAreNoNewEvents() {
+    void findShouldReturnProjectionDirectlyIfConsistentTrueButThereAreNoNewEvents() {
         var resourceId = "agreement-id";
         var agreement = stubAgreement(resourceId, 1);
-        when(eventService.getEventDigestForResource(resourceId))
+        when(eventService.getEventDigestForResourceAndType(resourceId, AGREEMENT))
                 .thenReturn(stubEventDigest(resourceId, 1));
         when(agreementDao.findByExternalId(resourceId))
                 .thenReturn(Optional.of(agreement));
@@ -71,11 +72,11 @@ public class AgreementServiceTest {
     }
 
     @Test
-    public void findShouldReturnNewProjectionIfConsistentTrueAndThereAreNewEvents() {
+    void findShouldReturnNewProjectionIfConsistentTrueAndThereAreNewEvents() {
         var resourceId = "agreement-id";
         var agreement = stubAgreement(resourceId, 1);
         var eventDigest = stubEventDigest(resourceId, 2);
-        when(eventService.getEventDigestForResource(resourceId))
+        when(eventService.getEventDigestForResourceAndType(resourceId, AGREEMENT))
                 .thenReturn(eventDigest);
         when(agreementEntityFactory.create(eventDigest))
                 .thenReturn(agreement);
@@ -86,11 +87,11 @@ public class AgreementServiceTest {
     }
 
     @Test
-    public void findShouldReturnNewProjectionIfConsistentTrueAndThereAreOnlyEventsAndNoProjection() {
+    void findShouldReturnNewProjectionIfConsistentTrueAndThereAreOnlyEventsAndNoProjection() {
         var resourceId = "agreement-id";
         var agreement = stubAgreement(resourceId, 1);
         var eventDigest = stubEventDigest(resourceId, 1);
-        when(eventService.getEventDigestForResource(resourceId))
+        when(eventService.getEventDigestForResourceAndType(resourceId, AGREEMENT))
                 .thenReturn(eventDigest);
         when(agreementEntityFactory.create(eventDigest))
                 .thenReturn(agreement);
@@ -101,9 +102,9 @@ public class AgreementServiceTest {
     }
 
     @Test
-    public void findShouldReturnEmptyValueWhenEventServiceHasNoEvents() {
+    void findShouldReturnEmptyValueWhenEventServiceHasNoEvents() {
         var resourceId = "agreement-id";
-        when(eventService.getEventDigestForResource(resourceId))
+        when(eventService.getEventDigestForResourceAndType(resourceId, AGREEMENT))
                 .thenThrow(EmptyEventsException.class);
 
         var result = agreementService.findAgreementEntity(resourceId, true);
@@ -112,7 +113,7 @@ public class AgreementServiceTest {
     }
 
     @Test
-    public void findShouldApplyFiltersWhenConsistentIsFalse() {
+    void findShouldApplyFiltersWhenConsistentIsFalse() {
         var resourceId = "agreement-id";
         var accountId = "123";
         var serviceId = "service-id";
@@ -135,12 +136,12 @@ public class AgreementServiceTest {
     }
 
     @Test
-    public void findShouldApplyFiltersWhenConsistentIsTrue() {
+    void findShouldApplyFiltersWhenConsistentIsTrue() {
         var resourceId = "agreement-id";
         var accountId = "123";
         var serviceId = "service-id";
         var agreement = stubAgreement(resourceId, 1, accountId, serviceId);
-        when(eventService.getEventDigestForResource(resourceId))
+        when(eventService.getEventDigestForResourceAndType(resourceId, AGREEMENT))
                 .thenReturn(stubEventDigest(resourceId, 1));
         when(agreementDao.findByExternalId(resourceId))
                 .thenReturn(Optional.of(agreement));

--- a/src/test/java/uk/gov/pay/ledger/queue/EventMessageHandlerTest.java
+++ b/src/test/java/uk/gov/pay/ledger/queue/EventMessageHandlerTest.java
@@ -195,8 +195,6 @@ class EventMessageHandlerTest {
 
     @Test
     void shouldNotPublishAgreementEventsToSNS() throws Exception {
-        String messageBody = "{ \"foo\": \"bar\"}";
-
         EventEntity event = aQueuePaymentEventFixture().withResourceType(ResourceType.AGREEMENT).toEntity();
         when(eventMessage.getEvent()).thenReturn(event);
         when(ledgerConfig.getSnsConfig()).thenReturn(snsConfig);


### PR DESCRIPTION
## WHAT
- Currently, when projecting agreement (during GET), events for the resource_external_id are processed and mapped to the agreement.
- If events for the resource_external_id are not of type AGREEMENT, Ledger still considers them and attempts to project events which cause an exception (`java.lang.RuntimeException: No salient event found for event digest for agreement with external ID`). This is because agreement status cannot be derived from these events
- So filtering events by resource type AGREEMENT as well. If no events exist, it will result in 404 which is expected
- Refactored `EventMessageHandler.processSingleMessage` method to extract publishing to SNS functionality as the method is getting complex.