### PR TITLE
PP-12789 upgrade to pay-java-commons

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <mainClass>uk.gov.pay.ledger.app.LedgerApp</mainClass>
-        <pay-java-commons.version>1.0.20240603094506</pay-java-commons.version>
+        <pay-java-commons.version>1.0.20240711152628</pay-java-commons.version>
         <prometheus.version>0.16.0</prometheus.version>
         <surefire.version>3.3.1</surefire.version>
         <swagger.version>2.2.22</swagger.version>

--- a/src/test/java/uk/gov/pay/ledger/pact/event/CancelledByUserEventQueueConsumerIT.java
+++ b/src/test/java/uk/gov/pay/ledger/pact/event/CancelledByUserEventQueueConsumerIT.java
@@ -1,10 +1,10 @@
 package uk.gov.pay.ledger.pact.event;
 
 import au.com.dius.pact.consumer.MessagePactBuilder;
-import au.com.dius.pact.consumer.MessagePactProviderRule;
-import au.com.dius.pact.consumer.Pact;
-import au.com.dius.pact.consumer.PactVerification;
-import au.com.dius.pact.model.v3.messaging.MessagePact;
+import au.com.dius.pact.consumer.junit.MessagePactProviderRule;
+import au.com.dius.pact.consumer.junit.PactVerification;
+import au.com.dius.pact.core.model.annotations.Pact;
+import au.com.dius.pact.core.model.messaging.MessagePact;
 import com.google.gson.Gson;
 import org.junit.Rule;
 import org.junit.Test;

--- a/src/test/java/uk/gov/pay/ledger/pact/event/CaptureConfirmedEventQueueConsumerIT.java
+++ b/src/test/java/uk/gov/pay/ledger/pact/event/CaptureConfirmedEventQueueConsumerIT.java
@@ -1,11 +1,11 @@
 package uk.gov.pay.ledger.pact.event;
 
 import au.com.dius.pact.consumer.MessagePactBuilder;
-import au.com.dius.pact.consumer.MessagePactProviderRule;
-import au.com.dius.pact.consumer.Pact;
-import au.com.dius.pact.consumer.PactVerification;
 import au.com.dius.pact.consumer.dsl.PactDslJsonBody;
-import au.com.dius.pact.model.v3.messaging.MessagePact;
+import au.com.dius.pact.consumer.junit.MessagePactProviderRule;
+import au.com.dius.pact.consumer.junit.PactVerification;
+import au.com.dius.pact.core.model.annotations.Pact;
+import au.com.dius.pact.core.model.messaging.MessagePact;
 import com.google.gson.Gson;
 import org.junit.Rule;
 import org.junit.Test;

--- a/src/test/java/uk/gov/pay/ledger/pact/event/CaptureSubmittedEventQueueConsumerIT.java
+++ b/src/test/java/uk/gov/pay/ledger/pact/event/CaptureSubmittedEventQueueConsumerIT.java
@@ -1,10 +1,10 @@
 package uk.gov.pay.ledger.pact.event;
 
 import au.com.dius.pact.consumer.MessagePactBuilder;
-import au.com.dius.pact.consumer.MessagePactProviderRule;
-import au.com.dius.pact.consumer.Pact;
-import au.com.dius.pact.consumer.PactVerification;
-import au.com.dius.pact.model.v3.messaging.MessagePact;
+import au.com.dius.pact.consumer.junit.MessagePactProviderRule;
+import au.com.dius.pact.consumer.junit.PactVerification;
+import au.com.dius.pact.core.model.annotations.Pact;
+import au.com.dius.pact.core.model.messaging.MessagePact;
 import com.google.gson.Gson;
 import org.junit.Rule;
 import org.junit.Test;

--- a/src/test/java/uk/gov/pay/ledger/pact/event/DisputeCreatedEventQueueConsumerIT.java
+++ b/src/test/java/uk/gov/pay/ledger/pact/event/DisputeCreatedEventQueueConsumerIT.java
@@ -1,10 +1,10 @@
 package uk.gov.pay.ledger.pact.event;
 
 import au.com.dius.pact.consumer.MessagePactBuilder;
-import au.com.dius.pact.consumer.MessagePactProviderRule;
-import au.com.dius.pact.consumer.Pact;
-import au.com.dius.pact.consumer.PactVerification;
-import au.com.dius.pact.model.v3.messaging.MessagePact;
+import au.com.dius.pact.consumer.junit.MessagePactProviderRule;
+import au.com.dius.pact.consumer.junit.PactVerification;
+import au.com.dius.pact.core.model.annotations.Pact;
+import au.com.dius.pact.core.model.messaging.MessagePact;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/src/test/java/uk/gov/pay/ledger/pact/event/DisputeEvidenceSubmittedEventQueueConsumerIT.java
+++ b/src/test/java/uk/gov/pay/ledger/pact/event/DisputeEvidenceSubmittedEventQueueConsumerIT.java
@@ -1,10 +1,10 @@
 package uk.gov.pay.ledger.pact.event;
 
 import au.com.dius.pact.consumer.MessagePactBuilder;
-import au.com.dius.pact.consumer.MessagePactProviderRule;
-import au.com.dius.pact.consumer.Pact;
-import au.com.dius.pact.consumer.PactVerification;
-import au.com.dius.pact.model.v3.messaging.MessagePact;
+import au.com.dius.pact.consumer.junit.MessagePactProviderRule;
+import au.com.dius.pact.consumer.junit.PactVerification;
+import au.com.dius.pact.core.model.annotations.Pact;
+import au.com.dius.pact.core.model.messaging.MessagePact;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/src/test/java/uk/gov/pay/ledger/pact/event/DisputeLostEventQueueConsumerIT.java
+++ b/src/test/java/uk/gov/pay/ledger/pact/event/DisputeLostEventQueueConsumerIT.java
@@ -1,10 +1,10 @@
 package uk.gov.pay.ledger.pact.event;
 
 import au.com.dius.pact.consumer.MessagePactBuilder;
-import au.com.dius.pact.consumer.MessagePactProviderRule;
-import au.com.dius.pact.consumer.Pact;
-import au.com.dius.pact.consumer.PactVerification;
-import au.com.dius.pact.model.v3.messaging.MessagePact;
+import au.com.dius.pact.consumer.junit.MessagePactProviderRule;
+import au.com.dius.pact.consumer.junit.PactVerification;
+import au.com.dius.pact.core.model.annotations.Pact;
+import au.com.dius.pact.core.model.messaging.MessagePact;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/src/test/java/uk/gov/pay/ledger/pact/event/DisputeWonEventQueueConsumerIT.java
+++ b/src/test/java/uk/gov/pay/ledger/pact/event/DisputeWonEventQueueConsumerIT.java
@@ -1,10 +1,10 @@
 package uk.gov.pay.ledger.pact.event;
 
 import au.com.dius.pact.consumer.MessagePactBuilder;
-import au.com.dius.pact.consumer.MessagePactProviderRule;
-import au.com.dius.pact.consumer.Pact;
-import au.com.dius.pact.consumer.PactVerification;
-import au.com.dius.pact.model.v3.messaging.MessagePact;
+import au.com.dius.pact.consumer.junit.MessagePactProviderRule;
+import au.com.dius.pact.consumer.junit.PactVerification;
+import au.com.dius.pact.core.model.annotations.Pact;
+import au.com.dius.pact.core.model.messaging.MessagePact;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/src/test/java/uk/gov/pay/ledger/pact/event/FeeIncurredEventQueueConsumerIT.java
+++ b/src/test/java/uk/gov/pay/ledger/pact/event/FeeIncurredEventQueueConsumerIT.java
@@ -1,16 +1,15 @@
 package uk.gov.pay.ledger.pact.event;
 
 import au.com.dius.pact.consumer.MessagePactBuilder;
-import au.com.dius.pact.consumer.MessagePactProviderRule;
-import au.com.dius.pact.consumer.Pact;
-import au.com.dius.pact.consumer.PactVerification;
-import au.com.dius.pact.model.v3.messaging.MessagePact;
+import au.com.dius.pact.consumer.junit.MessagePactProviderRule;
+import au.com.dius.pact.consumer.junit.PactVerification;
+import au.com.dius.pact.core.model.annotations.Pact;
+import au.com.dius.pact.core.model.messaging.MessagePact;
 import com.google.gson.GsonBuilder;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import uk.gov.pay.ledger.app.LedgerConfig;
-import uk.gov.pay.ledger.event.dao.EventDao;
 import uk.gov.pay.ledger.rule.AppWithPostgresAndSqsRule;
 import uk.gov.pay.ledger.rule.SqsTestDocker;
 import uk.gov.pay.ledger.transaction.dao.TransactionDao;

--- a/src/test/java/uk/gov/pay/ledger/pact/event/Gateway3dsExemptionResultObtainedEventQueueConsumerIT.java
+++ b/src/test/java/uk/gov/pay/ledger/pact/event/Gateway3dsExemptionResultObtainedEventQueueConsumerIT.java
@@ -1,10 +1,10 @@
 package uk.gov.pay.ledger.pact.event;
 
 import au.com.dius.pact.consumer.MessagePactBuilder;
-import au.com.dius.pact.consumer.MessagePactProviderRule;
-import au.com.dius.pact.consumer.Pact;
-import au.com.dius.pact.consumer.PactVerification;
-import au.com.dius.pact.model.v3.messaging.MessagePact;
+import au.com.dius.pact.consumer.junit.MessagePactProviderRule;
+import au.com.dius.pact.consumer.junit.PactVerification;
+import au.com.dius.pact.core.model.annotations.Pact;
+import au.com.dius.pact.core.model.messaging.MessagePact;
 import org.junit.Rule;
 import org.junit.Test;
 import uk.gov.pay.ledger.app.LedgerConfig;

--- a/src/test/java/uk/gov/pay/ledger/pact/event/Gateway3dsInfoObtainedEventQueueConsumerIT.java
+++ b/src/test/java/uk/gov/pay/ledger/pact/event/Gateway3dsInfoObtainedEventQueueConsumerIT.java
@@ -1,10 +1,10 @@
 package uk.gov.pay.ledger.pact.event;
 
 import au.com.dius.pact.consumer.MessagePactBuilder;
-import au.com.dius.pact.consumer.MessagePactProviderRule;
-import au.com.dius.pact.consumer.Pact;
-import au.com.dius.pact.consumer.PactVerification;
-import au.com.dius.pact.model.v3.messaging.MessagePact;
+import au.com.dius.pact.consumer.junit.MessagePactProviderRule;
+import au.com.dius.pact.consumer.junit.PactVerification;
+import au.com.dius.pact.core.model.annotations.Pact;
+import au.com.dius.pact.core.model.messaging.MessagePact;
 import org.junit.Rule;
 import org.junit.Test;
 import uk.gov.pay.ledger.app.LedgerConfig;

--- a/src/test/java/uk/gov/pay/ledger/pact/event/GatewayRequires3dsAuthorisationEventQueueConsumerIT.java
+++ b/src/test/java/uk/gov/pay/ledger/pact/event/GatewayRequires3dsAuthorisationEventQueueConsumerIT.java
@@ -1,10 +1,10 @@
 package uk.gov.pay.ledger.pact.event;
 
 import au.com.dius.pact.consumer.MessagePactBuilder;
-import au.com.dius.pact.consumer.MessagePactProviderRule;
-import au.com.dius.pact.consumer.Pact;
-import au.com.dius.pact.consumer.PactVerification;
-import au.com.dius.pact.model.v3.messaging.MessagePact;
+import au.com.dius.pact.consumer.junit.MessagePactProviderRule;
+import au.com.dius.pact.consumer.junit.PactVerification;
+import au.com.dius.pact.core.model.annotations.Pact;
+import au.com.dius.pact.core.model.messaging.MessagePact;
 import org.junit.Rule;
 import org.junit.Test;
 import uk.gov.pay.ledger.app.LedgerConfig;

--- a/src/test/java/uk/gov/pay/ledger/pact/event/PaymentCreatedEventQueueConsumerIT.java
+++ b/src/test/java/uk/gov/pay/ledger/pact/event/PaymentCreatedEventQueueConsumerIT.java
@@ -1,10 +1,10 @@
 package uk.gov.pay.ledger.pact.event;
 
 import au.com.dius.pact.consumer.MessagePactBuilder;
-import au.com.dius.pact.consumer.MessagePactProviderRule;
-import au.com.dius.pact.consumer.Pact;
-import au.com.dius.pact.consumer.PactVerification;
-import au.com.dius.pact.model.v3.messaging.MessagePact;
+import au.com.dius.pact.consumer.junit.MessagePactProviderRule;
+import au.com.dius.pact.consumer.junit.PactVerification;
+import au.com.dius.pact.core.model.annotations.Pact;
+import au.com.dius.pact.core.model.messaging.MessagePact;
 import org.junit.Rule;
 import org.junit.Test;
 import uk.gov.pay.ledger.app.LedgerConfig;

--- a/src/test/java/uk/gov/pay/ledger/pact/event/PaymentDetailsEnteredEventQueueConsumerIT.java
+++ b/src/test/java/uk/gov/pay/ledger/pact/event/PaymentDetailsEnteredEventQueueConsumerIT.java
@@ -1,10 +1,10 @@
 package uk.gov.pay.ledger.pact.event;
 
 import au.com.dius.pact.consumer.MessagePactBuilder;
-import au.com.dius.pact.consumer.MessagePactProviderRule;
-import au.com.dius.pact.consumer.Pact;
-import au.com.dius.pact.consumer.PactVerification;
-import au.com.dius.pact.model.v3.messaging.MessagePact;
+import au.com.dius.pact.consumer.junit.MessagePactProviderRule;
+import au.com.dius.pact.consumer.junit.PactVerification;
+import au.com.dius.pact.core.model.annotations.Pact;
+import au.com.dius.pact.core.model.messaging.MessagePact;
 import org.junit.Rule;
 import org.junit.Test;
 import uk.gov.pay.ledger.app.LedgerConfig;

--- a/src/test/java/uk/gov/pay/ledger/pact/event/PaymentDetailsSubmittedByAPIEventQueueConsumerIT.java
+++ b/src/test/java/uk/gov/pay/ledger/pact/event/PaymentDetailsSubmittedByAPIEventQueueConsumerIT.java
@@ -1,10 +1,10 @@
 package uk.gov.pay.ledger.pact.event;
 
 import au.com.dius.pact.consumer.MessagePactBuilder;
-import au.com.dius.pact.consumer.MessagePactProviderRule;
-import au.com.dius.pact.consumer.Pact;
-import au.com.dius.pact.consumer.PactVerification;
-import au.com.dius.pact.model.v3.messaging.MessagePact;
+import au.com.dius.pact.consumer.junit.MessagePactProviderRule;
+import au.com.dius.pact.consumer.junit.PactVerification;
+import au.com.dius.pact.core.model.annotations.Pact;
+import au.com.dius.pact.core.model.messaging.MessagePact;
 import org.junit.Rule;
 import org.junit.Test;
 import uk.gov.pay.ledger.app.LedgerConfig;

--- a/src/test/java/uk/gov/pay/ledger/pact/event/PaymentDetailsTakenFromPaymentInstrumentEventQueueConsumerIT.java
+++ b/src/test/java/uk/gov/pay/ledger/pact/event/PaymentDetailsTakenFromPaymentInstrumentEventQueueConsumerIT.java
@@ -1,10 +1,10 @@
 package uk.gov.pay.ledger.pact.event;
 
 import au.com.dius.pact.consumer.MessagePactBuilder;
-import au.com.dius.pact.consumer.MessagePactProviderRule;
-import au.com.dius.pact.consumer.Pact;
-import au.com.dius.pact.consumer.PactVerification;
-import au.com.dius.pact.model.v3.messaging.MessagePact;
+import au.com.dius.pact.consumer.junit.MessagePactProviderRule;
+import au.com.dius.pact.consumer.junit.PactVerification;
+import au.com.dius.pact.core.model.annotations.Pact;
+import au.com.dius.pact.core.model.messaging.MessagePact;
 import org.junit.Rule;
 import org.junit.Test;
 import uk.gov.pay.ledger.app.LedgerConfig;

--- a/src/test/java/uk/gov/pay/ledger/pact/event/PaymentIncludedInPayoutEventQueueConsumerIT.java
+++ b/src/test/java/uk/gov/pay/ledger/pact/event/PaymentIncludedInPayoutEventQueueConsumerIT.java
@@ -1,16 +1,15 @@
 package uk.gov.pay.ledger.pact.event;
 
 import au.com.dius.pact.consumer.MessagePactBuilder;
-import au.com.dius.pact.consumer.MessagePactProviderRule;
-import au.com.dius.pact.consumer.Pact;
-import au.com.dius.pact.consumer.PactVerification;
-import au.com.dius.pact.model.v3.messaging.MessagePact;
+import au.com.dius.pact.consumer.junit.MessagePactProviderRule;
+import au.com.dius.pact.consumer.junit.PactVerification;
+import au.com.dius.pact.core.model.annotations.Pact;
+import au.com.dius.pact.core.model.messaging.MessagePact;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import uk.gov.pay.ledger.app.LedgerConfig;
 import uk.gov.pay.ledger.event.dao.EventDao;
-import uk.gov.pay.ledger.event.model.ResourceType;
 import uk.gov.pay.ledger.rule.AppWithPostgresAndSqsRule;
 import uk.gov.pay.ledger.rule.SqsTestDocker;
 import uk.gov.pay.ledger.transaction.dao.TransactionDao;

--- a/src/test/java/uk/gov/pay/ledger/pact/event/PaymentNotificationCreatedEventQueueConsumerIT.java
+++ b/src/test/java/uk/gov/pay/ledger/pact/event/PaymentNotificationCreatedEventQueueConsumerIT.java
@@ -1,10 +1,10 @@
 package uk.gov.pay.ledger.pact.event;
 
 import au.com.dius.pact.consumer.MessagePactBuilder;
-import au.com.dius.pact.consumer.MessagePactProviderRule;
-import au.com.dius.pact.consumer.Pact;
-import au.com.dius.pact.consumer.PactVerification;
-import au.com.dius.pact.model.v3.messaging.MessagePact;
+import au.com.dius.pact.consumer.junit.MessagePactProviderRule;
+import au.com.dius.pact.consumer.junit.PactVerification;
+import au.com.dius.pact.core.model.annotations.Pact;
+import au.com.dius.pact.core.model.messaging.MessagePact;
 import org.junit.Rule;
 import org.junit.Test;
 import uk.gov.pay.ledger.app.LedgerConfig;

--- a/src/test/java/uk/gov/pay/ledger/pact/event/PayoutCreatedEventQueueConsumerIT.java
+++ b/src/test/java/uk/gov/pay/ledger/pact/event/PayoutCreatedEventQueueConsumerIT.java
@@ -1,10 +1,10 @@
 package uk.gov.pay.ledger.pact.event;
 
 import au.com.dius.pact.consumer.MessagePactBuilder;
-import au.com.dius.pact.consumer.MessagePactProviderRule;
-import au.com.dius.pact.consumer.Pact;
-import au.com.dius.pact.consumer.PactVerification;
-import au.com.dius.pact.model.v3.messaging.MessagePact;
+import au.com.dius.pact.consumer.junit.MessagePactProviderRule;
+import au.com.dius.pact.consumer.junit.PactVerification;
+import au.com.dius.pact.core.model.annotations.Pact;
+import au.com.dius.pact.core.model.messaging.MessagePact;
 import com.google.gson.Gson;
 import org.junit.Rule;
 import org.junit.Test;

--- a/src/test/java/uk/gov/pay/ledger/pact/event/PayoutFailedEventQueueConsumerIT.java
+++ b/src/test/java/uk/gov/pay/ledger/pact/event/PayoutFailedEventQueueConsumerIT.java
@@ -1,10 +1,10 @@
 package uk.gov.pay.ledger.pact.event;
 
 import au.com.dius.pact.consumer.MessagePactBuilder;
-import au.com.dius.pact.consumer.MessagePactProviderRule;
-import au.com.dius.pact.consumer.Pact;
-import au.com.dius.pact.consumer.PactVerification;
-import au.com.dius.pact.model.v3.messaging.MessagePact;
+import au.com.dius.pact.consumer.junit.MessagePactProviderRule;
+import au.com.dius.pact.consumer.junit.PactVerification;
+import au.com.dius.pact.core.model.annotations.Pact;
+import au.com.dius.pact.core.model.messaging.MessagePact;
 import com.google.gson.Gson;
 import org.junit.Rule;
 import org.junit.Test;

--- a/src/test/java/uk/gov/pay/ledger/pact/event/PayoutPaidEventQueueConsumerIT.java
+++ b/src/test/java/uk/gov/pay/ledger/pact/event/PayoutPaidEventQueueConsumerIT.java
@@ -1,10 +1,10 @@
 package uk.gov.pay.ledger.pact.event;
 
 import au.com.dius.pact.consumer.MessagePactBuilder;
-import au.com.dius.pact.consumer.MessagePactProviderRule;
-import au.com.dius.pact.consumer.Pact;
-import au.com.dius.pact.consumer.PactVerification;
-import au.com.dius.pact.model.v3.messaging.MessagePact;
+import au.com.dius.pact.consumer.junit.MessagePactProviderRule;
+import au.com.dius.pact.consumer.junit.PactVerification;
+import au.com.dius.pact.core.model.annotations.Pact;
+import au.com.dius.pact.core.model.messaging.MessagePact;
 import com.google.gson.Gson;
 import org.junit.Rule;
 import org.junit.Test;
@@ -12,7 +12,6 @@ import uk.gov.pay.ledger.payout.dao.PayoutDao;
 import uk.gov.pay.ledger.payout.entity.PayoutEntity;
 import uk.gov.pay.ledger.rule.AppWithPostgresAndSqsRule;
 import uk.gov.pay.ledger.rule.SqsTestDocker;
-import uk.gov.pay.ledger.util.fixture.PayoutFixture;
 import uk.gov.pay.ledger.util.fixture.QueuePayoutEventFixture;
 
 import java.time.ZonedDateTime;
@@ -27,8 +26,6 @@ import static org.awaitility.Awaitility.await;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static uk.gov.pay.ledger.payout.state.PayoutState.PAID_OUT;
-import static uk.gov.pay.ledger.payout.state.PayoutState.UNDEFINED;
-import static uk.gov.pay.ledger.util.fixture.PayoutFixture.PayoutFixtureBuilder.aPayoutFixture;
 
 public class PayoutPaidEventQueueConsumerIT {
     @Rule

--- a/src/test/java/uk/gov/pay/ledger/pact/event/PayoutUpdatedEventQueueConsumerIT.java
+++ b/src/test/java/uk/gov/pay/ledger/pact/event/PayoutUpdatedEventQueueConsumerIT.java
@@ -1,10 +1,10 @@
 package uk.gov.pay.ledger.pact.event;
 
 import au.com.dius.pact.consumer.MessagePactBuilder;
-import au.com.dius.pact.consumer.MessagePactProviderRule;
-import au.com.dius.pact.consumer.Pact;
-import au.com.dius.pact.consumer.PactVerification;
-import au.com.dius.pact.model.v3.messaging.MessagePact;
+import au.com.dius.pact.consumer.junit.MessagePactProviderRule;
+import au.com.dius.pact.consumer.junit.PactVerification;
+import au.com.dius.pact.core.model.annotations.Pact;
+import au.com.dius.pact.core.model.messaging.MessagePact;
 import com.google.gson.Gson;
 import org.junit.Rule;
 import org.junit.Test;
@@ -12,7 +12,6 @@ import uk.gov.pay.ledger.payout.dao.PayoutDao;
 import uk.gov.pay.ledger.payout.entity.PayoutEntity;
 import uk.gov.pay.ledger.rule.AppWithPostgresAndSqsRule;
 import uk.gov.pay.ledger.rule.SqsTestDocker;
-import uk.gov.pay.ledger.util.fixture.PayoutFixture;
 import uk.gov.pay.ledger.util.fixture.QueuePayoutEventFixture;
 
 import java.time.ZonedDateTime;
@@ -26,9 +25,7 @@ import static java.time.ZonedDateTime.parse;
 import static org.awaitility.Awaitility.await;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static uk.gov.pay.ledger.payout.state.PayoutState.PAID_OUT;
 import static uk.gov.pay.ledger.payout.state.PayoutState.UNDEFINED;
-import static uk.gov.pay.ledger.util.fixture.PayoutFixture.PayoutFixtureBuilder.aPayoutFixture;
 
 public class PayoutUpdatedEventQueueConsumerIT {
     @Rule

--- a/src/test/java/uk/gov/pay/ledger/pact/event/RefundCreatedByUserEventQueueConsumerIT.java
+++ b/src/test/java/uk/gov/pay/ledger/pact/event/RefundCreatedByUserEventQueueConsumerIT.java
@@ -1,10 +1,10 @@
 package uk.gov.pay.ledger.pact.event;
 
 import au.com.dius.pact.consumer.MessagePactBuilder;
-import au.com.dius.pact.consumer.MessagePactProviderRule;
-import au.com.dius.pact.consumer.Pact;
-import au.com.dius.pact.consumer.PactVerification;
-import au.com.dius.pact.model.v3.messaging.MessagePact;
+import au.com.dius.pact.consumer.junit.MessagePactProviderRule;
+import au.com.dius.pact.consumer.junit.PactVerification;
+import au.com.dius.pact.core.model.annotations.Pact;
+import au.com.dius.pact.core.model.messaging.MessagePact;
 import com.google.gson.Gson;
 import org.junit.Before;
 import org.junit.Rule;

--- a/src/test/java/uk/gov/pay/ledger/pact/event/RefundIncludedInPayoutEventQueueConsumerIT.java
+++ b/src/test/java/uk/gov/pay/ledger/pact/event/RefundIncludedInPayoutEventQueueConsumerIT.java
@@ -1,10 +1,10 @@
 package uk.gov.pay.ledger.pact.event;
 
 import au.com.dius.pact.consumer.MessagePactBuilder;
-import au.com.dius.pact.consumer.MessagePactProviderRule;
-import au.com.dius.pact.consumer.Pact;
-import au.com.dius.pact.consumer.PactVerification;
-import au.com.dius.pact.model.v3.messaging.MessagePact;
+import au.com.dius.pact.consumer.junit.MessagePactProviderRule;
+import au.com.dius.pact.consumer.junit.PactVerification;
+import au.com.dius.pact.core.model.annotations.Pact;
+import au.com.dius.pact.core.model.messaging.MessagePact;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;

--- a/src/test/java/uk/gov/pay/ledger/pact/event/RefundSubmittedEventQueueConsumerIT.java
+++ b/src/test/java/uk/gov/pay/ledger/pact/event/RefundSubmittedEventQueueConsumerIT.java
@@ -1,10 +1,10 @@
 package uk.gov.pay.ledger.pact.event;
 
 import au.com.dius.pact.consumer.MessagePactBuilder;
-import au.com.dius.pact.consumer.MessagePactProviderRule;
-import au.com.dius.pact.consumer.Pact;
-import au.com.dius.pact.consumer.PactVerification;
-import au.com.dius.pact.model.v3.messaging.MessagePact;
+import au.com.dius.pact.consumer.junit.MessagePactProviderRule;
+import au.com.dius.pact.consumer.junit.PactVerification;
+import au.com.dius.pact.core.model.annotations.Pact;
+import au.com.dius.pact.core.model.messaging.MessagePact;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;

--- a/src/test/java/uk/gov/pay/ledger/pact/event/RefundSucceededEventQueueConsumerIT.java
+++ b/src/test/java/uk/gov/pay/ledger/pact/event/RefundSucceededEventQueueConsumerIT.java
@@ -1,11 +1,11 @@
 package uk.gov.pay.ledger.pact.event;
 
 import au.com.dius.pact.consumer.MessagePactBuilder;
-import au.com.dius.pact.consumer.MessagePactProviderRule;
-import au.com.dius.pact.consumer.Pact;
-import au.com.dius.pact.consumer.PactVerification;
 import au.com.dius.pact.consumer.dsl.PactDslJsonBody;
-import au.com.dius.pact.model.v3.messaging.MessagePact;
+import au.com.dius.pact.consumer.junit.MessagePactProviderRule;
+import au.com.dius.pact.consumer.junit.PactVerification;
+import au.com.dius.pact.core.model.annotations.Pact;
+import au.com.dius.pact.core.model.messaging.MessagePact;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;

--- a/src/test/java/uk/gov/pay/ledger/pact/event/StatusCorrectedToCapturedToMatchGatewayStatusEventQueueConsumerIT.java
+++ b/src/test/java/uk/gov/pay/ledger/pact/event/StatusCorrectedToCapturedToMatchGatewayStatusEventQueueConsumerIT.java
@@ -1,11 +1,11 @@
 package uk.gov.pay.ledger.pact.event;
 
 import au.com.dius.pact.consumer.MessagePactBuilder;
-import au.com.dius.pact.consumer.MessagePactProviderRule;
-import au.com.dius.pact.consumer.Pact;
-import au.com.dius.pact.consumer.PactVerification;
 import au.com.dius.pact.consumer.dsl.PactDslJsonBody;
-import au.com.dius.pact.model.v3.messaging.MessagePact;
+import au.com.dius.pact.consumer.junit.MessagePactProviderRule;
+import au.com.dius.pact.consumer.junit.PactVerification;
+import au.com.dius.pact.core.model.annotations.Pact;
+import au.com.dius.pact.core.model.messaging.MessagePact;
 import com.google.gson.Gson;
 import org.junit.Rule;
 import org.junit.Test;

--- a/src/test/java/uk/gov/pay/ledger/pact/event/UserEmailCollectedEventQueueConsumerIT.java
+++ b/src/test/java/uk/gov/pay/ledger/pact/event/UserEmailCollectedEventQueueConsumerIT.java
@@ -1,10 +1,10 @@
 package uk.gov.pay.ledger.pact.event;
 
 import au.com.dius.pact.consumer.MessagePactBuilder;
-import au.com.dius.pact.consumer.MessagePactProviderRule;
-import au.com.dius.pact.consumer.Pact;
-import au.com.dius.pact.consumer.PactVerification;
-import au.com.dius.pact.model.v3.messaging.MessagePact;
+import au.com.dius.pact.consumer.junit.MessagePactProviderRule;
+import au.com.dius.pact.consumer.junit.PactVerification;
+import au.com.dius.pact.core.model.annotations.Pact;
+import au.com.dius.pact.core.model.messaging.MessagePact;
 import org.junit.Rule;
 import org.junit.Test;
 import uk.gov.pay.ledger.app.LedgerConfig;


### PR DESCRIPTION
`pay-java-commons` was upgraded to Java 21. Some of the imports needed update as they are transative dependencies.