### PR TITLE
BAU: Remove incorrect dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -49,20 +49,6 @@ updates:
       - dependencies
       - govuk-pay
       - docker
-  - package-ecosystem: docker
-    directory: "/m1"
-    schedule:
-      interval: daily
-      time: "03:00"
-    ignore:
-      - dependency-name: "eclipse-temurin"
-        versions:
-          - "> 21"
-    open-pull-requests-limit: 10
-    labels:
-      - dependencies
-      - govuk-pay
-      - docker
   - package-ecosystem: github-actions
     directory: "/"
     schedule:


### PR DESCRIPTION
WHAT YOU DID
We no longer have an m1 specific dockerfile, remove the dependabot config for it