### PR TITLE
PP-11232 Add method to redact PII from transaction

### DIFF
--- a/src/main/java/uk/gov/pay/ledger/util/JsonParser.java
+++ b/src/main/java/uk/gov/pay/ledger/util/JsonParser.java
@@ -4,8 +4,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import java.io.IOException;
-import java.time.Instant;
-import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.Map;
 import java.util.Optional;


### PR DESCRIPTION
## WHAT
- Added a new DAO method to redact PII (personally identifiable information) from transactions
- Uses JSONB_SET with `false` as the last arg (`create_missing` - default is true) to replace PII from the transaction_details JSON blob.
    - can't replace multiple fields at once so using nested JSONB_SET for multiple columns.
- Removed fields `reference, cardholder_name, email` from transaction_details JSON as these are not used anywhere and are also top-level DB columns. So having them in transaction_details as `<REDACTED>` doesn't add any value

- Note: `<REDACTED>` string is not finalised and may be updated later. So some other fields first/last digits card number