### PR TITLE
PP-11569 Update metrics to Counter

### DIFF
--- a/src/main/java/uk/gov/pay/ledger/expungeorredact/service/ExpungeOrRedactService.java
+++ b/src/main/java/uk/gov/pay/ledger/expungeorredact/service/ExpungeOrRedactService.java
@@ -1,6 +1,6 @@
 package uk.gov.pay.ledger.expungeorredact.service;
 
-import io.prometheus.client.Gauge;
+import io.prometheus.client.Counter;
 import io.prometheus.client.Histogram;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -41,12 +41,12 @@ public class ExpungeOrRedactService {
             .unit("seconds")
             .register();
 
-    private static final Gauge noOfTransactionsRedactedMetric = Gauge.build()
+    private static final Counter noOfTransactionsRedactedMetric = Counter.build()
             .name("expunge_and_redact_historical_data_job_no_of_transactions_redacted")
             .help("Number of transactions redacted")
             .register();
 
-    private static final Gauge noOfEventsDeletedRedactedMetric = Gauge.build()
+    private static final Counter noOfEventsDeletedRedactedMetric = Counter.build()
             .name("expunge_and_redact_historical_data_job_no_of_transaction_events_deleted")
             .help("Number of transaction events deleted")
             .register();
@@ -118,8 +118,8 @@ public class ExpungeOrRedactService {
                 kv("no_of_transactions_redacted", noOfTxsProcessed),
                 kv("no_of_events_deleted", noOfEventsDeleted));
 
-        noOfTransactionsRedactedMetric.set(noOfTxsProcessed);
-        noOfEventsDeletedRedactedMetric.set(noOfEventsDeleted);
+        noOfTransactionsRedactedMetric.inc(noOfTxsProcessed);
+        noOfEventsDeletedRedactedMetric.inc(noOfEventsDeleted);
     }
 
     private ZonedDateTime getRedactTransactionsUpToDate() {

--- a/src/test/java/uk/gov/pay/ledger/expungeorredact/service/ExpungeOrRedactServiceTest.java
+++ b/src/test/java/uk/gov/pay/ledger/expungeorredact/service/ExpungeOrRedactServiceTest.java
@@ -23,7 +23,6 @@ import uk.gov.pay.ledger.transaction.entity.TransactionEntity;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.ZonedDateTime;
-import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Optional;
 
@@ -109,8 +108,8 @@ class ExpungeOrRedactServiceTest {
 
     @Test
     void shouldNotRedactPIIFromTransactionsWhenNoTransactionsFound() {
-        Double initialNoOfTxsRedactedMetric = Optional.ofNullable(collectorRegistry.getSampleValue("expunge_and_redact_historical_data_job_no_of_transactions_redacted")).orElse(0.0);
-        Double initialNoOfTxEventsRemovedMetric = Optional.ofNullable(collectorRegistry.getSampleValue("expunge_and_redact_historical_data_job_no_of_transaction_events_deleted")).orElse(0.0);
+        Double initialNoOfTxsRedactedMetric = Optional.ofNullable(collectorRegistry.getSampleValue("expunge_and_redact_historical_data_job_no_of_transactions_redacted_total")).orElse(0.0);
+        Double initialNoOfTxEventsRemovedMetric = Optional.ofNullable(collectorRegistry.getSampleValue("expunge_and_redact_historical_data_job_no_of_transaction_events_deleted_total")).orElse(0.0);
 
         when(mockExpungeOrRedactHistoricalDataConfig.isExpungeAndRedactHistoricalDataEnabled()).thenReturn(true);
         when(mockExpungeOrRedactHistoricalDataConfig.getNoOfTransactionsToRedact()).thenReturn(100);
@@ -133,17 +132,17 @@ class ExpungeOrRedactServiceTest {
         verifyNoMoreInteractions(mockTransactionRedactionInfoDao);
         verifyNoInteractions(mockEventDao);
 
-        Double noOfTxsRedactedMetric = Optional.ofNullable(collectorRegistry.getSampleValue("expunge_and_redact_historical_data_job_no_of_transactions_redacted")).orElse(0.0);
+        Double noOfTxsRedactedMetric = Optional.ofNullable(collectorRegistry.getSampleValue("expunge_and_redact_historical_data_job_no_of_transactions_redacted_total")).orElse(0.0);
         assertThat(noOfTxsRedactedMetric, is(initialNoOfTxsRedactedMetric));
 
-        Double noOfEventsDeletedMetric = Optional.ofNullable(collectorRegistry.getSampleValue("expunge_and_redact_historical_data_job_no_of_transaction_events_deleted")).orElse(0.0);
+        Double noOfEventsDeletedMetric = Optional.ofNullable(collectorRegistry.getSampleValue("expunge_and_redact_historical_data_job_no_of_transaction_events_deleted_total")).orElse(0.0);
         assertThat(noOfEventsDeletedMetric, is(initialNoOfTxEventsRemovedMetric));
     }
 
     @Test
     void shouldRedactPIIFromTransactionsAndDeleteEvents() {
-        Double initialNoOfTxsRedactedMetric = Optional.ofNullable(collectorRegistry.getSampleValue("expunge_and_redact_historical_data_job_no_of_transactions_redacted")).orElse(0.0);
-        Double initialNoOfTxEventsRemovedMetric = Optional.ofNullable(collectorRegistry.getSampleValue("expunge_and_redact_historical_data_job_no_of_transaction_events_deleted")).orElse(0.0);
+        Double initialNoOfTxsRedactedMetric = Optional.ofNullable(collectorRegistry.getSampleValue("expunge_and_redact_historical_data_job_no_of_transactions_redacted_total")).orElse(0.0);
+        Double initialNoOfTxEventsRemovedMetric = Optional.ofNullable(collectorRegistry.getSampleValue("expunge_and_redact_historical_data_job_no_of_transaction_events_deleted_total")).orElse(0.0);
 
         when(mockExpungeOrRedactHistoricalDataConfig.isExpungeAndRedactHistoricalDataEnabled()).thenReturn(true);
         when(mockExpungeOrRedactHistoricalDataConfig.getNoOfTransactionsToRedact()).thenReturn(100);
@@ -173,10 +172,10 @@ class ExpungeOrRedactServiceTest {
         verifyNoMoreInteractions(mockTransactionDao);
         verifyNoMoreInteractions(mockTransactionRedactionInfoDao);
 
-        Double noOfTxsRedactedMetric = collectorRegistry.getSampleValue("expunge_and_redact_historical_data_job_no_of_transactions_redacted");
+        Double noOfTxsRedactedMetric = collectorRegistry.getSampleValue("expunge_and_redact_historical_data_job_no_of_transactions_redacted_total");
         assertThat(noOfTxsRedactedMetric, is(initialNoOfTxsRedactedMetric + 2));
 
-        Double noOfEventsDeletedMetric = collectorRegistry.getSampleValue("expunge_and_redact_historical_data_job_no_of_transaction_events_deleted");
+        Double noOfEventsDeletedMetric = collectorRegistry.getSampleValue("expunge_and_redact_historical_data_job_no_of_transaction_events_deleted_total");
         assertThat(noOfEventsDeletedMetric, is(initialNoOfTxEventsRemovedMetric + 20));
     }
 


### PR DESCRIPTION
## WHAT
- Changed metrics for counts to Counter which can be useful for measuring the rate
- Histogram/guage doesn't show exact counts or rates as required. We can use logs for the exact number of txs/events processed for every job run.