### PR TITLE
PP-11152 Update pact state

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -150,7 +150,7 @@
         "filename": "src/test/java/uk/gov/pay/ledger/pact/ContractTest.java",
         "hashed_secret": "fa143a7a660dac99bd4755c518d72306ad2df9d1",
         "is_verified": false,
-        "line_number": 774
+        "line_number": 776
       }
     ],
     "src/test/java/uk/gov/pay/ledger/rule/PostgresTestDocker.java": [
@@ -163,5 +163,5 @@
       }
     ]
   },
-  "generated_at": "2023-07-06T08:38:01Z"
+  "generated_at": "2023-07-14T13:58:17Z"
 }

--- a/src/test/java/uk/gov/pay/ledger/pact/ContractTest.java
+++ b/src/test/java/uk/gov/pay/ledger/pact/ContractTest.java
@@ -637,10 +637,12 @@ public abstract class ContractTest {
 
     @State("a recurring card payment exists for agreement")
     public void recurringCardPaymentExistsForAgreement(Map<String, String> params) {
+        String transactionExternalId = Optional.ofNullable(params.get("transaction_external_id")).orElse("transaction_123");
         String accountId = params.get("account_id");
         String agreementId = params.get("agreement_id");
 
         TransactionFixture.aTransactionFixture()
+                .withExternalId(transactionExternalId)
                 .withGatewayAccountId(accountId)
                 .withAgreementId(agreementId)
                 .withAuthorisationMode(AuthorisationMode.AGREEMENT)


### PR DESCRIPTION
Update Pact state that sets up recurring payments to set up a transaction with a particular external ID, extracted from the params specified by the Pact test.

This is so that we can add a Pact test to connector to get a single recurring payment transaction.