### PR TITLE
PP-10520 persist cancelled agreement info

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -118,21 +118,21 @@
         "filename": "openapi/ledger_spec.yaml",
         "hashed_secret": "cbbaa15cf3814df641e9ee9cb279046f93f322eb",
         "is_verified": false,
-        "line_number": 1206
+        "line_number": 1211
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/ledger_spec.yaml",
         "hashed_secret": "9baeb3f7db14ddab5d172149762035c0c022d76d",
         "is_verified": false,
-        "line_number": 1587
+        "line_number": 1592
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/ledger_spec.yaml",
         "hashed_secret": "920734ed7628ef47739eed5571412e2c8271790f",
         "is_verified": false,
-        "line_number": 1661
+        "line_number": 1666
       }
     ],
     "src/main/java/uk/gov/pay/ledger/event/model/Event.java": [
@@ -163,5 +163,5 @@
       }
     ]
   },
-  "generated_at": "2023-05-24T12:04:39Z"
+  "generated_at": "2023-06-13T15:54:12Z"
 }

--- a/openapi/ledger_spec.yaml
+++ b/openapi/ledger_spec.yaml
@@ -1037,6 +1037,11 @@ components:
     Agreement:
       type: object
       properties:
+        cancelled_by_user_email:
+          type: string
+        cancelled_date:
+          type: string
+          format: date-time
         created_date:
           type: string
           format: date-time

--- a/pom.xml
+++ b/pom.xml
@@ -262,6 +262,12 @@
             <version>${swaggger-version}</version>
             <scope>compile</scope>
         </dependency>
+        <dependency>
+            <groupId>org.exparity</groupId>
+            <artifactId>hamcrest-date</artifactId>
+            <version>2.0.8</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/uk/gov/pay/ledger/agreement/dao/AgreementDao.java
+++ b/src/main/java/uk/gov/pay/ledger/agreement/dao/AgreementDao.java
@@ -53,7 +53,9 @@ public class AgreementDao {
             "status," +
             "created_date," +
             "event_count," +
-            "user_identifier" +
+            "user_identifier," +
+            "cancelled_date," +
+            "cancelled_by_user_email" +
             ") " +
             "VALUES (" +
             ":externalId, " +
@@ -65,7 +67,9 @@ public class AgreementDao {
             ":status, " +
             ":createdDate, " +
             ":eventCount," +
-            ":userIdentifier" +
+            ":userIdentifier," +
+            ":cancelledDate," +
+            ":cancelledByUserEmail" +
             ") " +
             "ON CONFLICT (external_id) DO UPDATE SET " +
             "external_id = EXCLUDED.external_id, " +
@@ -77,7 +81,9 @@ public class AgreementDao {
             "status = EXCLUDED.status, " +
             "created_date = EXCLUDED.created_date, " +
             "event_count = EXCLUDED.event_count," +
-            "user_identifier = EXCLUDED.user_identifier " +
+            "user_identifier = EXCLUDED.user_identifier, " +
+            "cancelled_date = EXCLUDED.cancelled_date," +
+            "cancelled_by_user_email = EXCLUDED.cancelled_by_user_email " +
             "WHERE EXCLUDED.event_count >= agreement.event_count";
 
     private static final String SEARCH_AGREEMENT =
@@ -85,7 +91,7 @@ public class AgreementDao {
                     ":searchExtraFields " +
                     "ORDER BY a.created_date DESC OFFSET :offset LIMIT :limit";
 
-    private static final String COUNT_AGREEEMENT = "SELECT count(1) " +
+    private static final String COUNT_AGREEMENT = "SELECT count(1) " +
             "FROM agreement a " +
             ":searchExtraFields";
 
@@ -139,7 +145,7 @@ public class AgreementDao {
 
     public Long getTotalForSearch(AgreementSearchParams searchParams) {
         return jdbi.withHandle(handle -> {
-            Query query = handle.createQuery(createSearchTemplate(searchParams.getFilterTemplates(), COUNT_AGREEEMENT));
+            Query query = handle.createQuery(createSearchTemplate(searchParams.getFilterTemplates(), COUNT_AGREEMENT));
             searchParams.getQueryMap().forEach(bindSearchParameter(query));
             return query
                     .mapTo(Long.class)

--- a/src/main/java/uk/gov/pay/ledger/agreement/dao/AgreementMapper.java
+++ b/src/main/java/uk/gov/pay/ledger/agreement/dao/AgreementMapper.java
@@ -57,6 +57,8 @@ public class AgreementMapper implements RowMapper<AgreementEntity> {
                 ZonedDateTime.ofInstant(resultSet.getTimestamp("created_date").toInstant(), ZoneOffset.UTC),
                 resultSet.getInt("event_count"),
                 paymentInstrument,
-                resultSet.getString("user_identifier"));
+                resultSet.getString("user_identifier"),
+                resultSet.getTimestamp("cancelled_date") == null ? null : ZonedDateTime.ofInstant(resultSet.getTimestamp("created_date").toInstant(), ZoneOffset.UTC),
+                resultSet.getString("cancelled_by_user_email"));
     }
 }

--- a/src/main/java/uk/gov/pay/ledger/agreement/entity/AgreementEntity.java
+++ b/src/main/java/uk/gov/pay/ledger/agreement/entity/AgreementEntity.java
@@ -2,7 +2,11 @@ package uk.gov.pay.ledger.agreement.entity;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import uk.gov.service.payments.commons.api.json.MicrosecondPrecisionDateTimeDeserializer;
+import uk.gov.service.payments.commons.api.json.MicrosecondPrecisionDateTimeSerializer;
 import uk.gov.service.payments.commons.model.agreement.AgreementStatus;
 
 import java.time.ZonedDateTime;
@@ -21,12 +25,20 @@ public class AgreementEntity {
     private Integer eventCount;
     private PaymentInstrumentEntity paymentInstrument;
     private String userIdentifier;
+    @JsonDeserialize(using = MicrosecondPrecisionDateTimeDeserializer.class)
+    @JsonSerialize(using = MicrosecondPrecisionDateTimeSerializer.class)
+    private ZonedDateTime cancelledDate;
+
+    private String cancelledByUserEmail;
 
     public AgreementEntity() {
 
     }
 
-    public AgreementEntity(String externalId, String gatewayAccountId, String serviceId, String reference, String description, AgreementStatus status, Boolean live, ZonedDateTime createdDate, Integer eventCount, PaymentInstrumentEntity paymentInstrument, String userIdentifier) {
+    public AgreementEntity(String externalId, String gatewayAccountId, String serviceId, String reference,
+                           String description, AgreementStatus status, Boolean live, ZonedDateTime createdDate,
+                           Integer eventCount, PaymentInstrumentEntity paymentInstrument, String userIdentifier,
+                           ZonedDateTime cancelledDate, String cancelledByUserEmail) {
         this.externalId = externalId;
         this.gatewayAccountId = gatewayAccountId;
         this.serviceId = serviceId;
@@ -38,6 +50,8 @@ public class AgreementEntity {
         this.eventCount = eventCount;
         this.paymentInstrument = paymentInstrument;
         this.userIdentifier = userIdentifier;
+        this.cancelledDate = cancelledDate;
+        this.cancelledByUserEmail = cancelledByUserEmail;
     }
 
     public String getExternalId() {
@@ -126,5 +140,21 @@ public class AgreementEntity {
 
     public void setUserIdentifier(String userIdentifier) {
         this.userIdentifier = userIdentifier;
+    }
+
+    public ZonedDateTime getCancelledDate() {
+        return cancelledDate;
+    }
+
+    public String getCancelledByUserEmail() {
+        return cancelledByUserEmail;
+    }
+
+    public void setCancelledDate(ZonedDateTime cancelledDate) {
+        this.cancelledDate = cancelledDate;
+    }
+
+    public void setCancelledByUserEmail(String cancelledByUserEmail) {
+        this.cancelledByUserEmail = cancelledByUserEmail;
     }
 }

--- a/src/main/java/uk/gov/pay/ledger/agreement/entity/AgreementsFactory.java
+++ b/src/main/java/uk/gov/pay/ledger/agreement/entity/AgreementsFactory.java
@@ -35,6 +35,20 @@ public class AgreementsFactory {
         entity.setLive(eventDigest.isLive());
         entity.setEventCount(eventDigest.getEventCount());
         entity.setStatus(getStatus(eventDigest, eventDigest.getResourceExternalId()));
+        eventDigest.getLatestSalientEventType()
+                .ifPresent(salientEventType -> {
+                    if (salientEventType == SalientEventType.AGREEMENT_CANCELLED_BY_USER) {
+                        entity.setCancelledByUserEmail(eventDigest.getEventAggregate().get("user_email").toString());
+                        entity.setCancelledDate(eventDigest.getMostRecentEventTimestamp());
+                    } else if (salientEventType == SalientEventType.AGREEMENT_CANCELLED_BY_SERVICE) {
+                        entity.setCancelledByUserEmail(null);
+                        entity.setCancelledDate(eventDigest.getMostRecentEventTimestamp());
+                    } else {
+                        entity.setCancelledByUserEmail(null);
+                        entity.setCancelledDate(null);
+                    }
+                });
+
         return entity;
     }
 

--- a/src/main/java/uk/gov/pay/ledger/agreement/model/Agreement.java
+++ b/src/main/java/uk/gov/pay/ledger/agreement/model/Agreement.java
@@ -22,8 +22,14 @@ public class Agreement {
     private ZonedDateTime createdDate;
     private PaymentInstrument paymentInstrument;
     private String userIdentifier;
+    @JsonSerialize(using = ApiResponseDateTimeSerializer.class)
+    private ZonedDateTime cancelledDate;
+    private String cancelledByUserEmail;
 
-    public Agreement(String externalId, String serviceId, String reference, String description, AgreementStatus status, Boolean live, ZonedDateTime createdDate, PaymentInstrument paymentInstrument, String userIdentifier) {
+    public Agreement(String externalId, String serviceId, String reference, String description,
+                     AgreementStatus status, Boolean live, ZonedDateTime createdDate,
+                     PaymentInstrument paymentInstrument, String userIdentifier,
+                     ZonedDateTime cancelledDate, String cancelledByUserEmail) {
         this.externalId = externalId;
         this.serviceId = serviceId;
         this.reference = reference;
@@ -33,6 +39,8 @@ public class Agreement {
         this.createdDate = createdDate;
         this.paymentInstrument = paymentInstrument;
         this.userIdentifier = userIdentifier;
+        this.cancelledDate = cancelledDate;
+        this.cancelledByUserEmail = cancelledByUserEmail;
     }
 
     public static Agreement from(AgreementEntity entity) {
@@ -45,7 +53,9 @@ public class Agreement {
                 entity.getLive(),
                 entity.getCreatedDate(),
                 Optional.ofNullable(entity.getPaymentInstrument()).map(PaymentInstrument::from).orElse(null),
-                entity.getUserIdentifier());
+                entity.getUserIdentifier(),
+                entity.getCancelledDate(),
+                entity.getCancelledByUserEmail());
     }
 
     public String getExternalId() {
@@ -82,5 +92,13 @@ public class Agreement {
 
     public String getUserIdentifier() {
         return userIdentifier;
+    }
+
+    public ZonedDateTime getCancelledDate() {
+        return cancelledDate;
+    }
+
+    public String getCancelledByUserEmail() {
+        return cancelledByUserEmail;
     }
 }

--- a/src/main/java/uk/gov/pay/ledger/event/model/EventDigest.java
+++ b/src/main/java/uk/gov/pay/ledger/event/model/EventDigest.java
@@ -25,6 +25,7 @@ public class EventDigest {
     private Integer eventCount;
     private Map<String, Object> eventAggregate;
     private final ZonedDateTime eventCreatedDate;
+    private final SalientEventType latestSalientEventType;
 
     private EventDigest(
             String serviceId,
@@ -36,8 +37,8 @@ public class EventDigest {
             String parentResourceExternalId,
             Integer eventCount,
             Map<String, Object> eventAggregate,
-            ZonedDateTime eventCreatedDate
-    ) {
+            ZonedDateTime eventCreatedDate,
+            SalientEventType latestSalientEventType) {
         this.serviceId = serviceId;
         this.live = live;
         this.mostRecentEventTimestamp = mostRecentEventTimestamp;
@@ -48,6 +49,7 @@ public class EventDigest {
         this.eventCount = eventCount;
         this.eventAggregate = eventAggregate;
         this.eventCreatedDate = eventCreatedDate;
+        this.latestSalientEventType = latestSalientEventType;
     }
 
     public static EventDigest fromEventList(List<EventEntity> events) {
@@ -88,7 +90,8 @@ public class EventDigest {
                 parentResourceExternalId,
                 events.size(),
                 eventPayload,
-                earliestDate
+                earliestDate,
+                latestSalientEventType
         );
     }
 
@@ -154,5 +157,9 @@ public class EventDigest {
 
     public ZonedDateTime getEventCreatedDate() {
         return eventCreatedDate;
+    }
+
+    public Optional<SalientEventType> getLatestSalientEventType() {
+        return Optional.ofNullable(latestSalientEventType);
     }
 }

--- a/src/test/java/uk/gov/pay/ledger/agreement/entity/AgreementsFactoryTest.java
+++ b/src/test/java/uk/gov/pay/ledger/agreement/entity/AgreementsFactoryTest.java
@@ -7,10 +7,13 @@ import uk.gov.pay.ledger.event.model.EventDigest;
 import uk.gov.pay.ledger.event.model.ResourceType;
 import uk.gov.service.payments.commons.model.agreement.AgreementStatus;
 
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Map;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static uk.gov.pay.ledger.util.fixture.QueuePaymentEventFixture.aQueuePaymentEventFixture;
 
@@ -89,5 +92,142 @@ class AgreementsFactoryTest {
         assertThat(entity.getCreatedDate(), is(event.getEventDate()));
         assertThat(entity.getEventCount(), is(1));
         assertThat(entity.getStatus(), is(AgreementStatus.INACTIVE));
+    }
+
+    @Test
+    public void shouldConvertCancelledEventDigestToAgreementEntity() {
+        ZonedDateTime now = ZonedDateTime.now(ZoneOffset.UTC);
+        var event = aQueuePaymentEventFixture()
+                .withEventType("AGREEMENT_CANCELLED_BY_USER")
+                .withResourceType(ResourceType.AGREEMENT)
+                .withEventDate(now)
+                .withEventData(gsonBuilder.create()
+                        .toJson(Map.of(
+                                "reference", "agreement-reference",
+                                "description", "agreement description text",
+                                "user_identifier", "a-valid-user-identifier",
+                                "user_email", "jdoe@example.org",
+                                "cancelled_date", now.toString()
+                        ))
+                )
+                .toEntity();
+        var eventDigest = EventDigest.fromEventList(List.of(event));
+        var entity = agreementEntityFactory.create(eventDigest);
+
+        assertThat(entity.getServiceId(), is(event.getServiceId()));
+        assertThat(entity.getLive(), is(entity.getLive()));
+        assertThat(entity.getCreatedDate(), is(event.getEventDate()));
+        assertThat(entity.getEventCount(), is(1));
+        assertThat(entity.getReference(), is("agreement-reference"));
+        assertThat(entity.getDescription(), is("agreement description text"));
+        assertThat(entity.getUserIdentifier(), is("a-valid-user-identifier"));
+        assertThat(entity.getStatus(), is(AgreementStatus.CANCELLED));
+        assertThat(entity.getCancelledByUserEmail(), is("jdoe@example.org"));
+        assertThat(entity.getCancelledDate(), is(now));
+    }
+
+    @Test
+    public void shouldNotReturnUSerEmailIfNewerEventOverWritesIt() {
+        var now = ZonedDateTime.now(ZoneOffset.UTC).minusHours(2L);
+        var secondNow = ZonedDateTime.now(ZoneOffset.UTC);
+        var event1 = aQueuePaymentEventFixture()
+                .withEventType("AGREEMENT_CANCELLED_BY_USER")
+                .withResourceType(ResourceType.AGREEMENT)
+                .withEventDate(now)
+                .withEventData(gsonBuilder.create()
+                        .toJson(Map.of(
+                                "reference", "agreement-reference",
+                                "description", "agreement description text",
+                                "user_identifier", "a-valid-user-identifier",
+                                "user_email", "jdoe@example.org",
+                                "cancelled_date", now.toString()
+                        ))
+                )
+                .toEntity();
+        var event2 = aQueuePaymentEventFixture()
+                .withEventType("AGREEMENT_CANCELLED_BY_SERVICE")
+                .withResourceType(ResourceType.AGREEMENT)
+                .withEventDate(secondNow)
+                .withEventData(gsonBuilder.create()
+                        .toJson(Map.of(
+                                "reference", "agreement-reference",
+                                "description", "agreement description text",
+                                "user_identifier", "a-valid-user-identifier",
+                                "cancelled_date", secondNow.toString()
+                        ))
+                )
+                .toEntity();
+        var eventDigest = EventDigest.fromEventList(List.of(event2, event1));
+        var entity = agreementEntityFactory.create(eventDigest);
+
+        assertThat(entity.getServiceId(), is(event1.getServiceId()));
+        assertThat(entity.getLive(), is(entity.getLive()));
+        assertThat(entity.getCreatedDate(), is(event1.getEventDate()));
+        assertThat(entity.getEventCount(), is(2));
+        assertThat(entity.getReference(), is("agreement-reference"));
+        assertThat(entity.getDescription(), is("agreement description text"));
+        assertThat(entity.getUserIdentifier(), is("a-valid-user-identifier"));
+        assertThat(entity.getStatus(), is(AgreementStatus.CANCELLED));
+        assertThat(entity.getCancelledByUserEmail(), is(nullValue()));
+        assertThat(entity.getCancelledDate(), is(secondNow));
+    }
+
+    @Test
+    public void shouldOverwriteLatestCancelledStateByEventDigestWhenThereIsANewerEvent() {
+        var now = ZonedDateTime.now(ZoneOffset.UTC).minusHours(2L);
+        var secondNow = ZonedDateTime.now(ZoneOffset.UTC).minusHours(1L);
+        var thirdNow = ZonedDateTime.now(ZoneOffset.UTC);
+        var event1 = aQueuePaymentEventFixture()
+                .withEventType("AGREEMENT_CANCELLED_BY_USER")
+                .withResourceType(ResourceType.AGREEMENT)
+                .withEventDate(now)
+                .withEventData(gsonBuilder.create()
+                        .toJson(Map.of(
+                                "reference", "agreement-reference",
+                                "description", "agreement description text",
+                                "user_identifier", "a-valid-user-identifier",
+                                "user_email", "jdoe@example.org",
+                                "cancelled_date", now.toString()
+                        ))
+                )
+                .toEntity();
+        var event2 = aQueuePaymentEventFixture()
+                .withEventType("AGREEMENT_CANCELLED_BY_SERVICE")
+                .withResourceType(ResourceType.AGREEMENT)
+                .withEventDate(secondNow)
+                .withEventData(gsonBuilder.create()
+                        .toJson(Map.of(
+                                "reference", "agreement-reference",
+                                "description", "agreement description text",
+                                "user_identifier", "a-valid-user-identifier",
+                                "cancelled_date", secondNow.toString()
+                        ))
+                )
+                .toEntity();
+        var event3 = aQueuePaymentEventFixture()
+                .withEventType("AGREEMENT_CREATED")
+                .withResourceType(ResourceType.AGREEMENT)
+                .withEventDate(thirdNow)
+                .withEventData(gsonBuilder.create()
+                        .toJson(Map.of(
+                                "reference", "agreement-reference",
+                                "description", "agreement description text",
+                                "user_identifier", "a-valid-user-identifier"
+                        ))
+                )
+                .toEntity();
+        var eventDigest = EventDigest.fromEventList(List.of(event3, event2, event1));
+        var entity = agreementEntityFactory.create(eventDigest);
+
+        assertThat(entity.getServiceId(), is(event1.getServiceId()));
+        assertThat(entity.getLive(), is(entity.getLive()));
+        assertThat(entity.getCreatedDate(), is(event1.getEventDate()));
+        assertThat(entity.getEventCount(), is(3));
+        assertThat(entity.getReference(), is("agreement-reference"));
+        assertThat(entity.getDescription(), is("agreement description text"));
+        assertThat(entity.getUserIdentifier(), is("a-valid-user-identifier"));
+        assertThat(entity.getStatus(), is(AgreementStatus.CREATED));
+        assertThat(entity.getCancelledByUserEmail(), is(nullValue()));
+        assertThat(entity.getCancelledDate(), is(nullValue()));
     }
 }

--- a/src/test/java/uk/gov/pay/ledger/event/resource/EventResourceAgreementIT.java
+++ b/src/test/java/uk/gov/pay/ledger/event/resource/EventResourceAgreementIT.java
@@ -1,0 +1,88 @@
+package uk.gov.pay.ledger.event.resource;
+
+import org.exparity.hamcrest.date.ZonedDateTimeMatchers;
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import uk.gov.pay.ledger.agreement.dao.AgreementDao;
+import uk.gov.pay.ledger.agreement.entity.AgreementEntity;
+import uk.gov.pay.ledger.event.dao.EventDao;
+import uk.gov.pay.ledger.event.model.ResourceType;
+import uk.gov.pay.ledger.extension.AppWithPostgresAndSqsExtension;
+import uk.gov.pay.ledger.util.DatabaseTestHelper;
+import uk.gov.pay.ledger.util.fixture.EventFixture;
+
+import javax.ws.rs.core.Response;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.temporal.ChronoUnit;
+
+import static io.restassured.RestAssured.given;
+import static io.restassured.http.ContentType.JSON;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class EventResourceAgreementIT {
+
+    @RegisterExtension
+    public static AppWithPostgresAndSqsExtension rule = new AppWithPostgresAndSqsExtension();
+
+    private Integer port = rule.getAppRule().getLocalPort();
+
+    private DatabaseTestHelper databaseTestHelper;
+
+    private final EventDao eventDao = rule.getJdbi().onDemand(EventDao.class);
+    private final AgreementDao agreementDao = new AgreementDao(rule.getJdbi());
+
+    @BeforeEach
+    public void setUp() {
+        databaseTestHelper = DatabaseTestHelper.aDatabaseTestHelper(rule.getJdbi());
+        databaseTestHelper.truncateAllData();
+    }
+
+    @Test
+    public void shouldWriteCancelledEvent() {
+        var serviceId = "service-id";
+        var agreementId = "agreement-id";
+        var now = ZonedDateTime.now(ZoneOffset.UTC);
+
+        var agreementEvent = EventFixture.anEventFixture()
+                .withResourceExternalId(agreementId)
+                .withServiceId(serviceId)
+                .withResourceType(ResourceType.AGREEMENT)
+                .withEventType("CREATED")
+                .withEventData("{\"data\": \"Event 1\"}");
+        eventDao.insertEventWithResourceTypeId(agreementEvent.toEntity());
+
+        var params = new JSONArray();
+        var event = new JSONObject()
+                .put("event_type", "AGREEMENT_CANCELLED_BY_USER")
+                .put("service_id", serviceId)
+                .put("resource_type", "agreement")
+                .put("live", false)
+                .put("timestamp", now.toString())
+                .put("event_details", new JSONObject()
+                        .put("user_email", "jdoe@example.org")
+                        .put("cancelled_date", now.toString()))
+                .put("resource_external_id", agreementId);
+        params.put(event);
+
+        given().port(port)
+                .contentType(JSON)
+                .body(params.toString())
+                .post("/v1/event")
+                .then()
+                .statusCode(Response.Status.ACCEPTED.getStatusCode());
+
+        var results = databaseTestHelper.getEventsByExternalId(agreementId);
+        assertThat(results.size(), is(2));
+
+        var agreement = agreementDao.findByExternalId(agreementId);
+        assertThat(agreement.isPresent(), is(true));
+        AgreementEntity agreementEntity = agreement.get();
+        assertThat(agreementEntity.getCancelledByUserEmail(), is("jdoe@example.org"));
+        assertThat(agreementEntity.getCancelledDate(), is(ZonedDateTimeMatchers.within(1, ChronoUnit.SECONDS, now)));
+    }
+}

--- a/src/test/java/uk/gov/pay/ledger/util/fixture/AgreementFixture.java
+++ b/src/test/java/uk/gov/pay/ledger/util/fixture/AgreementFixture.java
@@ -23,6 +23,8 @@ public class AgreementFixture implements DbFixture<AgreementFixture, AgreementEn
     private ZonedDateTime createdDate = ZonedDateTime.now(ZoneOffset.UTC);
     private Integer eventCount = 1;
     private String userIdentifier;
+    private ZonedDateTime cancelledDate;
+    private String cancelledByUserEmail;
 
     private AgreementFixture() {
     }
@@ -97,12 +99,23 @@ public class AgreementFixture implements DbFixture<AgreementFixture, AgreementEn
         return this;
     }
 
+    public AgreementFixture withCancelledDate(ZonedDateTime cancelledDate) {
+        this.cancelledDate = cancelledDate;
+        return this;
+    }
+
+    public AgreementFixture withCancelledByUserEmail(String cancelledByUserEmail) {
+        this.cancelledByUserEmail = cancelledByUserEmail;
+        return this;
+    }
+
     @Override
     public AgreementFixture insert(Jdbi jdbi) {
         var sql = "INSERT INTO agreement" +
-                "(id, external_id, gateway_account_id, service_id, reference, description, status, live, created_date, event_count, user_identifier) " +
+                "(id, external_id, gateway_account_id, service_id, reference, description, status, live, created_date, " +
+                "event_count, user_identifier, cancelled_date, cancelled_by_user_email) " +
                 "VALUES " +
-                "(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
+                "(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
 
         jdbi.withHandle(h ->
                 h.execute(
@@ -117,7 +130,9 @@ public class AgreementFixture implements DbFixture<AgreementFixture, AgreementEn
                         live,
                         createdDate,
                         eventCount,
-                        userIdentifier
+                        userIdentifier,
+                        cancelledDate,
+                        cancelledByUserEmail
                 )
         );
         return this;
@@ -136,6 +151,8 @@ public class AgreementFixture implements DbFixture<AgreementFixture, AgreementEn
                 createdDate,
                 eventCount,
                 null,
-                userIdentifier);
+                userIdentifier,
+                cancelledDate,
+                cancelledByUserEmail);
     }
 }


### PR DESCRIPTION
- persist cancelled agreement event details (cancelled date, cancelled by user email (if applicable))
- refactor AgreementsFactory to set cancelled date and cancelled by date only if the latest salient event type is agreement cancelled
- refactor EventDigest to hold on to last SalientEventType
- add relevant tests