### PR TITLE
PP-11548: Initialise prom metrics without default sample builder

### DIFF
--- a/build-local.sh
+++ b/build-local.sh
@@ -5,4 +5,8 @@ set -e
 cd "$(dirname "$0")"
 
 mvn -DskipITs clean verify
-docker build -t govukpay/ledger:local .
+if [ "$(uname -m)" == "arm64" ]; then
+  docker build -t governmentdigitalservice/pay-ledger:local -f m1/arm64.Dockerfile .
+else
+  docker build -t governmentdigitalservice/pay-ledger:local .
+fi


### PR DESCRIPTION
# What?
Now we don't need to build our default labels in the app (since they are now added by the sidecar) we should remove the default sample builder.

1. Remove default sample builder
2. Update local build script to account for m1 macs, and use the correct container tag

# How?

This change has already been rolled out to connector and is working well.
