### PR TITLE
PP-12841 add new fields to EventTicker class

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -118,21 +118,21 @@
         "filename": "openapi/ledger_spec.yaml",
         "hashed_secret": "cbbaa15cf3814df641e9ee9cb279046f93f322eb",
         "is_verified": false,
-        "line_number": 1235
+        "line_number": 1243
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/ledger_spec.yaml",
         "hashed_secret": "9baeb3f7db14ddab5d172149762035c0c022d76d",
         "is_verified": false,
-        "line_number": 1621
+        "line_number": 1644
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/ledger_spec.yaml",
         "hashed_secret": "920734ed7628ef47739eed5571412e2c8271790f",
         "is_verified": false,
-        "line_number": 1695
+        "line_number": 1718
       }
     ],
     "src/main/java/uk/gov/pay/ledger/event/model/Event.java": [
@@ -163,5 +163,5 @@
       }
     ]
   },
-  "generated_at": "2023-11-27T11:45:04Z"
+  "generated_at": "2024-07-04T16:52:23Z"
 }

--- a/openapi/ledger_spec.yaml
+++ b/openapi/ledger_spec.yaml
@@ -243,6 +243,14 @@ paths:
         required: true
         schema:
           type: string
+      - description: event types to find
+        example: PAYMENT_CREATED
+        in: query
+        name: event_types
+        schema:
+          type: array
+          items:
+            type: string
       responses:
         "200":
           content:
@@ -260,7 +268,7 @@ paths:
           description: Missing query parameters
         "500":
           description: Invalid parameters or Downstream system error
-      summary: Get list of events between a date/time range
+      summary: Get list of events between a date/time range and event type
       tags:
       - Events
   /v1/payout:
@@ -1291,6 +1299,12 @@ components:
         gateway_account_id:
           type: string
           example: "1"
+        is_moto:
+          type: boolean
+          example: true
+        is_recurring:
+          type: boolean
+          example: true
         payment_provider:
           type: string
           example: sandbox
@@ -1309,9 +1323,18 @@ components:
           - dispute
           - payment_instrument
           example: payment
+        service_external_id:
+          type: string
+          example: HrMU7UgY7OUM8fgT2bZCTKzvKu
+        source:
+          type: string
+          example: CARD_API
         transaction_type:
           type: string
           example: PAYMENT
+        wallet_type:
+          type: string
+          example: APPLE_PAY
     ExternalTransactionState:
       type: object
       properties:

--- a/pom.xml
+++ b/pom.xml
@@ -81,6 +81,10 @@
             <artifactId>dropwizard-jdbi3</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.jdbi</groupId>
+            <artifactId>jdbi3-stringtemplate4</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.dropwizard</groupId>
             <artifactId>dropwizard-json-logging</artifactId>
         </dependency>

--- a/src/main/java/uk/gov/pay/ledger/event/dao/EventDao.java
+++ b/src/main/java/uk/gov/pay/ledger/event/dao/EventDao.java
@@ -1,10 +1,7 @@
 package uk.gov.pay.ledger.event.dao;
 
-import org.jdbi.v3.core.statement.DefinedAttributeTemplateEngine;
-import org.jdbi.v3.core.statement.TemplateEngine;
 import org.jdbi.v3.sqlobject.CreateSqlObject;
 import org.jdbi.v3.sqlobject.config.RegisterRowMapper;
-import org.jdbi.v3.sqlobject.config.UseTemplateEngine;
 import org.jdbi.v3.sqlobject.customizer.Bind;
 import org.jdbi.v3.sqlobject.customizer.BindBean;
 import org.jdbi.v3.sqlobject.customizer.BindList;
@@ -18,7 +15,6 @@ import uk.gov.pay.ledger.event.dao.mapper.EventMapper;
 import uk.gov.pay.ledger.event.dao.mapper.EventTickerMapper;
 import uk.gov.pay.ledger.event.entity.EventEntity;
 import uk.gov.pay.ledger.event.model.EventTicker;
-import uk.gov.pay.ledger.event.model.SalientEventType;
 
 import java.time.ZonedDateTime;
 import java.util.List;

--- a/src/main/java/uk/gov/pay/ledger/event/dao/EventDao.java
+++ b/src/main/java/uk/gov/pay/ledger/event/dao/EventDao.java
@@ -81,7 +81,8 @@ public interface EventDao {
     List<EventEntity> findEventsForExternalIds(@BindList("externalIds") Set<String> externalIds);
 
     @SqlQuery("SELECT e.id, e.event_type, e.resource_external_id, e.event_date, t.card_brand, t.amount, " +
-            "t.transaction_details->'payment_provider' as payment_provider, t.gateway_account_id, t.type " +
+            "t.transaction_details->>'wallet' as wallet_type, t.transaction_details->>'authorisation_mode' as authorisation_mode, " +
+            "t.transaction_details->>'payment_provider' as payment_provider, t.gateway_account_id, t.source, t.service_id, t.type, t.moto " +
             "FROM event e LEFT JOIN transaction t ON e.resource_external_id = t.external_id " +
             "WHERE (e.event_date between :fromDate AND :toDate) AND t.live ORDER BY e.event_date DESC")
     List<EventTicker> findEventsTickerFromDate(@Bind("fromDate") ZonedDateTime fromDate, @Bind("toDate") ZonedDateTime toDate);

--- a/src/main/java/uk/gov/pay/ledger/event/dao/mapper/EventTickerMapper.java
+++ b/src/main/java/uk/gov/pay/ledger/event/dao/mapper/EventTickerMapper.java
@@ -19,7 +19,7 @@ public class EventTickerMapper implements RowMapper<EventTicker> {
 
     @Override
     public EventTicker map(ResultSet resultSet, StatementContext statementContext) throws SQLException {
-        Boolean isRecurring = Objects.equals(resultSet.getString("authorisation_mode"), AGREEMENT.getName());
+        boolean isRecurring = Objects.equals(resultSet.getString("authorisation_mode"), AGREEMENT.getName());
         return new EventTicker(resultSet.getLong("id"),
                 ResourceType.valueOf(resultSet.getString("type").toUpperCase(Locale.UK)),
                 resultSet.getString("resource_external_id"),

--- a/src/main/java/uk/gov/pay/ledger/event/dao/mapper/EventTickerMapper.java
+++ b/src/main/java/uk/gov/pay/ledger/event/dao/mapper/EventTickerMapper.java
@@ -4,7 +4,6 @@ import org.jdbi.v3.core.mapper.RowMapper;
 import org.jdbi.v3.core.statement.StatementContext;
 import uk.gov.pay.ledger.event.model.EventTicker;
 import uk.gov.pay.ledger.event.model.ResourceType;
-import uk.gov.service.payments.commons.model.AuthorisationMode;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;

--- a/src/main/java/uk/gov/pay/ledger/event/dao/mapper/EventTickerMapper.java
+++ b/src/main/java/uk/gov/pay/ledger/event/dao/mapper/EventTickerMapper.java
@@ -4,17 +4,23 @@ import org.jdbi.v3.core.mapper.RowMapper;
 import org.jdbi.v3.core.statement.StatementContext;
 import uk.gov.pay.ledger.event.model.EventTicker;
 import uk.gov.pay.ledger.event.model.ResourceType;
+import uk.gov.service.payments.commons.model.AuthorisationMode;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.Locale;
+import java.util.Objects;
+
+import static uk.gov.service.payments.commons.model.AuthorisationMode.AGREEMENT;
+
 
 public class EventTickerMapper implements RowMapper<EventTicker> {
 
     @Override
     public EventTicker map(ResultSet resultSet, StatementContext statementContext) throws SQLException {
+        Boolean isRecurring = Objects.equals(resultSet.getString("authorisation_mode"), AGREEMENT.getName());
         return new EventTicker(resultSet.getLong("id"),
                 ResourceType.valueOf(resultSet.getString("type").toUpperCase(Locale.UK)),
                 resultSet.getString("resource_external_id"),
@@ -24,6 +30,12 @@ public class EventTickerMapper implements RowMapper<EventTicker> {
                 resultSet.getString("type"),
                 resultSet.getString("payment_provider"),
                 resultSet.getString("gateway_account_id"),
-                resultSet.getLong("amount"));
+                resultSet.getLong("amount"),
+                resultSet.getString("service_id"),
+                resultSet.getString("wallet_type"),
+                resultSet.getString("source"),
+                resultSet.getBoolean("moto"),
+                isRecurring
+        );
     }
 }

--- a/src/main/java/uk/gov/pay/ledger/event/model/EventTicker.java
+++ b/src/main/java/uk/gov/pay/ledger/event/model/EventTicker.java
@@ -34,11 +34,22 @@ public class EventTicker {
     private String gatewayAccountId;
     @Schema(example = "100")
     private Long amount;
+    @Schema(example = "HrMU7UgY7OUM8fgT2bZCTKzvKu")
+    private String serviceExternalId;
+    @Schema(example = "APPLE_PAY")
+    private String walletType;
+    @Schema(example = "CARD_API")
+    private String source;
+    @Schema(example = "true")
+    private Boolean isMoto;
+    @Schema(example = "true")
+    private Boolean isRecurring;
 
     public EventTicker() { }
 
     public EventTicker(Long id, ResourceType resourceType, String resourceExternalId,
-                       ZonedDateTime eventDate, String eventType, String cardBrand, String transactionType, String paymentProvider, String gatewayAccountId, Long amount) {
+                       ZonedDateTime eventDate, String eventType, String cardBrand, String transactionType, String paymentProvider, String gatewayAccountId, Long amount,
+                       String serviceExternalId, String walletType, String source, Boolean isMoto, Boolean isRecurring) {
         this.id = id;
         this.resourceType = resourceType;
         this.resourceExternalId = resourceExternalId;
@@ -49,6 +60,12 @@ public class EventTicker {
         this.paymentProvider = paymentProvider;
         this.gatewayAccountId = gatewayAccountId;
         this.amount = amount;
+        this.serviceExternalId = serviceExternalId;
+        this.walletType = walletType;
+        this.source = source;
+        this.isMoto = isMoto;
+        this.isRecurring = isRecurring;
+        
     }
 
     public Long getId() {
@@ -122,4 +139,14 @@ public class EventTicker {
     public Long getAmount() {
         return amount;
     }
+
+    public String getServiceExternalId() { return serviceExternalId; }
+
+    public String getWalletType() { return walletType; }
+
+    public String getSource() { return source; }
+    
+    public Boolean getIsMoto() { return isMoto; }
+    
+    public Boolean getIsRecurring() { return isRecurring; }
 }

--- a/src/main/java/uk/gov/pay/ledger/event/model/EventTicker.java
+++ b/src/main/java/uk/gov/pay/ledger/event/model/EventTicker.java
@@ -41,15 +41,15 @@ public class EventTicker {
     @Schema(example = "CARD_API")
     private String source;
     @Schema(example = "true")
-    private Boolean isMoto;
+    private boolean isMoto;
     @Schema(example = "true")
-    private Boolean isRecurring;
+    private boolean isRecurring;
 
     public EventTicker() { }
 
     public EventTicker(Long id, ResourceType resourceType, String resourceExternalId,
                        ZonedDateTime eventDate, String eventType, String cardBrand, String transactionType, String paymentProvider, String gatewayAccountId, Long amount,
-                       String serviceExternalId, String walletType, String source, Boolean isMoto, Boolean isRecurring) {
+                       String serviceExternalId, String walletType, String source, boolean isMoto, boolean isRecurring) {
         this.id = id;
         this.resourceType = resourceType;
         this.resourceExternalId = resourceExternalId;
@@ -146,7 +146,7 @@ public class EventTicker {
 
     public String getSource() { return source; }
     
-    public Boolean getIsMoto() { return isMoto; }
+    public boolean getIsMoto() { return isMoto; }
     
-    public Boolean getIsRecurring() { return isRecurring; }
+    public boolean getIsRecurring() { return isRecurring; }
 }

--- a/src/main/java/uk/gov/pay/ledger/event/resource/EventResource.java
+++ b/src/main/java/uk/gov/pay/ledger/event/resource/EventResource.java
@@ -13,7 +13,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.pay.ledger.event.dao.EventDao;
 import uk.gov.pay.ledger.event.model.EventTicker;
-import uk.gov.pay.ledger.event.model.SalientEventType;
 import uk.gov.pay.ledger.exception.ErrorResponse;
 import uk.gov.pay.ledger.queue.EventMessage;
 import uk.gov.pay.ledger.queue.EventMessageDto;
@@ -22,7 +21,6 @@ import uk.gov.service.payments.commons.queue.exception.QueueException;
 
 import javax.validation.Valid;
 import javax.validation.constraints.NotEmpty;
-import javax.ws.rs.DefaultValue;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
@@ -30,17 +28,11 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Response;
 import java.time.ZonedDateTime;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
-import java.util.Objects;
 import java.util.stream.Collectors;
 
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
-import static net.logstash.logback.argument.StructuredArguments.e;
 import static net.logstash.logback.argument.StructuredArguments.kv;
-import static uk.gov.pay.ledger.event.model.SalientEventType.USER_APPROVED_FOR_CAPTURE;
-import static uk.gov.pay.ledger.event.model.SalientEventType.USER_APPROVED_FOR_CAPTURE_AWAITING_SERVICE_APPROVAL;
 
 @Path("/v1/event")
 @Produces(APPLICATION_JSON)

--- a/src/test/java/uk/gov/pay/ledger/event/dao/EventDaoIT.java
+++ b/src/test/java/uk/gov/pay/ledger/event/dao/EventDaoIT.java
@@ -16,6 +16,7 @@ import uk.gov.service.payments.commons.model.AuthorisationMode;
 import java.io.IOException;
 import java.sql.Timestamp;
 import java.time.ZonedDateTime;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -276,17 +277,21 @@ class EventDaoIT {
         EventEntity event2 = anEventFixture()
                 .withResourceExternalId("external-id-1")
                 .withEventDate(event1.getEventDate().minusDays(1))
+                .withEventType("PAYMENT_CREATED")
                 .insert(rule.getJdbi())
                 .toEntity();
         anEventFixture()
                 .withResourceExternalId("external-id-1")
                 .withEventDate(event2.getEventDate().minusDays(1))
+                .withEventType("PAYMENT_CREATED")
                 .insert(rule.getJdbi())
                 .toEntity();
 
-        List<EventTicker> eventTickers = eventDao.findEventsTickerFromDate(
+        List<EventTicker> eventTickers = eventDao.findEventsTickerFromDateAndType(
                 event1.getEventDate().minusHours(1),
-                event1.getEventDate().plusHours(1)
+                event1.getEventDate().plusHours(1),
+                true,
+                List.of("PAYMENT_CREATED")
         );
         assertThat(eventTickers.size(), is(1));
         assertThat(eventTickers.get(0).getGatewayAccountId(), is("100"));

--- a/src/test/java/uk/gov/pay/ledger/event/dao/EventDaoIT.java
+++ b/src/test/java/uk/gov/pay/ledger/event/dao/EventDaoIT.java
@@ -16,7 +16,6 @@ import uk.gov.service.payments.commons.model.AuthorisationMode;
 import java.io.IOException;
 import java.sql.Timestamp;
 import java.time.ZonedDateTime;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;

--- a/src/test/java/uk/gov/pay/ledger/event/dao/EventDaoIT.java
+++ b/src/test/java/uk/gov/pay/ledger/event/dao/EventDaoIT.java
@@ -11,6 +11,7 @@ import uk.gov.pay.ledger.event.entity.EventEntity;
 import uk.gov.pay.ledger.event.model.EventTicker;
 import uk.gov.pay.ledger.extension.AppWithPostgresAndSqsExtension;
 import uk.gov.pay.ledger.util.DatabaseTestHelper;
+import uk.gov.service.payments.commons.model.AuthorisationMode;
 
 import java.io.IOException;
 import java.sql.Timestamp;
@@ -259,6 +260,11 @@ class EventDaoIT {
                 .withGatewayAccountId("100")
                 .withAmount(200L)
                 .withLive(true)
+                .withMoto(true)
+                .withSource("CARD_API")
+                .withAuthorisationMode(AuthorisationMode.AGREEMENT)
+                .withServiceId("service-id-event-ticker")
+                .withDefaultTransactionDetails()
                 .insert(rule.getJdbi())
                 .toEntity();
 
@@ -286,6 +292,12 @@ class EventDaoIT {
         assertThat(eventTickers.get(0).getGatewayAccountId(), is("100"));
         assertThat(eventTickers.get(0).getResourceExternalId(), is("external-id-1"));
         assertThat(eventTickers.get(0).getEventType(), is("PAYMENT_CREATED"));
+        assertThat(eventTickers.get(0).getServiceExternalId(), is("service-id-event-ticker"));
+        assertThat(eventTickers.get(0).getWalletType(), is("APPLE_PAY"));
+        assertThat(eventTickers.get(0).getPaymentProvider(), is("sandbox"));
+        assertThat(eventTickers.get(0).getSource(), is("CARD_API"));
+        assertThat(eventTickers.get(0).getIsMoto(), is(true));
+        assertThat(eventTickers.get(0).getIsRecurring(), is(true));
         assertThat(eventTickers.get(0).getAmount(), is(200L));
     }
 


### PR DESCRIPTION
### WHAT

add the following fields to the EventTicker class for consumption via the live payments dashboard:

- service_external_id
- wallet_type
- source
- is_moto
- is_recurring

add new query parameter to `/ticker` resource for filtering events by salient event type