### PR TITLE
PP-11232 Redact transaction description and some improvements

### DIFF
--- a/src/main/java/uk/gov/pay/ledger/transaction/dao/TransactionDao.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/dao/TransactionDao.java
@@ -215,14 +215,15 @@ public class TransactionDao {
 
     private static final String REDACT_PII_FROM_TRANSACTIONS =
             "UPDATE transaction t " +
-                    "set reference = '<REDACTED>'," +
-                    "  cardholder_name = (case when cardholder_name IS NOT NULL then '<REDACTED>' end), " +
-                    "  email = (case when email IS NOT NULL then '<REDACTED>' end), " +
+                    "set reference = '<DELETED>'," +
+                    "  description = '<DELETED>', " +
+                    "  cardholder_name = (case when cardholder_name IS NOT NULL then '<DELETED>' end), " +
+                    "  email = (case when email IS NOT NULL then '<DELETED>' end), " +
                     "  transaction_details = JSONB_SET(" +
-                    "                              JSONB_SET(transaction_details, '{address_line1}','\"<REDACTED>\"', false), " +
-                    "                              '{address_line2}','\"<REDACTED>\"', false" +
+                    "                              JSONB_SET(transaction_details, '{address_line1}','\"<DELETED>\"', false), " +
+                    "                              '{address_line2}','\"<DELETED>\"', false" +
                     "                        )" +
-                    "                         -'{reference,cardholder_name,email}'::text[]" +
+                    "                         -'{reference,cardholder_name,email,description}'::text[]" +
                     " WHERE t.external_id = :externalId";
 
     private static final String GET_SOURCE_TYPE_ENUM_VALUES =

--- a/src/test/java/uk/gov/pay/ledger/expungeorredact/resource/ExpungeOrRedactResourceIT.java
+++ b/src/test/java/uk/gov/pay/ledger/expungeorredact/resource/ExpungeOrRedactResourceIT.java
@@ -135,9 +135,10 @@ class ExpungeOrRedactResourceIT {
         Arrays.stream(transactionEntities)
                 .forEach(transactionEntity -> {
                     Map<String, Object> transaction = databaseTestHelper.getTransaction(transactionEntity.getExternalId());
-                    assertThat(transaction.get("reference"), is("<REDACTED>"));
-                    assertThat(transaction.get("cardholder_name"), is("<REDACTED>"));
-                    assertThat(transaction.get("email"), is("<REDACTED>"));
+                    assertThat(transaction.get("reference"), is("<DELETED>"));
+                    assertThat(transaction.get("cardholder_name"), is("<DELETED>"));
+                    assertThat(transaction.get("email"), is("<DELETED>"));
+                    assertThat(transaction.get("description"), is("<DELETED>"));
 
                     List<Map<String, Object>> event = databaseTestHelper.getEventsByExternalId(transactionEntity.getExternalId());
                     assertThat(event.size(), is(0));


### PR DESCRIPTION
## WHAT
- Redacts `description` from transaction too as sometimes services use `name + dob` in this field
- Updated string to use to `<DELETED>` when redacting PII as finalised in the story
- Fixes calculation for the total no of transactions redacted and added `metrics`
- Removes {} as the `kv()`s are being added to the logline as well as additional key-value pairs and duplicating info.