### PR TITLE
PP-13515 refactor queue msg pact tests

### DIFF
--- a/src/test/java/uk/gov/pay/ledger/event/model/TransactionEntityFactoryTest.java
+++ b/src/test/java/uk/gov/pay/ledger/event/model/TransactionEntityFactoryTest.java
@@ -81,17 +81,17 @@ public class TransactionEntityFactoryTest {
         assertThat(transactionEntity.getSource(), is(notNullValue()));
         assertThat(transactionEntity.isLive(), is(true));
         assertThat(transactionEntity.getGatewayPayoutId(), is("payout-id"));
-        assertThat(transactionEntity.getAgreementId(), is("an-agreement-id"));
+        assertThat(transactionEntity.getAgreementId(), is("an-agreement-external-id"));
 
         JsonObject transactionDetails = JsonParser.parseString(transactionEntity.getTransactionDetails()).getAsJsonObject();
         assertThat(transactionDetails.get("language").getAsString(), is("en"));
         assertThat(transactionDetails.get("payment_provider").getAsString(), is("sandbox"));
-        assertThat(transactionDetails.get("expiry_date").getAsString(), is("11/21"));
-        assertThat(transactionDetails.get("address_line1").getAsString(), is("12 Rouge Avenue"));
-        assertThat(transactionDetails.get("address_postcode").getAsString(), is("N1 3QU"));
+        assertThat(transactionDetails.get("expiry_date").getAsString(), is("12/99"));
+        assertThat(transactionDetails.get("address_line1").getAsString(), is("125 Kingsway"));
+        assertThat(transactionDetails.get("address_postcode").getAsString(), is("WC2B 6NH"));
         assertThat(transactionDetails.get("address_country").getAsString(), is("GB"));
         assertThat(transactionDetails.get("delayed_capture").getAsBoolean(), is(false));
-        assertThat(transactionDetails.get("return_url").getAsString(), is("https://example.org"));
+        assertThat(transactionDetails.get("return_url").getAsString(), is("http://return.invalid"));
         assertThat(transactionDetails.get("corporate_surcharge").getAsInt(), is(5));
         assertThat(transactionDetails.get("gateway_transaction_id").getAsString(), is(eventDigest.getEventAggregate().get("gateway_transaction_id")));
         assertThat(transactionDetails.get("external_metadata").getAsJsonObject().get("key").getAsString(), is("value"));

--- a/src/test/java/uk/gov/pay/ledger/pact/event/CancelledByUserEventQueueConsumerIT.java
+++ b/src/test/java/uk/gov/pay/ledger/pact/event/CancelledByUserEventQueueConsumerIT.java
@@ -43,7 +43,7 @@ public class CancelledByUserEventQueueConsumerIT {
     private String externalId = "externalId";
     private ZonedDateTime eventDate = ZonedDateTime.parse("2018-03-12T16:25:01.123456Z");
     private String gatewayAccountId = "gateway_account_id";
-    private String gatewayTransactionId = "validGatewayTransactionId";
+    private String gatewayTransactionId = "gateway_transaction_id";
 
     @Pact(provider = "connector", consumer = "ledger")
     public MessagePact createCancelledByUserEventPact(MessagePactBuilder builder) {

--- a/src/test/java/uk/gov/pay/ledger/pact/event/DisputeCreatedEventQueueConsumerIT.java
+++ b/src/test/java/uk/gov/pay/ledger/pact/event/DisputeCreatedEventQueueConsumerIT.java
@@ -115,7 +115,7 @@ public class DisputeCreatedEventQueueConsumerIT {
         assertThat(eventData.get("amount").asLong(), is(amount));
         assertThat(eventData.get("gateway_account_id").asText(), is(gatewayAccountId));
         assertThat(eventData.get("reason").asText(), is(reason));
-        assertThat(eventData.get("evidence_due_date").asText(), is("2022-02-14T23:59:59.000Z"));
+        assertThat(eventData.get("evidence_due_date").asText(), is("2022-02-14T23:59:59.000000Z"));
 
         TransactionDao transactionDao = new TransactionDao(appRule.getJdbi(), mock(LedgerConfig.class));
 
@@ -129,7 +129,7 @@ public class DisputeCreatedEventQueueConsumerIT {
 
         Map<String, String> transactionDetails = gson.fromJson(transaction.get().getTransactionDetails(), Map.class);
         assertThat(transactionDetails.get("reason"), is("duplicate"));
-        assertThat(transactionDetails.get("evidence_due_date"), is("2022-02-14T23:59:59.000Z"));
+        assertThat(transactionDetails.get("evidence_due_date"), is("2022-02-14T23:59:59.000000Z"));
     }
 
     public void setMessage(byte[] messageContents) {

--- a/src/test/java/uk/gov/pay/ledger/pact/event/Gateway3dsExemptionResultObtainedEventQueueConsumerIT.java
+++ b/src/test/java/uk/gov/pay/ledger/pact/event/Gateway3dsExemptionResultObtainedEventQueueConsumerIT.java
@@ -76,7 +76,7 @@ public class Gateway3dsExemptionResultObtainedEventQueueConsumerIT {
 
         assertThat(transaction.isPresent(), is(true));
         assertThat(transaction.get().getExternalId(), is(externalId));
-        assertThat(transaction.get().getTransactionDetails(), containsString("\"exemption3ds\": \"HONOURED\""));
+        assertThat(transaction.get().getTransactionDetails(), containsString("\"exemption3ds\": \"EXEMPTION_HONOURED\""));
     }
 
     public void setMessage(byte[] messageContents) {

--- a/src/test/java/uk/gov/pay/ledger/pact/event/GatewayRequires3dsAuthorisationEventQueueConsumerIT.java
+++ b/src/test/java/uk/gov/pay/ledger/pact/event/GatewayRequires3dsAuthorisationEventQueueConsumerIT.java
@@ -77,7 +77,7 @@ public class GatewayRequires3dsAuthorisationEventQueueConsumerIT {
 
         assertThat(transaction.isPresent(), is(true));
         assertThat(transaction.get().getExternalId(), is(externalId));
-        assertThat(transaction.get().getTransactionDetails(), containsString("\"version_3ds\": \"1.2.1\""));
+        assertThat(transaction.get().getTransactionDetails(), containsString("\"version_3ds\": \"2.1.0\""));
         assertThat(transaction.get().getTransactionDetails(), containsString("\"requires_3ds\": true"));
     }
 

--- a/src/test/java/uk/gov/pay/ledger/pact/event/PaymentCreatedEventQueueConsumerIT.java
+++ b/src/test/java/uk/gov/pay/ledger/pact/event/PaymentCreatedEventQueueConsumerIT.java
@@ -40,7 +40,7 @@ public class PaymentCreatedEventQueueConsumerIT {
     private byte[] currentMessage;
     private String externalId = "created_externalId";
     private ZonedDateTime eventDate = ZonedDateTime.parse("2018-03-12T16:25:01.123456Z");
-    private String gatewayAccountId = "gateway_account_id";
+    private String gatewayAccountId = "1";
     private String credentialExternalId = "credential-external-id-1";
 
     @Pact(provider = "connector", consumer = "ledger")
@@ -79,18 +79,18 @@ public class PaymentCreatedEventQueueConsumerIT {
         assertThat(transaction.isPresent(), is(true));
         assertThat(transaction.get().getExternalId(), is(externalId));
         assertThat(transaction.get().getAmount(), is(1000L));
-        assertThat(transaction.get().getDescription(), is("a description"));
-        assertThat(transaction.get().getReference(), is("aref"));
+        assertThat(transaction.get().getDescription(), is("This is a description"));
+        assertThat(transaction.get().getReference(), is("This is a reference"));
         assertThat(transaction.get().getGatewayAccountId(), is(gatewayAccountId));
-        assertThat(transaction.get().getTransactionDetails(), containsString("\"return_url\": \"https://example.org\""));
+        assertThat(transaction.get().getTransactionDetails(), containsString("\"return_url\": \"http://return.invalid\""));
         assertThat(transaction.get().getTransactionDetails(), containsString("\"payment_provider\": \"sandbox\""));
         assertThat(transaction.get().getTransactionDetails(), containsString("\"language\": \"en\""));
         assertThat(transaction.get().getTransactionDetails(), containsString("\"delayed_capture\": false"));
         assertThat(transaction.get().getTransactionDetails(), containsString("\"external_metadata\": {\"key\": \"value\"}"));
-        assertThat(transaction.get().getEmail(), is("j.doe@example.org"));
-        assertThat(transaction.get().getCardholderName(), is("J citizen"));
-        assertThat(transaction.get().getTransactionDetails(), containsString("\"address_line1\": \"12 Rouge Avenue\""));
-        assertThat(transaction.get().getTransactionDetails(), containsString("\"address_postcode\": \"N1 3QU\""));
+        assertThat(transaction.get().getEmail(), is("test@email.invalid"));
+        assertThat(transaction.get().getCardholderName(), is("Mr Test"));
+        assertThat(transaction.get().getTransactionDetails(), containsString("\"address_line1\": \"125 Kingsway\""));
+        assertThat(transaction.get().getTransactionDetails(), containsString("\"address_postcode\": \"WC2B 6NH\""));
         assertThat(transaction.get().getTransactionDetails(), containsString("\"address_city\": \"London\""));
         assertThat(transaction.get().getTransactionDetails(), containsString("\"address_country\": \"GB\""));
         assertThat(transaction.get().getTransactionDetails(), containsString("\"credential_external_id\": \"" + credentialExternalId + "\""));

--- a/src/test/java/uk/gov/pay/ledger/pact/event/PaymentDetailsEnteredEventQueueConsumerIT.java
+++ b/src/test/java/uk/gov/pay/ledger/pact/event/PaymentDetailsEnteredEventQueueConsumerIT.java
@@ -48,7 +48,7 @@ public class PaymentDetailsEnteredEventQueueConsumerIT {
                 .withResourceExternalId(externalId)
                 .withEventDate(eventDate)
                 .withEventType(paymentDetailsEnteredEventName)
-                .withGatewayAccountId("I0YI1")
+                .withGatewayAccountId("gateway_transaction_id")
                 .withDefaultEventDataForEventType(paymentDetailsEnteredEventName)
                 .withLive(true);
 
@@ -82,11 +82,11 @@ public class PaymentDetailsEnteredEventQueueConsumerIT {
         assertThat(transaction.get().getCardBrand(), is("visa"));
         assertThat(transaction.get().getFirstDigitsCardNumber(), is("424242"));
         assertThat(transaction.get().getLastDigitsCardNumber(), is("4242"));
-        assertThat(transaction.get().getCardholderName(), is("J citizen"));
+        assertThat(transaction.get().getCardholderName(), is("Mr Test"));
         assertThat(transaction.get().getTransactionDetails(), containsString("\"corporate_surcharge\": 5"));
-        assertThat(transaction.get().getTransactionDetails(), containsString("\"expiry_date\": \"11/21\""));
-        assertThat(transaction.get().getTransactionDetails(), containsString("\"address_line1\": \"12 Rouge Avenue\""));
-        assertThat(transaction.get().getTransactionDetails(), containsString("\"address_postcode\": \"N1 3QU\""));
+        assertThat(transaction.get().getTransactionDetails(), containsString("\"expiry_date\": \"12/99\""));
+        assertThat(transaction.get().getTransactionDetails(), containsString("\"address_line1\": \"125 Kingsway\""));
+        assertThat(transaction.get().getTransactionDetails(), containsString("\"address_postcode\": \"WC2B 6NH\""));
         assertThat(transaction.get().getTransactionDetails(), containsString("\"address_city\": \"London\""));
         assertThat(transaction.get().getTransactionDetails(), containsString("\"address_country\": \"GB\""));
         assertThat(transaction.get().getTotalAmount(), is(1005L));

--- a/src/test/java/uk/gov/pay/ledger/pact/event/PaymentDetailsSubmittedByAPIEventQueueConsumerIT.java
+++ b/src/test/java/uk/gov/pay/ledger/pact/event/PaymentDetailsSubmittedByAPIEventQueueConsumerIT.java
@@ -82,8 +82,8 @@ public class PaymentDetailsSubmittedByAPIEventQueueConsumerIT {
         assertThat(transaction.get().getCardBrand(), is("visa"));
         assertThat(transaction.get().getFirstDigitsCardNumber(), is("424242"));
         assertThat(transaction.get().getLastDigitsCardNumber(), is("4242"));
-        assertThat(transaction.get().getCardholderName(), is("J citizen"));
-        assertThat(transaction.get().getTransactionDetails(), containsString("\"expiry_date\": \"11/21\""));
+        assertThat(transaction.get().getCardholderName(), is("Mr Test"));
+        assertThat(transaction.get().getTransactionDetails(), containsString("\"expiry_date\": \"12/99\""));
     }
 
     private void setupTransaction(TransactionDao transactionDao) {

--- a/src/test/java/uk/gov/pay/ledger/pact/event/PaymentIncludedInPayoutEventQueueConsumerIT.java
+++ b/src/test/java/uk/gov/pay/ledger/pact/event/PaymentIncludedInPayoutEventQueueConsumerIT.java
@@ -40,7 +40,7 @@ public class PaymentIncludedInPayoutEventQueueConsumerIT {
 
     private byte[] currentMessage;
     private String paymentExternalId = "payment-external-id";
-    private String payoutId = "po_12345";
+    private String payoutId = "po_1234567890";
     private ZonedDateTime eventDate = ZonedDateTime.parse("2018-03-12T16:25:01.123456Z");
 
     @Pact(provider = "connector", consumer = "ledger")

--- a/src/test/java/uk/gov/pay/ledger/pact/event/PaymentNotificationCreatedEventQueueConsumerIT.java
+++ b/src/test/java/uk/gov/pay/ledger/pact/event/PaymentNotificationCreatedEventQueueConsumerIT.java
@@ -84,22 +84,22 @@ public class PaymentNotificationCreatedEventQueueConsumerIT {
         assertThat(transaction.get().getCardBrand(), is("visa"));
         assertThat(transaction.get().getFirstDigitsCardNumber(), is("424242"));
         assertThat(transaction.get().getLastDigitsCardNumber(), is("4242"));
-        assertThat(transaction.get().getCardholderName(), is("J citizen"));
-        assertThat(transaction.get().getReference(), is("MRPC12345"));
+        assertThat(transaction.get().getCardholderName(), is("Mr Test"));
+        assertThat(transaction.get().getReference(), is("This is a reference"));
         assertThat(transaction.get().getCardBrand(), is("visa"));
-        assertThat(transaction.get().getDescription(), is("New passport application"));
+        assertThat(transaction.get().getDescription(), is("This is a description"));
         assertThat(transaction.get().getTransactionDetails(), containsString("\"gateway_transaction_id\": \"providerId\""));
         assertThat(transaction.get().getTransactionDetails(), containsString("\"amount\": 1000"));
-        assertThat(transaction.get().getTransactionDetails(), containsString("\"expiry_date\": \"11/21\""));
+        assertThat(transaction.get().getTransactionDetails(), containsString("\"expiry_date\": \"12/99\""));
         assertThat(transaction.get().getTransactionDetails(), containsString("\"status\": \"success\""));
-        assertThat(transaction.get().getTransactionDetails(), containsString("\"auth_code\": \"authCode\""));
+        assertThat(transaction.get().getTransactionDetails(), containsString("\"auth_code\": \"012345\""));
         assertThat(transaction.get().getTransactionDetails(), containsString("\"processor_id\": \"processorId\""));
         assertThat(transaction.get().getTransactionDetails(), containsString("\"telephone_number\": \"+447700900796\""));
         assertThat(transaction.get().getTransactionDetails(), containsString("\"authorised_date\": \"2018-02-21T16:05:33Z\""));
         assertThat(transaction.get().getTransactionDetails(), containsString("\"created_date\": \"2018-02-21T15:05:13Z\""));
         assertThat(transaction.get().getTransactionDetails(), containsString("\"card_brand_label\": \"Visa\""));
         assertThat(transaction.get().getTransactionDetails(), containsString("\"payment_provider\": \"sandbox\""));
-        assertThat(transaction.get().getTransactionDetails(), containsString("\"expiry_date\": \"11/21\""));
+        assertThat(transaction.get().getTransactionDetails(), containsString("\"expiry_date\": \"12/99\""));
         assertThat(transaction.get().getTransactionDetails(), containsString("\"credential_external_id\": \"" + credentialExternalId + "\""));
     }
 

--- a/src/test/java/uk/gov/pay/ledger/pact/event/PayoutPaidEventQueueConsumerIT.java
+++ b/src/test/java/uk/gov/pay/ledger/pact/event/PayoutPaidEventQueueConsumerIT.java
@@ -38,7 +38,7 @@ public class PayoutPaidEventQueueConsumerIT {
 
     private byte[] currentMessage;
     private String gatewayPayoutId = "po_paid_1234567890";
-    private ZonedDateTime eventDate = parse("2020-05-13T18:50:00Z");
+    private ZonedDateTime eventDate = parse("2020-05-13T18:45:33.000000Z");
     private String eventType = "PAYOUT_PAID";
 
     @Pact(provider = "connector", consumer = "ledger")
@@ -72,7 +72,7 @@ public class PayoutPaidEventQueueConsumerIT {
         Optional<PayoutEntity> payoutEntity = payoutDao.findByGatewayPayoutId(gatewayPayoutId);
         assertThat(payoutEntity.isPresent(), is(true));
         assertThat(payoutEntity.get().getGatewayPayoutId(), is(gatewayPayoutId));
-        assertThat(payoutEntity.get().getPaidOutDate().toString(), is("2020-05-13T18:50Z"));
+        assertThat(payoutEntity.get().getPaidOutDate().toString(), is("2020-05-13T18:45:33Z"));
         assertThat(payoutEntity.get().getState(), is(PAID_OUT));
 
         Map<String, Object> payoutDetails = new Gson().fromJson(payoutEntity.get().getPayoutDetails(), Map.class);

--- a/src/test/java/uk/gov/pay/ledger/pact/event/RefundCreatedByUserEventQueueConsumerIT.java
+++ b/src/test/java/uk/gov/pay/ledger/pact/event/RefundCreatedByUserEventQueueConsumerIT.java
@@ -47,7 +47,7 @@ public class RefundCreatedByUserEventQueueConsumerIT {
     private QueueRefundEventFixture refundFixture = aQueueRefundEventFixture()
             .withResourceType(ResourceType.REFUND)
             .withEventType("REFUND_CREATED_BY_USER")
-            .withRefundedBy("a_user_id")
+            .withRefundedBy("user_external_id")
             .withUserEmail("test@example.com")
             .withDefaultEventDataForEventType("REFUND_CREATED_BY_USER");
 

--- a/src/test/java/uk/gov/pay/ledger/pact/event/RefundIncludedInPayoutEventQueueConsumerIT.java
+++ b/src/test/java/uk/gov/pay/ledger/pact/event/RefundIncludedInPayoutEventQueueConsumerIT.java
@@ -42,7 +42,7 @@ public class RefundIncludedInPayoutEventQueueConsumerIT {
 
     private byte[] currentMessage;
     private String refundExternalId = "refund-external-id";
-    private String payoutId = "po_12345";
+    private String payoutId = "po_1234567890";
     private ZonedDateTime eventDate = ZonedDateTime.parse("2018-03-12T16:25:01.123456Z");
     private QueueRefundEventFixture refundFixture;
 

--- a/src/test/java/uk/gov/pay/ledger/queue/QueueMessageReceiverIT.java
+++ b/src/test/java/uk/gov/pay/ledger/queue/QueueMessageReceiverIT.java
@@ -218,18 +218,18 @@ public class QueueMessageReceiverIT {
 
         Optional<TransactionEntity> mayBeRefund = transactionDao.findTransactionByExternalId(resourceExternalId);
         TransactionEntity refund = mayBeRefund.get();
-        assertThat(refund.getCardholderName(), is("J citizen"));
-        assertThat(refund.getEmail(), is("j.doe@example.org"));
+        assertThat(refund.getCardholderName(), is("Mr Test"));
+        assertThat(refund.getEmail(), is("test@email.invalid"));
         assertThat(refund.getCardBrand(), is("visa"));
-        assertThat(refund.getDescription(), is("a description"));
+        assertThat(refund.getDescription(), is("This is a description"));
         assertThat(refund.getLastDigitsCardNumber(), is("4242"));
         assertThat(refund.getFirstDigitsCardNumber(), is("424242"));
-        assertThat(refund.getReference(), is("aref"));
+        assertThat(refund.getReference(), is("This is a reference"));
         Map<String, Object> transactionDetails = new Gson().fromJson(refund.getTransactionDetails(), Map.class);
         Map<String, String> paymentDetails = (Map<String, String>) transactionDetails.get("payment_details");
 
         assertThat(paymentDetails.get("card_brand_label"), is("Visa"));
-        assertThat(paymentDetails.get("expiry_date"), is("11/21"));
+        assertThat(paymentDetails.get("expiry_date"), is("12/99"));
         assertThat(paymentDetails.get("card_type"), is("DEBIT"));
     }
 
@@ -416,13 +416,13 @@ public class QueueMessageReceiverIT {
         assertThat(dispute, hasEntry("fee", null));
         assertThat(dispute, hasEntry("net_amount", null));
 
-        assertThat(dispute, hasEntry("cardholder_name", "J citizen"));
-        assertThat(dispute, hasEntry("email", "j.doe@example.org"));
+        assertThat(dispute, hasEntry("cardholder_name", "Mr Test"));
+        assertThat(dispute, hasEntry("email", "test@email.invalid"));
         assertThat(dispute, hasEntry("card_brand", "visa"));
-        assertThat(dispute, hasEntry("description", "a description"));
+        assertThat(dispute, hasEntry("description", "This is a description"));
         assertThat(dispute, hasEntry("last_digits_card_number", "4242"));
         assertThat(dispute, hasEntry("first_digits_card_number", "424242"));
-        assertThat(dispute, hasEntry("reference", "aref"));
+        assertThat(dispute, hasEntry("reference", "This is a reference"));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/ledger/util/fixture/QueueDisputeEventFixture.java
+++ b/src/test/java/uk/gov/pay/ledger/util/fixture/QueueDisputeEventFixture.java
@@ -79,7 +79,7 @@ public class QueueDisputeEventFixture implements QueueFixture<QueueDisputeEventF
                                 .put("gateway_account_id", "a-gateway-account-id")
                                 .put("amount", 6500)
                                 .put("reason", "duplicate")
-                                .put("evidence_due_date", "2022-02-14T23:59:59.000Z")
+                                .put("evidence_due_date", "2022-02-14T23:59:59.000000Z")
                                 .build());
                 break;
             case "DISPUTE_LOST":

--- a/src/test/java/uk/gov/pay/ledger/util/fixture/QueueEventFixtureUtil.java
+++ b/src/test/java/uk/gov/pay/ledger/util/fixture/QueueEventFixtureUtil.java
@@ -82,7 +82,11 @@ public class QueueEventFixtureUtil {
                             } else if (value.isBoolean()) {
                                 dslJsonBody.booleanType(e.getKey(), value.getAsBoolean());
                             } else {
-                                dslJsonBody.stringType(e.getKey(), value.getAsString());
+                                if (e.getKey().contains("id") || e.getKey().contains("date")) {
+                                    dslJsonBody.stringType(e.getKey(), value.getAsString());
+                                } else {
+                                    dslJsonBody.stringValue(e.getKey(), value.getAsString());
+                                }
                             }
                         } else if (e.getValue().isJsonArray()) {
                             // We're currently only adding a single example from an array to the pact, and then in the

--- a/src/test/java/uk/gov/pay/ledger/util/fixture/QueuePaymentEventFixture.java
+++ b/src/test/java/uk/gov/pay/ledger/util/fixture/QueuePaymentEventFixture.java
@@ -122,25 +122,25 @@ public class QueuePaymentEventFixture implements QueueFixture<QueuePaymentEventF
                 eventData = gsonBuilder.create()
                         .toJson(ImmutableMap.builder()
                                 .put("amount", 1000)
-                                .put("description", "a description")
+                                .put("description", "This is a description")
                                 .put("language", "en")
-                                .put("reference", "aref")
-                                .put("return_url", "https://example.org")
+                                .put("reference", "This is a reference")
+                                .put("return_url", "http://return.invalid")
                                 .put("gateway_account_id", gatewayAccountId)
                                 .put("credential_external_id", credentialExternalId)
                                 .put("payment_provider", "sandbox")
                                 .put("delayed_capture", false)
                                 .put("moto", false)
                                 .put("external_metadata", metadata)
-                                .put("email", "j.doe@example.org")
-                                .put("cardholder_name", "J citizen")
-                                .put("address_line1", "12 Rouge Avenue")
-                                .put("address_postcode", "N1 3QU")
+                                .put("email", "test@email.invalid")
+                                .put("cardholder_name", "Mr Test")
+                                .put("address_line1", "125 Kingsway")
+                                .put("address_postcode", "WC2B 6NH")
                                 .put("address_city", "London")
                                 .put("source", CARD_API)
                                 .put("address_country", "GB")
                                 .put("authorisation_mode", "web")
-                                .put("agreement_id", "an-agreement-id")
+                                .put("agreement_id", "an-agreement-external-id")
                                 .build());
                 break;
             case "PAYMENT_DETAILS_ENTERED":
@@ -148,10 +148,10 @@ public class QueuePaymentEventFixture implements QueueFixture<QueuePaymentEventF
                         .toJson(ImmutableMap.builder()
                                 .put("last_digits_card_number", "4242")
                                 .put("first_digits_card_number", "424242")
-                                .put("cardholder_name", "J citizen")
-                                .put("expiry_date", "11/21")
-                                .put("address_line1", "12 Rouge Avenue")
-                                .put("address_postcode", "N1 3QU")
+                                .put("cardholder_name", "Mr Test")
+                                .put("expiry_date", "12/99")
+                                .put("address_line1", "125 Kingsway")
+                                .put("address_postcode", "WC2B 6NH")
                                 .put("address_city", "London")
                                 .put("address_country", "GB")
                                 .put("card_type", "DEBIT")
@@ -167,8 +167,8 @@ public class QueuePaymentEventFixture implements QueueFixture<QueuePaymentEventF
                         .toJson(ImmutableMap.builder()
                                 .put("last_digits_card_number", "4242")
                                 .put("first_digits_card_number", "424242")
-                                .put("cardholder_name", "J citizen")
-                                .put("expiry_date", "11/21")
+                                .put("cardholder_name", "Mr Test")
+                                .put("expiry_date", "12/99")
                                 .put("card_type", "DEBIT")
                                 .put("card_brand", "visa")
                                 .put("card_brand_label", "Visa")
@@ -192,20 +192,20 @@ public class QueuePaymentEventFixture implements QueueFixture<QueuePaymentEventF
                 externalMetadata.addProperty("processor_id", "processorId");
                 externalMetadata.addProperty("authorised_date", "2018-02-21T16:05:33Z");
                 externalMetadata.addProperty("created_date", "2018-02-21T15:05:13Z");
-                externalMetadata.addProperty("auth_code", "authCode");
+                externalMetadata.addProperty("auth_code", "012345");
                 externalMetadata.addProperty("status", "success");
                 eventData = gsonBuilder.create()
                     .toJson(ImmutableMap.builder()
                             .put("credential_external_id", credentialExternalId)
                             .put("amount", 1000)
-                            .put("description", "New passport application")
-                            .put("reference", "MRPC12345")
+                            .put("description", "This is a description")
+                            .put("reference", "This is a reference")
                             .put("email", "j.doe@example.org")
                             .put("external_metadata", externalMetadata)
                             .put("last_digits_card_number", "4242")
                             .put("first_digits_card_number", "424242")
-                            .put("cardholder_name", "J citizen")
-                            .put("expiry_date", "11/21")
+                            .put("cardholder_name", "Mr Test")
+                            .put("expiry_date", "12/99")
                             .put("card_brand", "visa")
                             .put("card_brand_label", "Visa")
                             .put("payment_provider", "sandbox")
@@ -213,7 +213,7 @@ public class QueuePaymentEventFixture implements QueueFixture<QueuePaymentEventF
                             .build());
                 break;
             case "CANCELLED_BY_USER":
-                eventData = gsonBuilder.create().toJson(Map.of("gateway_transaction_id", "validGatewayTransactionId"));
+                eventData = gsonBuilder.create().toJson(Map.of("gateway_transaction_id", "gateway_transaction_id"));
                 break;
             case "USER_EMAIL_COLLECTED":
                 eventData = gsonBuilder.create().toJson(Map.of("email", "test@example.org"));
@@ -222,13 +222,13 @@ public class QueuePaymentEventFixture implements QueueFixture<QueuePaymentEventF
                 eventData = gsonBuilder.create().toJson(Map.of("exemption_3ds_requested", "OPTIMISED"));
                 break;
             case "GATEWAY_3DS_EXEMPTION_RESULT_OBTAINED":
-                eventData = gsonBuilder.create().toJson(Map.of("exemption3ds", "HONOURED"));
+                eventData = gsonBuilder.create().toJson(Map.of("exemption3ds", "EXEMPTION_HONOURED"));
                 break;
             case "GATEWAY_3DS_INFO_OBTAINED":
                 eventData = gsonBuilder.create().toJson(Map.of("version_3ds", "2.1.0"));
                 break;
             case "GATEWAY_REQUIRES_3DS_AUTHORISATION":
-                eventData = gsonBuilder.create().toJson(Map.of("version_3ds", "1.2.1", "requires_3ds", true));
+                eventData = gsonBuilder.create().toJson(Map.of("version_3ds", "2.1.0", "requires_3ds", true));
                 break;
             case "GATEWAY_DOES_NOT_REQUIRE_3DS_AUTHORISATION":
                 eventData = gsonBuilder.create().toJson(Map.of("requires_3ds", false));

--- a/src/test/java/uk/gov/pay/ledger/util/fixture/QueuePayoutEventFixture.java
+++ b/src/test/java/uk/gov/pay/ledger/util/fixture/QueuePayoutEventFixture.java
@@ -60,7 +60,7 @@ public class QueuePayoutEventFixture implements QueueFixture<QueuePayoutEventFix
             case "PAYOUT_PAID":
                 eventData = new GsonBuilder().create()
                         .toJson(ImmutableMap.builder()
-                                .put("paid_out_date", "2020-05-13T18:50:00.000000Z")
+                                .put("paid_out_date", "2020-05-13T18:45:33.000000Z")
                                 .put("gateway_status", "paid")
                                 .build());
                 break;

--- a/src/test/java/uk/gov/pay/ledger/util/fixture/QueueRefundEventFixture.java
+++ b/src/test/java/uk/gov/pay/ledger/util/fixture/QueueRefundEventFixture.java
@@ -79,7 +79,7 @@ public class QueueRefundEventFixture implements QueueFixture<QueueRefundEventFix
             case "REFUND_CREATED_BY_USER":
                 eventData = new GsonBuilder().create()
                         .toJson(ImmutableMap.builder()
-                                .put("gateway_account_id", gatewayAccountId)
+                                .put("gateway_account_id", "1")
                                 .put("amount", amount)
                                 .put("refunded_by", refundedBy)
                                 .put("user_email", userEmail)


### PR DESCRIPTION
Current setup checks if the type of the JsonElement of the Json payload coming from the provider (connector) is matching the type of the JsonElement of the Json payload of what the consumer (ledger) expects. This will match `honoured` to `HONOURED` or `EXEMPTION_HONOURED` to `HONOURED`.

Refactor `QueueEventFixtureUtil.getNestedPact()` to use strict, value based matching of strings. Also refactor existing tests to match values generated by `connector`