### PR TITLE
PP-13622 Fix incorrect negation for won disputes in CSV files

### DIFF
--- a/src/main/java/uk/gov/pay/ledger/transaction/model/CsvTransactionFactory.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/model/CsvTransactionFactory.java
@@ -31,6 +31,7 @@ import static org.apache.commons.lang3.StringUtils.replaceChars;
 import static org.apache.commons.text.WordUtils.capitalizeFully;
 import static uk.gov.pay.ledger.transaction.model.TransactionType.DISPUTE;
 import static uk.gov.pay.ledger.transaction.model.TransactionType.REFUND;
+import static uk.gov.pay.ledger.transaction.state.TransactionState.WON;
 import static uk.gov.pay.ledger.util.JsonParser.safeGetAsBoolean;
 import static uk.gov.pay.ledger.util.JsonParser.safeGetAsLong;
 import static uk.gov.pay.ledger.util.JsonParser.safeGetAsString;
@@ -154,7 +155,11 @@ public class CsvTransactionFactory {
                         getPaymentTransactionAttributes(transactionEntity, transactionDetails.get("payment_details"))
                 );
                 result.put(FIELD_GOVUK_PAYMENT_ID, transactionEntity.getParentExternalId());
-                result.put(FIELD_AMOUNT, penceToCurrency(transactionEntity.getAmount() * -1));
+                if (transactionEntity.getState() == WON) {
+                    result.put(FIELD_AMOUNT, penceToCurrency(transactionEntity.getAmount()));
+                } else {
+                    result.put(FIELD_AMOUNT, penceToCurrency(transactionEntity.getAmount() * -1));
+                }
             }
 
             result.put(FIELD_PROVIDER_ID, sanitiseAgainstSpreadsheetFormulaInjection(transactionEntity.getGatewayTransactionId()));

--- a/src/test/java/uk/gov/pay/ledger/transaction/model/CsvTransactionFactoryTest.java
+++ b/src/test/java/uk/gov/pay/ledger/transaction/model/CsvTransactionFactoryTest.java
@@ -146,6 +146,35 @@ class CsvTransactionFactoryTest {
     }
 
     @Test
+    void toMapShouldNotNegateAmountForWonDisputeTransaction() {
+        TransactionEntity transactionEntity = transactionFixture
+                .withTransactionType(TransactionType.DISPUTE.name())
+                .withState(TransactionState.WON)
+                .withAmount(2000L)
+                .withFee(0L)
+                .withNetAmount(2000L)
+                .withParentExternalId("parent-external-id")
+                .withReference("ref-1")
+                .withDescription("test description")
+                .withDefaultPaymentDetails()
+                .withDefaultTransactionDetails()
+                .toEntity();
+
+        Map<String, Object> csvDataMap = csvTransactionFactory.toMap(transactionEntity);
+
+        assertPaymentDetails(csvDataMap, transactionEntity);
+        assertThat(csvDataMap.get("Amount"), is("20.00"));
+        assertThat(csvDataMap.get("Net"), is("20.00"));
+        assertThat(csvDataMap.get("Fee"), is("0.00"));
+        assertThat(csvDataMap.get("Provider ID"), is(transactionFixture.getGatewayTransactionId()));
+        assertThat(csvDataMap.get("GOV.UK Payment ID"), is(transactionFixture.getParentExternalId()));
+        assertThat(csvDataMap.get("State"), is("Dispute won in your favour"));
+        assertThat(csvDataMap.get("Finished"), is(true));
+        assertThat(csvDataMap.get("Date Created"), is("12 Mar 2018"));
+        assertThat(csvDataMap.get("Time Created"), is("16:25:01"));
+    }
+
+    @Test
     void toMapShouldUseAmountForTotalAmountForSuccessfulPayment() {
         TransactionEntity transactionEntity = transactionFixture
                 .withState(TransactionState.SUCCESS)


### PR DESCRIPTION
With this change, we are fixing a bug for which disputed amounts are shown as negative numbers in the CSV files.

The logic will now consider also the state of the dispute and present the value as positive when the dispute has been won by the service.

Further information in Jira.

https://payments-platform.atlassian.net/browse/PP-13622