### PR TITLE
PP-11232 Add TransactionRedactionInfo table

### DIFF
--- a/src/main/java/uk/gov/pay/ledger/event/entity/EventEntity.java
+++ b/src/main/java/uk/gov/pay/ledger/event/entity/EventEntity.java
@@ -3,10 +3,7 @@ package uk.gov.pay.ledger.event.entity;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import io.swagger.v3.oas.annotations.media.Schema;
 import uk.gov.pay.ledger.event.model.ResourceType;
-import uk.gov.service.payments.commons.api.json.MicrosecondPrecisionDateTimeSerializer;
 
 import java.time.ZonedDateTime;
 import java.util.Objects;

--- a/src/main/resources/migrations/00078_add_transaction_redaction_info_table.sql
+++ b/src/main/resources/migrations/00078_add_transaction_redaction_info_table.sql
@@ -1,0 +1,8 @@
+--liquibase formatted sql
+
+--changeset uk.gov.pay:create_table_transaction_redaction_info
+CREATE TABLE transaction_redaction_info (
+    last_processed_transaction_created_date TIMESTAMP WITH TIME ZONE
+);
+
+--rollback drop table transaction_redaction_info;


### PR DESCRIPTION
## WHAT
- Added a new table to record the created_date of the last transaction redacted for PII. The date recorded in this table will be used to select transactions to redact between a date range (on created_date which is indexed). 
- Without this, we may have to create another index based on reference (to filter out REDACTED records) and created_date (to select the next batch to redact) which is expensive.