### PR TITLE
PP-11232 Add TransactionDAO method

### DIFF
--- a/src/main/java/uk/gov/pay/ledger/transaction/dao/TransactionDao.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/dao/TransactionDao.java
@@ -441,4 +441,13 @@ public class TransactionDao {
                 .collect(Collectors.toList()));
     }
 
+    public Optional<ZonedDateTime> getCreatedDateOfFirstTransaction() {
+        String query = "select min(created_date) from transaction";
+
+        return jdbi.withHandle(handle ->
+                handle.createQuery(query)
+                        .mapTo(ZonedDateTime.class)
+                        .findFirst()
+        );
+    }
 }


### PR DESCRIPTION
## WHAT
- Added method to find the created_date of first transaction. This will be used by the expunge/redact job (on the first run)  to find transactions between first transaction date and 7 years for redaction. On subsequent runs, job uses created date of last processed transaction.