### PR TITLE
PP-13344 return empty string

### DIFF
--- a/src/main/java/uk/gov/pay/ledger/transaction/model/CsvTransactionFactory.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/model/CsvTransactionFactory.java
@@ -127,7 +127,8 @@ public class CsvTransactionFactory {
                     result.putAll(getFeeBreakdown(transactionEntity, feeBreakdownNode));
                 }
 
-                result.put(FIELD_3D_SECURE_REQUIRED, safeGetAsBoolean(transactionDetails, "requires_3ds", null));
+                Boolean requires3ds = safeGetAsBoolean(transactionDetails, "requires_3ds", null);
+                result.put(FIELD_3D_SECURE_REQUIRED, Boolean.TRUE.equals(requires3ds) ? true : null);
 
                 Optional<Map<String, Object>> externalMetadata = getExternalMetadata(transactionEntity.getTransactionDetails());
 

--- a/src/test/java/uk/gov/pay/ledger/transaction/model/CsvTransactionFactoryTest.java
+++ b/src/test/java/uk/gov/pay/ledger/transaction/model/CsvTransactionFactoryTest.java
@@ -376,7 +376,7 @@ class CsvTransactionFactoryTest {
     }
 
     @Test
-    void toMapShouldIncludeShouldInclude3DSecureRequired() {
+    void toMapShouldInclude3DSecureRequiredWhenTrue() {
         var transactionEntity = transactionFixture
                 .withTotalAmount(123L)
                 .withVersion3ds("2.0.1")
@@ -401,6 +401,46 @@ class CsvTransactionFactoryTest {
         assertThat(csvDataMap.get("MOTO"), is(true));
         assertThat(csvDataMap.get("Payment Provider"), is("sandbox"));
         assertThat(csvDataMap.get("3-D Secure Required"), is(true));
+    }
+
+    @Test
+    void toMapShouldReturnMapWithNullValueFor3DSecureRequiredWhenRequires3dsIsFalse() {
+
+        var transactionEntity = transactionFixture
+                .withTotalAmount(123L)
+                .withVersion3ds("2.0.1")
+                .withRequires3ds(false)
+                .withDefaultTransactionDetails()
+                .toEntity();
+
+        Map<String, Object> csvDataMap = csvTransactionFactory.toMap(transactionEntity);
+
+        assertPaymentDetails(csvDataMap, transactionEntity);
+
+        assertThat(csvDataMap.get("Amount"), is("1.00"));
+        assertThat(csvDataMap.get("GOV.UK Payment ID"), is(transactionEntity.getExternalId()));
+        assertThat(csvDataMap.get("Provider ID"), is(transactionEntity.getGatewayTransactionId()));
+        assertThat(csvDataMap.get("3-D Secure Required"), is(nullValue()));
+    }
+
+    @Test
+    void toMapShouldReturnMapWithNullValueFor3DSecureRequiredWhenRequires3dsIsNull() {
+
+        var transactionEntity = transactionFixture
+                .withTotalAmount(123L)
+                .withVersion3ds("2.0.1")
+                .withRequires3ds(null)
+                .withDefaultTransactionDetails()
+                .toEntity();
+
+        Map<String, Object> csvDataMap = csvTransactionFactory.toMap(transactionEntity);
+
+        assertPaymentDetails(csvDataMap, transactionEntity);
+
+        assertThat(csvDataMap.get("Amount"), is("1.00"));
+        assertThat(csvDataMap.get("GOV.UK Payment ID"), is(transactionEntity.getExternalId()));
+        assertThat(csvDataMap.get("Provider ID"), is(transactionEntity.getGatewayTransactionId()));
+        assertThat(csvDataMap.get("3-D Secure Required"), is(nullValue()));
     }
 
     private void assertPaymentDetails(Map<String, Object> csvDataMap, TransactionEntity transactionEntity) {

--- a/src/test/java/uk/gov/pay/ledger/util/fixture/TransactionFixture.java
+++ b/src/test/java/uk/gov/pay/ledger/util/fixture/TransactionFixture.java
@@ -78,6 +78,7 @@ public class TransactionFixture implements DbFixture<TransactionFixture, Transac
     private String source;
     private String gatewayPayoutId;
     private String version3ds;
+    private Boolean requires3ds = true;
     private String agreementId;
     private Boolean disputed;
     private AuthorisationMode authorisationMode = AuthorisationMode.WEB;
@@ -365,6 +366,11 @@ public class TransactionFixture implements DbFixture<TransactionFixture, Transac
         return this;
     }
 
+    public TransactionFixture withRequires3ds(Boolean requires3ds) {
+        this.requires3ds = requires3ds;
+        return this;
+    }
+
     @Override
     public TransactionFixture insert(Jdbi jdbi) {
         jdbi.withHandle(h ->
@@ -509,7 +515,7 @@ public class TransactionFixture implements DbFixture<TransactionFixture, Transac
         Optional.ofNullable(version3ds).ifPresent(
                 version -> {
                     transactionDetails.addProperty("version_3ds", version);
-                    transactionDetails.addProperty("requires_3ds", true);
+                    transactionDetails.addProperty("requires_3ds", requires3ds);
                 });
         Optional.ofNullable(disputed).ifPresent(
                 disputed -> transactionDetails.addProperty("disputed", disputed)


### PR DESCRIPTION
When a payment in ledger has its requires_3ds property false the value of the ‘3-D Secure Required’ column is an empty string