### PR TITLE
PP-13430 ignore pact test

### DIFF
--- a/src/test/java/uk/gov/pay/ledger/pact/event/Requested3dsExemptionQueueConsumerIT.java
+++ b/src/test/java/uk/gov/pay/ledger/pact/event/Requested3dsExemptionQueueConsumerIT.java
@@ -5,6 +5,7 @@ import au.com.dius.pact.consumer.junit.MessagePactProviderRule;
 import au.com.dius.pact.consumer.junit.PactVerification;
 import au.com.dius.pact.core.model.annotations.Pact;
 import au.com.dius.pact.core.model.messaging.MessagePact;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import uk.gov.pay.ledger.app.LedgerConfig;
@@ -28,6 +29,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.mock;
 import static uk.gov.pay.ledger.util.fixture.QueuePaymentEventFixture.aQueuePaymentEventFixture;
 
+@Ignore
 public class Requested3dsExemptionQueueConsumerIT {
     @Rule
     public MessagePactProviderRule mockProvider = new MessagePactProviderRule(this);
@@ -70,13 +72,13 @@ public class Requested3dsExemptionQueueConsumerIT {
 
         await().atMost(1, TimeUnit.SECONDS).until(
                 () -> transactionDao.findTransactionByExternalId(externalId).isPresent()
-                && transactionDao.findTransactionByExternalId(externalId).get().getTransactionDetails().contains("\"type\""));
+                && transactionDao.findTransactionByExternalId(externalId).get().getTransactionDetails().contains("\"exemption_3ds_requested\""));
 
         Optional<TransactionEntity> transaction = transactionDao.findTransactionByExternalId(externalId);
 
         assertThat(transaction.isPresent(), is(true));
         assertThat(transaction.get().getExternalId(), is(externalId));
-        assertThat(transaction.get().getTransactionDetails(), containsString("\"type\": \"OPTIMISED\""));
+        assertThat(transaction.get().getTransactionDetails(), containsString("\"exemption_3ds_requested\": \"OPTIMISED\""));
     }
 
     public void setMessage(byte[] messageContents) {


### PR DESCRIPTION
Temporarily ignore queue message pact test.

We are changing the property name in Connector. Ignore the test while Connector changes go through.