### PR TITLE
PP-11232 Update service to redact PII from transactions

### DIFF
--- a/src/main/java/uk/gov/pay/ledger/expungeorredact/service/ExpungeOrRedactService.java
+++ b/src/main/java/uk/gov/pay/ledger/expungeorredact/service/ExpungeOrRedactService.java
@@ -6,16 +6,33 @@ import org.slf4j.LoggerFactory;
 import uk.gov.pay.ledger.app.LedgerConfig;
 import uk.gov.pay.ledger.app.config.ExpungeOrRedactHistoricalDataConfig;
 import uk.gov.pay.ledger.event.dao.EventDao;
+import uk.gov.pay.ledger.expungeorredact.dao.TransactionRedactionInfoDao;
 import uk.gov.pay.ledger.transaction.dao.TransactionDao;
+import uk.gov.pay.ledger.transaction.entity.TransactionEntity;
 
 import javax.inject.Inject;
+import java.time.Clock;
+import java.time.ZonedDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static java.lang.Math.min;
+import static java.time.ZoneOffset.UTC;
+import static java.util.Optional.ofNullable;
+import static net.logstash.logback.argument.StructuredArguments.kv;
+import static uk.gov.service.payments.logging.LoggingKeys.RESOURCE_EXTERNAL_ID;
 
 public class ExpungeOrRedactService {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ExpungeOrRedactService.class);
+    private final TransactionRedactionInfoDao transactionRedactionInfoDao;
     private final ExpungeOrRedactHistoricalDataConfig expungeOrRedactHistoricalDataConfig;
-    private TransactionDao transactionDao;
-    private EventDao eventDao;
+    private final Clock clock;
+    private final TransactionDao transactionDao;
+    private final EventDao eventDao;
+
+    private static final int PAGE_SIZE = 500;
 
     private static final Histogram duration = Histogram.build()
             .name("expunge_and_redact_historical_data_job_duration_seconds")
@@ -23,16 +40,23 @@ public class ExpungeOrRedactService {
             .register();
 
     @Inject
-    public ExpungeOrRedactService(TransactionDao transactionDao, EventDao eventDao, LedgerConfig ledgerConfig) {
+    public ExpungeOrRedactService(TransactionDao transactionDao, EventDao eventDao,
+                                  TransactionRedactionInfoDao transactionRedactionInfoDao,
+                                  LedgerConfig ledgerConfig,
+                                  Clock clock) {
         this.transactionDao = transactionDao;
         this.eventDao = eventDao;
+        this.transactionRedactionInfoDao = transactionRedactionInfoDao;
         this.expungeOrRedactHistoricalDataConfig = ledgerConfig.getExpungeOrRedactHistoricalDataConfig();
+        this.clock = clock;
     }
 
     public void redactOrDeleteData() {
         Histogram.Timer responseTimeTimer = duration.startTimer();
         try {
-            if (!expungeOrRedactHistoricalDataConfig.isExpungeAndRedactHistoricalDataEnabled()) {
+            if (expungeOrRedactHistoricalDataConfig.isExpungeAndRedactHistoricalDataEnabled()) {
+                redactPIIFromTransactionsAndDeleteRelatedEvents();
+            } else {
                 LOGGER.info("Expunging and redacting historical data is not enabled");
             }
         } finally {
@@ -40,4 +64,70 @@ public class ExpungeOrRedactService {
         }
     }
 
+    private void redactPIIFromTransactionsAndDeleteRelatedEvents() {
+        int totalNoOfTransactionsToRedact = expungeOrRedactHistoricalDataConfig.getNoOfTransactionsToRedact();
+        ZonedDateTime createdDateOfLastProcessedTransaction = getCreatedDateOfLastProcessedTransaction();
+        ZonedDateTime redactTransactionsUpToDate = getRedactTransactionsUpToDate();
+
+        int noOfTxsProcessed = 0;
+        int noOfEventsDeleted = 0;
+
+        while (noOfTxsProcessed < totalNoOfTransactionsToRedact) {
+            int remainingNoOfTransactions = totalNoOfTransactionsToRedact - noOfTxsProcessed;
+            int noOfTxsToFetch = min(remainingNoOfTransactions, PAGE_SIZE);
+
+            List<TransactionEntity> transactionsForRedaction = transactionDao.findTransactionsForRedaction(
+                    createdDateOfLastProcessedTransaction, redactTransactionsUpToDate, noOfTxsToFetch);
+
+            if (transactionsForRedaction.isEmpty()) {
+                break;
+            }
+
+            transactionsForRedaction.forEach(transactionEntity -> {
+                transactionDao.redactPIIFromTransaction(transactionEntity.getExternalId());
+                LOGGER.info("Redacted PII from transaction [{}]", kv(RESOURCE_EXTERNAL_ID, transactionEntity.getExternalId()));
+            });
+
+            List<String> transactionExternalIds = transactionsForRedaction
+                    .stream()
+                    .map(TransactionEntity::getExternalId)
+                    .collect(Collectors.toList());
+
+            noOfEventsDeleted += eventDao.deleteEventsForTransactions(transactionExternalIds);
+            noOfTxsProcessed += noOfTxsToFetch;
+
+            createdDateOfLastProcessedTransaction = transactionsForRedaction
+                    .stream().map(TransactionEntity::getCreatedDate)
+                    .max(ZonedDateTime::compareTo).get();
+        }
+
+        LOGGER.info("Redacted PII from transactions [{}, {}]",
+                kv("no_of_transactions_redacted", noOfTxsProcessed),
+                kv("no_of_events_deleted", noOfEventsDeleted));
+
+        if (noOfTxsProcessed > 0) {
+            transactionRedactionInfoDao.update(createdDateOfLastProcessedTransaction);
+        }
+    }
+
+    private ZonedDateTime getRedactTransactionsUpToDate() {
+        return clock.instant()
+                .minus(expungeOrRedactHistoricalDataConfig.getExpungeOrRedactDataOlderThanDays(), ChronoUnit.DAYS)
+                .atZone(UTC);
+    }
+
+    private ZonedDateTime getCreatedDateOfLastProcessedTransaction() {
+        return ofNullable(transactionRedactionInfoDao.getCreatedDateOfLastProcessedTransaction())
+                .orElseGet(this::getCreatedDateOfFirstTransaction)
+                .withZoneSameInstant(UTC);
+    }
+
+    private ZonedDateTime getCreatedDateOfFirstTransaction() {
+        ZonedDateTime dateOfFirstTransaction = transactionDao.getCreatedDateOfFirstTransaction()
+                .orElseGet(this::getRedactTransactionsUpToDate);
+
+        transactionRedactionInfoDao.insert(dateOfFirstTransaction);
+
+        return dateOfFirstTransaction;
+    }
 }

--- a/src/test/java/uk/gov/pay/ledger/expungeorredact/service/ExpungeOrRedactServiceTest.java
+++ b/src/test/java/uk/gov/pay/ledger/expungeorredact/service/ExpungeOrRedactServiceTest.java
@@ -16,19 +16,31 @@ import org.slf4j.LoggerFactory;
 import uk.gov.pay.ledger.app.LedgerConfig;
 import uk.gov.pay.ledger.app.config.ExpungeOrRedactHistoricalDataConfig;
 import uk.gov.pay.ledger.event.dao.EventDao;
+import uk.gov.pay.ledger.expungeorredact.dao.TransactionRedactionInfoDao;
 import uk.gov.pay.ledger.transaction.dao.TransactionDao;
+import uk.gov.pay.ledger.transaction.entity.TransactionEntity;
 
+import java.time.Clock;
+import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 
 import static ch.qos.logback.classic.Level.INFO;
+import static java.time.ZoneOffset.UTC;
+import static java.time.ZonedDateTime.parse;
+import static java.time.temporal.ChronoUnit.DAYS;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.core.Is.is;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
+import static uk.gov.pay.ledger.util.fixture.TransactionFixture.aTransactionFixture;
 
 @ExtendWith(MockitoExtension.class)
 class ExpungeOrRedactServiceTest {
@@ -37,6 +49,9 @@ class ExpungeOrRedactServiceTest {
     TransactionDao mockTransactionDao;
     @Mock
     EventDao mockEventDao;
+
+    @Mock
+    TransactionRedactionInfoDao mockTransactionRedactionInfoDao;
 
     @Mock
     LedgerConfig mockLedgerConfig;
@@ -53,10 +68,14 @@ class ExpungeOrRedactServiceTest {
 
     ExpungeOrRedactService expungeOrRedactService;
 
+    String SYSTEM_INSTANT = "2022-03-03T10:15:30Z";
+    Clock clock;
+
     @BeforeEach
     void setUp() {
+        clock = Clock.fixed(Instant.parse(SYSTEM_INSTANT), UTC);
         when(mockLedgerConfig.getExpungeOrRedactHistoricalDataConfig()).thenReturn(mockExpungeOrRedactHistoricalDataConfig);
-        expungeOrRedactService = new ExpungeOrRedactService(mockTransactionDao, mockEventDao, mockLedgerConfig);
+        expungeOrRedactService = new ExpungeOrRedactService(mockTransactionDao, mockEventDao, mockTransactionRedactionInfoDao, mockLedgerConfig, clock);
     }
 
     @Test
@@ -85,4 +104,88 @@ class ExpungeOrRedactServiceTest {
         Double duration = collectorRegistry.getSampleValue("expunge_and_redact_historical_data_job_duration_seconds_sum");
         assertThat(duration, greaterThan(initialDuration));
     }
+
+    @Test
+    void shouldNotRedactPIIFromTransactionsWhenNoTransactionsFound() {
+        when(mockExpungeOrRedactHistoricalDataConfig.isExpungeAndRedactHistoricalDataEnabled()).thenReturn(true);
+        when(mockExpungeOrRedactHistoricalDataConfig.getNoOfTransactionsToRedact()).thenReturn(100);
+        when(mockExpungeOrRedactHistoricalDataConfig.getExpungeOrRedactDataOlderThanDays()).thenReturn(1);
+
+        when(mockTransactionRedactionInfoDao.getCreatedDateOfLastProcessedTransaction()).thenReturn(parse("2020-01-01T10:15:30Z"));
+        when(mockTransactionDao.findTransactionsForRedaction(any(), any(), anyInt())).thenReturn(List.of());
+
+        expungeOrRedactService.redactOrDeleteData();
+
+        verify(mockTransactionDao).findTransactionsForRedaction(
+                parse("2020-01-01T10:15:30Z"),
+                parse(SYSTEM_INSTANT).minus(1, DAYS),
+                100);
+
+        verify(mockTransactionDao, never()).redactPIIFromTransaction(any());
+        verify(mockTransactionRedactionInfoDao).getCreatedDateOfLastProcessedTransaction();
+
+        verifyNoMoreInteractions(mockTransactionDao);
+        verifyNoMoreInteractions(mockTransactionRedactionInfoDao);
+        verifyNoInteractions(mockEventDao);
+    }
+
+    @Test
+    void shouldRedactPIIFromTransactionsAndDeleteEvents() {
+        when(mockExpungeOrRedactHistoricalDataConfig.isExpungeAndRedactHistoricalDataEnabled()).thenReturn(true);
+        when(mockExpungeOrRedactHistoricalDataConfig.getNoOfTransactionsToRedact()).thenReturn(100);
+        when(mockExpungeOrRedactHistoricalDataConfig.getExpungeOrRedactDataOlderThanDays()).thenReturn(1);
+
+        when(mockTransactionRedactionInfoDao.getCreatedDateOfLastProcessedTransaction()).thenReturn(parse("2020-01-01T10:15:30Z"));
+
+        TransactionEntity transactionEntity1 = aTransactionFixture().toEntity();
+        TransactionEntity transactionEntity2 = aTransactionFixture().toEntity();
+        when(mockTransactionDao.findTransactionsForRedaction(any(), any(), anyInt())).thenReturn(
+                List.of(transactionEntity1, transactionEntity2)
+        );
+
+        expungeOrRedactService.redactOrDeleteData();
+
+        verify(mockTransactionDao).findTransactionsForRedaction(
+                parse("2020-01-01T10:15:30Z"),
+                parse(SYSTEM_INSTANT).minus(1, DAYS),
+                100);
+
+        verify(mockTransactionDao, times(2)).redactPIIFromTransaction(any());
+        verify(mockEventDao).deleteEventsForTransactions(List.of(transactionEntity1.getExternalId(), transactionEntity2.getExternalId()));
+        verify(mockTransactionRedactionInfoDao).update(transactionEntity2.getCreatedDate());
+
+        verifyNoMoreInteractions(mockTransactionDao);
+        verifyNoMoreInteractions(mockTransactionRedactionInfoDao);
+    }
+
+    @Test
+    void shouldUseCreatedDateOfFirstTransactionWhenInfoIsNotAvailableInTransactionRedactionInfo() {
+        when(mockExpungeOrRedactHistoricalDataConfig.isExpungeAndRedactHistoricalDataEnabled()).thenReturn(true);
+        when(mockExpungeOrRedactHistoricalDataConfig.getNoOfTransactionsToRedact()).thenReturn(100);
+        when(mockExpungeOrRedactHistoricalDataConfig.getExpungeOrRedactDataOlderThanDays()).thenReturn(1);
+
+        when(mockTransactionRedactionInfoDao.getCreatedDateOfLastProcessedTransaction()).thenReturn(null);
+        when(mockTransactionDao.getCreatedDateOfFirstTransaction()).thenReturn(Optional.of(parse("2020-01-01T10:15:30Z")));
+
+        expungeOrRedactService.redactOrDeleteData();
+
+        verify(mockTransactionDao).getCreatedDateOfFirstTransaction();
+        verify(mockTransactionRedactionInfoDao).insert(parse("2020-01-01T10:15:30Z"));
+    }
+
+    @Test
+    void shouldUseTheDateDerivedBasedOnConfigForTheStartingIndexWhenNoTransactionsExists() {
+        when(mockExpungeOrRedactHistoricalDataConfig.isExpungeAndRedactHistoricalDataEnabled()).thenReturn(true);
+        when(mockExpungeOrRedactHistoricalDataConfig.getNoOfTransactionsToRedact()).thenReturn(100);
+        when(mockExpungeOrRedactHistoricalDataConfig.getExpungeOrRedactDataOlderThanDays()).thenReturn(1);
+
+        when(mockTransactionRedactionInfoDao.getCreatedDateOfLastProcessedTransaction()).thenReturn(null);
+        when(mockTransactionDao.getCreatedDateOfFirstTransaction()).thenReturn(Optional.ofNullable(null));
+
+        expungeOrRedactService.redactOrDeleteData();
+
+        verify(mockTransactionDao).getCreatedDateOfFirstTransaction();
+        verify(mockTransactionRedactionInfoDao).insert(parse("2022-03-02T10:15:30Z"));
+    }
+
 }


### PR DESCRIPTION
## WHAT
- Redacts PII from transactions and deletes related events
- redact PII.. method processes transactions for a date range
    - start date: created_date of last processed transaction. If not gets the first transaction created date. When there are no transactions, uses the derived date up to which transactions can be redacted based on config. 
    - end date: Date up to which transactions can be redacted. This is based on config (default is now() - 7 years)
- Uses the system clock provided so fixed dates can be used for testing