### PR TITLE
PP-11232 Update search to find transactions to redact

### DIFF
--- a/src/main/java/uk/gov/pay/ledger/expungeorredact/service/ExpungeOrRedactService.java
+++ b/src/main/java/uk/gov/pay/ledger/expungeorredact/service/ExpungeOrRedactService.java
@@ -13,12 +13,12 @@ import uk.gov.pay.ledger.transaction.entity.TransactionEntity;
 import javax.inject.Inject;
 import java.time.Clock;
 import java.time.ZonedDateTime;
-import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.stream.Collectors;
 
 import static java.lang.Math.min;
 import static java.time.ZoneOffset.UTC;
+import static java.time.temporal.ChronoUnit.DAYS;
 import static java.util.Optional.ofNullable;
 import static net.logstash.logback.argument.StructuredArguments.kv;
 import static uk.gov.service.payments.logging.LoggingKeys.RESOURCE_EXTERNAL_ID;
@@ -110,6 +110,7 @@ public class ExpungeOrRedactService {
             createdDateOfLastProcessedTransaction = transactionsForRedaction
                     .stream().map(TransactionEntity::getCreatedDate)
                     .max(ZonedDateTime::compareTo).get();
+            transactionRedactionInfoDao.update(createdDateOfLastProcessedTransaction);
         }
 
         LOGGER.info("Completed redacting PII from transactions",
@@ -118,27 +119,24 @@ public class ExpungeOrRedactService {
 
         noOfTransactionsRedactedMetric.observe(noOfTxsProcessed);
         noOfEventsDeletedRedactedMetric.observe(noOfEventsDeleted);
-
-        if (noOfTxsProcessed > 0) {
-            transactionRedactionInfoDao.update(createdDateOfLastProcessedTransaction);
-        }
     }
 
     private ZonedDateTime getRedactTransactionsUpToDate() {
         return clock.instant()
-                .minus(expungeOrRedactHistoricalDataConfig.getExpungeOrRedactDataOlderThanDays(), ChronoUnit.DAYS)
+                .minus(expungeOrRedactHistoricalDataConfig.getExpungeOrRedactDataOlderThanDays(), DAYS)
                 .atZone(UTC);
     }
 
     private ZonedDateTime getCreatedDateOfLastProcessedTransaction() {
         return ofNullable(transactionRedactionInfoDao.getCreatedDateOfLastProcessedTransaction())
-                .orElseGet(this::getCreatedDateOfFirstTransaction)
+                .orElseGet(this::getDateBeforeCreatedDateOfFirstTransaction)
                 .withZoneSameInstant(UTC);
     }
 
-    private ZonedDateTime getCreatedDateOfFirstTransaction() {
+    private ZonedDateTime getDateBeforeCreatedDateOfFirstTransaction() {
         ZonedDateTime dateOfFirstTransaction = transactionDao.getCreatedDateOfFirstTransaction()
-                .orElseGet(this::getRedactTransactionsUpToDate);
+                .orElseGet(this::getRedactTransactionsUpToDate)
+                .minus(1, DAYS);
 
         transactionRedactionInfoDao.insert(dateOfFirstTransaction);
 

--- a/src/main/java/uk/gov/pay/ledger/expungeorredact/service/ExpungeOrRedactService.java
+++ b/src/main/java/uk/gov/pay/ledger/expungeorredact/service/ExpungeOrRedactService.java
@@ -129,11 +129,11 @@ public class ExpungeOrRedactService {
 
     private ZonedDateTime getCreatedDateOfLastProcessedTransaction() {
         return ofNullable(transactionRedactionInfoDao.getCreatedDateOfLastProcessedTransaction())
-                .orElseGet(this::getDateBeforeCreatedDateOfFirstTransaction)
+                .orElseGet(this::getDayBeforeCreatedDateOfFirstTransaction)
                 .withZoneSameInstant(UTC);
     }
 
-    private ZonedDateTime getDateBeforeCreatedDateOfFirstTransaction() {
+    private ZonedDateTime getDayBeforeCreatedDateOfFirstTransaction() {
         ZonedDateTime dateOfFirstTransaction = transactionDao.getCreatedDateOfFirstTransaction()
                 .orElseGet(this::getRedactTransactionsUpToDate)
                 .minus(1, DAYS);

--- a/src/main/java/uk/gov/pay/ledger/transaction/dao/TransactionDao.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/dao/TransactionDao.java
@@ -86,7 +86,7 @@ public class TransactionDao {
 
     private static final String SEARCH_TRANSACTIONS_FOR_REDACTION =
             "SELECT t.* FROM transaction t " +
-                    " WHERE t.created_date >= :dateOfLastProcessedTransaction AND t.created_date < :redactTransactionsUpToDate  " +
+                    " WHERE t.created_date > :dateOfLastProcessedTransaction AND t.created_date <= :redactTransactionsUpToDate  " +
                     "ORDER BY t.created_date ASC LIMIT :limit";
 
     private static final String COUNT_TRANSACTIONS = "SELECT count(:distinctClauseWhenSearchingByMetadataValue t.id) " +

--- a/src/test/java/uk/gov/pay/ledger/expungeorredact/service/ExpungeOrRedactServiceTest.java
+++ b/src/test/java/uk/gov/pay/ledger/expungeorredact/service/ExpungeOrRedactServiceTest.java
@@ -22,6 +22,8 @@ import uk.gov.pay.ledger.transaction.entity.TransactionEntity;
 
 import java.time.Clock;
 import java.time.Instant;
+import java.time.ZonedDateTime;
+import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Optional;
 
@@ -215,12 +217,13 @@ class ExpungeOrRedactServiceTest {
         when(mockExpungeOrRedactHistoricalDataConfig.getExpungeOrRedactDataOlderThanDays()).thenReturn(1);
 
         when(mockTransactionRedactionInfoDao.getCreatedDateOfLastProcessedTransaction()).thenReturn(null);
-        when(mockTransactionDao.getCreatedDateOfFirstTransaction()).thenReturn(Optional.of(parse("2020-01-01T10:15:30Z")));
+        ZonedDateTime dateOfFirstTransaction = parse("2020-01-01T10:15:30Z");
+        when(mockTransactionDao.getCreatedDateOfFirstTransaction()).thenReturn(Optional.of(dateOfFirstTransaction));
 
         expungeOrRedactService.redactOrDeleteData();
 
         verify(mockTransactionDao).getCreatedDateOfFirstTransaction();
-        verify(mockTransactionRedactionInfoDao).insert(parse("2020-01-01T10:15:30Z"));
+        verify(mockTransactionRedactionInfoDao).insert(dateOfFirstTransaction.minus(1, DAYS));
     }
 
     @Test
@@ -235,7 +238,7 @@ class ExpungeOrRedactServiceTest {
         expungeOrRedactService.redactOrDeleteData();
 
         verify(mockTransactionDao).getCreatedDateOfFirstTransaction();
-        verify(mockTransactionRedactionInfoDao).insert(parse("2022-03-02T10:15:30Z"));
+        verify(mockTransactionRedactionInfoDao).insert(parse("2022-03-01T10:15:30Z"));
     }
 
 }

--- a/src/test/java/uk/gov/pay/ledger/transaction/dao/TransactionDaoIT.java
+++ b/src/test/java/uk/gov/pay/ledger/transaction/dao/TransactionDaoIT.java
@@ -477,21 +477,21 @@ class TransactionDaoIT {
 
         @Test
         void shouldReturnTransactionsCorrectlyForDateRangesAndNumberOfTransactions() {
+            TransactionEntity transactionMatchingStartRangeOfSearchAndToExclude = aTransactionFixture()
+                    .withCreatedDate(parse("2015-12-31T00:00:00Z"))
+                    .insert(rule.getJdbi())
+                    .toEntity();
             TransactionEntity transactionToReturnToDelete1 = aTransactionFixture()
                     .withCreatedDate(parse("2016-01-01T00:00:00Z"))
                     .insert(rule.getJdbi())
                     .toEntity();
-            TransactionEntity transactionToReturnToDelete2 = aTransactionFixture()
-                    .withCreatedDate(parse("2016-01-01T01:00:00Z"))
-                    .insert(rule.getJdbi())
-                    .toEntity();
-            TransactionEntity transactionEligibleForSearchButNotReturnedDueToLimit = aTransactionFixture()
-                    .withCreatedDate(parse("2016-01-01T02:00:00Z"))
+            TransactionEntity transactionMatchingEndDateOfSearchAndToReturn = aTransactionFixture()
+                    .withCreatedDate(parse("2016-01-02T00:00:00Z"))
                     .insert(rule.getJdbi())
                     .toEntity();
 
             TransactionEntity transactionToExclude1 = aTransactionFixture()
-                    .withCreatedDate(parse("2016-01-02T00:00:00Z"))
+                    .withCreatedDate(parse("2016-01-02T00:00:01Z"))
                     .insert(rule.getJdbi())
                     .toEntity();
             TransactionEntity transactionToExclude2 = aTransactionFixture()
@@ -513,10 +513,10 @@ class TransactionDaoIT {
             assertThat(transactionsForRedaction.size(), is(2));
             assertThat(transactionIdsReturned, hasItems(
                     transactionToReturnToDelete1.getExternalId(),
-                    transactionToReturnToDelete2.getExternalId())
+                    transactionMatchingEndDateOfSearchAndToReturn.getExternalId())
             );
             assertThat(transactionIdsReturned, not(hasItems(
-                    transactionEligibleForSearchButNotReturnedDueToLimit.getExternalId(),
+                    transactionMatchingStartRangeOfSearchAndToExclude.getExternalId(),
                     transactionToExclude1.getExternalId(),
                     transactionToExclude2.getExternalId())
             ));


### PR DESCRIPTION
## WHAT
- Updated search conditions to find transactions for redaction. Removed `=` when matching with `dateOfLastProcessedTransaction` so transaction processed in the last run is excluded in the new run

- Updates `transaction_redaction_info` after every batch of transactions processed. This is so that if the task is stopped midway (possible with perf env) it can resume after the last batch of txs processed.