### PR TITLE
bau: Ensure gateway account id query params are unique

### DIFF
--- a/src/main/java/uk/gov/pay/ledger/util/CommaDelimitedSetParameter.java
+++ b/src/main/java/uk/gov/pay/ledger/util/CommaDelimitedSetParameter.java
@@ -2,6 +2,7 @@ package uk.gov.pay.ledger.util;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 
 import static org.apache.commons.lang3.StringUtils.isBlank;
 
@@ -13,7 +14,7 @@ public class CommaDelimitedSetParameter {
         this.queryString = queryString;
         elements = isBlank(queryString)
                 ? new ArrayList<>()
-                : List.of(queryString.split(","));
+                : new ArrayList<>(Set.of(queryString.split(",")));
     }
 
     public boolean isNotEmpty() {

--- a/src/test/java/uk/gov/pay/ledger/payout/dao/PayoutDaoSearchIT.java
+++ b/src/test/java/uk/gov/pay/ledger/payout/dao/PayoutDaoSearchIT.java
@@ -1,10 +1,8 @@
 package uk.gov.pay.ledger.payout.dao;
 
-import io.dropwizard.testing.junit5.DropwizardExtensionsSupport;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import uk.gov.pay.ledger.extension.AppWithPostgresAndSqsExtension;
 import uk.gov.pay.ledger.payout.entity.PayoutEntity;

--- a/src/test/java/uk/gov/pay/ledger/transaction/resource/TransactionResourceSearchIT.java
+++ b/src/test/java/uk/gov/pay/ledger/transaction/resource/TransactionResourceSearchIT.java
@@ -393,7 +393,7 @@ public class TransactionResourceSearchIT {
         String targetGatewayAccountId2 = "456";
         String targetGatewayAccountId3 = "1337";
 
-        TransactionFixture targetPayment = aTransactionFixture()
+        aTransactionFixture()
                 .withTransactionType("PAYMENT")
                 .withState(TransactionState.SUBMITTED)
                 .withGatewayAccountId(targetGatewayAccountId)


### PR DESCRIPTION
Despite the class name, the fact that account ids might not be unique is bugging me 😂 Why didn't I make [getParameters return a Set](https://github.com/alphagov/pay-ledger/blob/master/src/main/java/uk/gov/pay/ledger/util/CommaDelimitedSetParameter.java#L27)? I tried, and it's [not worth the effort](https://github.com/alphagov/pay-ledger/pull/3119).