### PR TITLE
PP-11541 Add x_request_id to expunge resource

### DIFF
--- a/src/main/java/uk/gov/pay/ledger/expungeorredact/resource/ExpungeOrRedactResource.java
+++ b/src/main/java/uk/gov/pay/ledger/expungeorredact/resource/ExpungeOrRedactResource.java
@@ -5,12 +5,16 @@ import com.google.inject.Inject;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import org.slf4j.MDC;
 import uk.gov.pay.ledger.expungeorredact.service.ExpungeOrRedactService;
 
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.Response;
+import java.util.UUID;
+
+import static uk.gov.service.payments.logging.LoggingKeys.MDC_REQUEST_ID_KEY;
 
 @Path("/v1/tasks")
 @Produces("application/json")
@@ -34,7 +38,12 @@ public class ExpungeOrRedactResource {
             }
     )
     public Response expungeOrRedactData() {
+        String correlationId = MDC.get(MDC_REQUEST_ID_KEY) == null ? "ExpungeOrRedactResource-" + UUID.randomUUID() : MDC.get(MDC_REQUEST_ID_KEY);
+        MDC.put(MDC_REQUEST_ID_KEY, correlationId);
+
         expungeOrRedactService.redactOrDeleteData();
+
+        MDC.remove(MDC_REQUEST_ID_KEY);
         return Response.ok().build();
     }
 }


### PR DESCRIPTION
## WHAT
- Added `x_request_id` to MDC so that the request-id is attached to all log activity for the expunge task and we can correlate the same in logs.