### PR TITLE
PP-12830 remove spotify

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -294,12 +294,6 @@
             <artifactId>testing</artifactId>
             <version>${pay-java-commons.version}</version>
             <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>com.spotify</groupId>
-                    <artifactId>docker-client</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>

--- a/src/test/resources/logback.xml
+++ b/src/test/resources/logback.xml
@@ -1,7 +1,6 @@
 <configuration debug="false">
   <logger name="liquibase" level="WARN" />
   <logger name="org.apache.http" level="WARN" />
-  <logger name="com.spotify" level="WARN" />
   <logger name="uk.gov.pay." level="INFO" />
   <logger name="org.testcontainers" level="WARN" />
   <root level="WARN"/>


### PR DESCRIPTION
When we upgraded to Dropwizard 3, a few scattered code was left behind that refers to com.spotify.