### PR TITLE
PP-13646 update AWS SDK to version 2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,9 +37,9 @@
                 <scope>import</scope>
             </dependency>
             <dependency>
-                <groupId>com.amazonaws</groupId>
-                <artifactId>aws-java-sdk-bom</artifactId>
-                <version>1.12.782</version>
+                <groupId>software.amazon.awssdk</groupId>
+                <artifactId>bom</artifactId>
+                <version>2.31.33</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -109,8 +109,12 @@
             <artifactId>jackson-dataformat-csv</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.amazonaws</groupId>
-            <artifactId>aws-java-sdk-sqs</artifactId>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>sqs</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>sns</artifactId>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>
@@ -169,13 +173,8 @@
         </dependency>
         <dependency>
             <groupId>uk.gov.service.payments</groupId>
-            <artifactId>queue-dropwizard-4</artifactId>
+            <artifactId>queue-dropwizard-4-aws-sdk-v2</artifactId>
             <version>${pay-java-commons.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>software.amazon.awssdk</groupId>
-            <artifactId>sns</artifactId>
-            <version>2.31.30</version>
         </dependency>
         <dependency>
             <groupId>com.google.code.gson</groupId>

--- a/src/test/java/uk/gov/pay/ledger/extension/AppWithPostgresAndSqsExtension.java
+++ b/src/test/java/uk/gov/pay/ledger/extension/AppWithPostgresAndSqsExtension.java
@@ -1,6 +1,5 @@
 package uk.gov.pay.ledger.extension;
 
-import com.amazonaws.services.sqs.AmazonSQS;
 import io.dropwizard.testing.ConfigOverride;
 import io.dropwizard.testing.junit5.DropwizardAppExtension;
 import org.jdbi.v3.core.Jdbi;
@@ -10,6 +9,7 @@ import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.services.sqs.SqsClient;
 import uk.gov.pay.ledger.app.LedgerApp;
 import uk.gov.pay.ledger.app.LedgerConfig;
 import uk.gov.pay.ledger.rule.SqsTestDocker;
@@ -30,7 +30,7 @@ public class AppWithPostgresAndSqsExtension implements BeforeAllCallback, AfterA
 
     private static String CONFIG_PATH = resourceFilePath("config/test-config.yaml");
     private final Jdbi jdbi;
-    private AmazonSQS sqsClient;
+    private SqsClient sqsClient;
     private DropwizardAppExtension<LedgerConfig> dropwizardAppExtension;
 
     public AppWithPostgresAndSqsExtension() {
@@ -40,7 +40,7 @@ public class AppWithPostgresAndSqsExtension implements BeforeAllCallback, AfterA
     public AppWithPostgresAndSqsExtension(ConfigOverride... configOverrides) {
         getOrCreate();
 
-        sqsClient = SqsTestDocker.initialise("event-queue");
+        sqsClient = SqsTestDocker.initialise(List.of("event-queue"));
 
         ConfigOverride[] newConfigOverrides = overrideDatabaseConfig(configOverrides);
         newConfigOverrides = overrideSqsConfig(newConfigOverrides);
@@ -94,7 +94,7 @@ public class AppWithPostgresAndSqsExtension implements BeforeAllCallback, AfterA
         return jdbi;
     }
 
-    public AmazonSQS getSqsClient() {
+    public SqsClient getSqsClient() {
         return sqsClient;
     }
 }

--- a/src/test/java/uk/gov/pay/ledger/pact/event/CancelledByUserEventQueueConsumerIT.java
+++ b/src/test/java/uk/gov/pay/ledger/pact/event/CancelledByUserEventQueueConsumerIT.java
@@ -8,6 +8,7 @@ import au.com.dius.pact.core.model.messaging.MessagePact;
 import com.google.gson.Gson;
 import org.junit.Rule;
 import org.junit.Test;
+import software.amazon.awssdk.services.sqs.model.SendMessageRequest;
 import uk.gov.pay.ledger.app.LedgerConfig;
 import uk.gov.pay.ledger.event.model.SalientEventType;
 import uk.gov.pay.ledger.rule.AppWithPostgresAndSqsRule;
@@ -67,7 +68,11 @@ public class CancelledByUserEventQueueConsumerIT {
     @Test
     @PactVerification({"connector"})
     public void test() {
-        appRule.getSqsClient().sendMessage(SqsTestDocker.getQueueUrl("event-queue"), new String(currentMessage));
+        SendMessageRequest messageRequest = SendMessageRequest.builder()
+                .queueUrl(SqsTestDocker.getQueueUrl("event-queue"))
+                .messageBody(new String(currentMessage))
+                .build();
+        appRule.getSqsClient().sendMessage(messageRequest);
 
         TransactionDao transactionDao = new TransactionDao(appRule.getJdbi(), mock(LedgerConfig.class));
 

--- a/src/test/java/uk/gov/pay/ledger/pact/event/CaptureConfirmedEventQueueConsumerIT.java
+++ b/src/test/java/uk/gov/pay/ledger/pact/event/CaptureConfirmedEventQueueConsumerIT.java
@@ -9,6 +9,7 @@ import au.com.dius.pact.core.model.messaging.MessagePact;
 import com.google.gson.Gson;
 import org.junit.Rule;
 import org.junit.Test;
+import software.amazon.awssdk.services.sqs.model.SendMessageRequest;
 import uk.gov.pay.ledger.app.LedgerConfig;
 import uk.gov.pay.ledger.event.dao.EventDao;
 import uk.gov.pay.ledger.event.entity.EventEntity;
@@ -71,7 +72,11 @@ public class CaptureConfirmedEventQueueConsumerIT {
     @Test
     @PactVerification({"connector"})
     public void test() {
-        appRule.getSqsClient().sendMessage(SqsTestDocker.getQueueUrl("event-queue"), new String(currentMessage));
+        SendMessageRequest messageRequest = SendMessageRequest.builder()
+                .queueUrl(SqsTestDocker.getQueueUrl("event-queue"))
+                .messageBody(new String(currentMessage))
+                .build();
+        appRule.getSqsClient().sendMessage(messageRequest);
 
         TransactionDao transactionDao = new TransactionDao(appRule.getJdbi(), mock(LedgerConfig.class));
         EventDao eventDao = appRule.getJdbi().onDemand(EventDao.class);

--- a/src/test/java/uk/gov/pay/ledger/pact/event/CaptureSubmittedEventQueueConsumerIT.java
+++ b/src/test/java/uk/gov/pay/ledger/pact/event/CaptureSubmittedEventQueueConsumerIT.java
@@ -8,6 +8,7 @@ import au.com.dius.pact.core.model.messaging.MessagePact;
 import com.google.gson.Gson;
 import org.junit.Rule;
 import org.junit.Test;
+import software.amazon.awssdk.services.sqs.model.SendMessageRequest;
 import uk.gov.pay.ledger.app.LedgerConfig;
 import uk.gov.pay.ledger.event.model.SalientEventType;
 import uk.gov.pay.ledger.rule.AppWithPostgresAndSqsRule;
@@ -67,7 +68,11 @@ public class CaptureSubmittedEventQueueConsumerIT {
     @Test
     @PactVerification({"connector"})
     public void test() {
-        appRule.getSqsClient().sendMessage(SqsTestDocker.getQueueUrl("event-queue"), new String(currentMessage));
+        SendMessageRequest messageRequest = SendMessageRequest.builder()
+                .queueUrl(SqsTestDocker.getQueueUrl("event-queue"))
+                .messageBody(new String(currentMessage))
+                .build();
+        appRule.getSqsClient().sendMessage(messageRequest);
 
         TransactionDao transactionDao = new TransactionDao(appRule.getJdbi(), mock(LedgerConfig.class));
 

--- a/src/test/java/uk/gov/pay/ledger/pact/event/DisputeCreatedEventQueueConsumerIT.java
+++ b/src/test/java/uk/gov/pay/ledger/pact/event/DisputeCreatedEventQueueConsumerIT.java
@@ -12,6 +12,7 @@ import com.google.gson.Gson;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import software.amazon.awssdk.services.sqs.model.SendMessageRequest;
 import uk.gov.pay.ledger.app.LedgerConfig;
 import uk.gov.pay.ledger.event.dao.EventDao;
 import uk.gov.pay.ledger.event.entity.EventEntity;
@@ -96,7 +97,11 @@ public class DisputeCreatedEventQueueConsumerIT {
     @Test
     @PactVerification({"connector"})
     public void test() throws JsonProcessingException {
-        appRule.getSqsClient().sendMessage(SqsTestDocker.getQueueUrl("event-queue"), new String(currentMessage));
+        SendMessageRequest messageRequest = SendMessageRequest.builder()
+                .queueUrl(SqsTestDocker.getQueueUrl("event-queue"))
+                .messageBody(new String(currentMessage))
+                .build();
+        appRule.getSqsClient().sendMessage(messageRequest);
         EventDao eventDao = appRule.getJdbi().onDemand(EventDao.class);
         await().atMost(1, TimeUnit.SECONDS).until(
                 () -> !eventDao.findEventsForExternalIds(Set.of(resourceExternalId)).isEmpty()

--- a/src/test/java/uk/gov/pay/ledger/pact/event/DisputeEvidenceSubmittedEventQueueConsumerIT.java
+++ b/src/test/java/uk/gov/pay/ledger/pact/event/DisputeEvidenceSubmittedEventQueueConsumerIT.java
@@ -12,6 +12,7 @@ import com.google.gson.GsonBuilder;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import software.amazon.awssdk.services.sqs.model.SendMessageRequest;
 import uk.gov.pay.ledger.app.LedgerConfig;
 import uk.gov.pay.ledger.event.dao.EventDao;
 import uk.gov.pay.ledger.event.entity.EventEntity;
@@ -96,7 +97,11 @@ public class DisputeEvidenceSubmittedEventQueueConsumerIT {
     @Test
     @PactVerification({"connector"})
     public void test() throws JsonProcessingException {
-        appRule.getSqsClient().sendMessage(SqsTestDocker.getQueueUrl("event-queue"), new String(currentMessage));
+        SendMessageRequest messageRequest = SendMessageRequest.builder()
+                .queueUrl(SqsTestDocker.getQueueUrl("event-queue"))
+                .messageBody(new String(currentMessage))
+                .build();
+        appRule.getSqsClient().sendMessage(messageRequest);
         EventDao eventDao = appRule.getJdbi().onDemand(EventDao.class);
         await().atMost(1, TimeUnit.SECONDS).until(
                 () -> !eventDao.findEventsForExternalIds(Set.of(resourceExternalId)).isEmpty()

--- a/src/test/java/uk/gov/pay/ledger/pact/event/DisputeLostEventQueueConsumerIT.java
+++ b/src/test/java/uk/gov/pay/ledger/pact/event/DisputeLostEventQueueConsumerIT.java
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import software.amazon.awssdk.services.sqs.model.SendMessageRequest;
 import uk.gov.pay.ledger.app.LedgerConfig;
 import uk.gov.pay.ledger.event.dao.EventDao;
 import uk.gov.pay.ledger.event.entity.EventEntity;
@@ -96,7 +97,11 @@ public class DisputeLostEventQueueConsumerIT {
     @Test
     @PactVerification({"connector"})
     public void test() throws JsonProcessingException {
-        appRule.getSqsClient().sendMessage(SqsTestDocker.getQueueUrl("event-queue"), new String(currentMessage));
+        SendMessageRequest messageRequest = SendMessageRequest.builder()
+                .queueUrl(SqsTestDocker.getQueueUrl("event-queue"))
+                .messageBody(new String(currentMessage))
+                .build();
+        appRule.getSqsClient().sendMessage(messageRequest);
         EventDao eventDao = appRule.getJdbi().onDemand(EventDao.class);
         await().atMost(1, TimeUnit.SECONDS).until(
                 () -> !eventDao.findEventsForExternalIds(Set.of(resourceExternalId)).isEmpty()

--- a/src/test/java/uk/gov/pay/ledger/pact/event/DisputeWonEventQueueConsumerIT.java
+++ b/src/test/java/uk/gov/pay/ledger/pact/event/DisputeWonEventQueueConsumerIT.java
@@ -12,6 +12,7 @@ import com.google.gson.GsonBuilder;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import software.amazon.awssdk.services.sqs.model.SendMessageRequest;
 import uk.gov.pay.ledger.app.LedgerConfig;
 import uk.gov.pay.ledger.event.dao.EventDao;
 import uk.gov.pay.ledger.event.entity.EventEntity;
@@ -96,7 +97,11 @@ public class DisputeWonEventQueueConsumerIT {
     @Test
     @PactVerification({"connector"})
     public void test() throws JsonProcessingException {
-        appRule.getSqsClient().sendMessage(SqsTestDocker.getQueueUrl("event-queue"), new String(currentMessage));
+        SendMessageRequest messageRequest = SendMessageRequest.builder()
+                                .queueUrl(SqsTestDocker.getQueueUrl("event-queue"))
+                                .messageBody(new String(currentMessage))
+                                .build();
+        appRule.getSqsClient().sendMessage(messageRequest);
         EventDao eventDao = appRule.getJdbi().onDemand(EventDao.class);
         await().atMost(1, TimeUnit.SECONDS).until(
                 () -> !eventDao.findEventsForExternalIds(Set.of(resourceExternalId)).isEmpty()

--- a/src/test/java/uk/gov/pay/ledger/pact/event/FeeIncurredEventQueueConsumerIT.java
+++ b/src/test/java/uk/gov/pay/ledger/pact/event/FeeIncurredEventQueueConsumerIT.java
@@ -9,6 +9,7 @@ import com.google.gson.GsonBuilder;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import software.amazon.awssdk.services.sqs.model.SendMessageRequest;
 import uk.gov.pay.ledger.app.LedgerConfig;
 import uk.gov.pay.ledger.rule.AppWithPostgresAndSqsRule;
 import uk.gov.pay.ledger.rule.SqsTestDocker;
@@ -86,7 +87,11 @@ public class FeeIncurredEventQueueConsumerIT {
     @Test
     @PactVerification({"connector"})
     public void test() {
-        appRule.getSqsClient().sendMessage(SqsTestDocker.getQueueUrl("event-queue"), new String(currentMessage));
+        SendMessageRequest messageRequest = SendMessageRequest.builder()
+                .queueUrl(SqsTestDocker.getQueueUrl("event-queue"))
+                .messageBody(new String(currentMessage))
+                .build();
+        appRule.getSqsClient().sendMessage(messageRequest);
 
         TransactionDao transactionDao = new TransactionDao(appRule.getJdbi(), mock(LedgerConfig.class));
 

--- a/src/test/java/uk/gov/pay/ledger/pact/event/Gateway3dsExemptionResultObtainedEventQueueConsumerIT.java
+++ b/src/test/java/uk/gov/pay/ledger/pact/event/Gateway3dsExemptionResultObtainedEventQueueConsumerIT.java
@@ -7,6 +7,7 @@ import au.com.dius.pact.core.model.annotations.Pact;
 import au.com.dius.pact.core.model.messaging.MessagePact;
 import org.junit.Rule;
 import org.junit.Test;
+import software.amazon.awssdk.services.sqs.model.SendMessageRequest;
 import uk.gov.pay.ledger.app.LedgerConfig;
 import uk.gov.pay.ledger.rule.AppWithPostgresAndSqsRule;
 import uk.gov.pay.ledger.rule.SqsTestDocker;
@@ -66,7 +67,11 @@ public class Gateway3dsExemptionResultObtainedEventQueueConsumerIT {
     public void test() {
         TransactionDao transactionDao = new TransactionDao(appRule.getJdbi(), mock(LedgerConfig.class));
 
-        appRule.getSqsClient().sendMessage(SqsTestDocker.getQueueUrl("event-queue"), new String(currentMessage));
+        SendMessageRequest messageRequest = SendMessageRequest.builder()
+                .queueUrl(SqsTestDocker.getQueueUrl("event-queue"))
+                .messageBody(new String(currentMessage))
+                .build();
+        appRule.getSqsClient().sendMessage(messageRequest);
 
         await().atMost(1, TimeUnit.SECONDS).until(
                 () -> transactionDao.findTransactionByExternalId(externalId).isPresent()

--- a/src/test/java/uk/gov/pay/ledger/pact/event/Gateway3dsInfoObtainedEventQueueConsumerIT.java
+++ b/src/test/java/uk/gov/pay/ledger/pact/event/Gateway3dsInfoObtainedEventQueueConsumerIT.java
@@ -7,6 +7,7 @@ import au.com.dius.pact.core.model.annotations.Pact;
 import au.com.dius.pact.core.model.messaging.MessagePact;
 import org.junit.Rule;
 import org.junit.Test;
+import software.amazon.awssdk.services.sqs.model.SendMessageRequest;
 import uk.gov.pay.ledger.app.LedgerConfig;
 import uk.gov.pay.ledger.rule.AppWithPostgresAndSqsRule;
 import uk.gov.pay.ledger.rule.SqsTestDocker;
@@ -66,7 +67,11 @@ public class Gateway3dsInfoObtainedEventQueueConsumerIT {
     public void test() {
         TransactionDao transactionDao = new TransactionDao(appRule.getJdbi(), mock(LedgerConfig.class));
 
-        appRule.getSqsClient().sendMessage(SqsTestDocker.getQueueUrl("event-queue"), new String(currentMessage));
+        SendMessageRequest messageRequest = SendMessageRequest.builder()
+                .queueUrl(SqsTestDocker.getQueueUrl("event-queue"))
+                .messageBody(new String(currentMessage))
+                .build();
+        appRule.getSqsClient().sendMessage(messageRequest);
 
         await().atMost(1, TimeUnit.SECONDS).until(
                 () -> transactionDao.findTransactionByExternalId(externalId).isPresent()

--- a/src/test/java/uk/gov/pay/ledger/pact/event/GatewayDoesNotRequire3dsAuthorisationEventQueueConsumerIT.java
+++ b/src/test/java/uk/gov/pay/ledger/pact/event/GatewayDoesNotRequire3dsAuthorisationEventQueueConsumerIT.java
@@ -7,6 +7,7 @@ import au.com.dius.pact.core.model.annotations.Pact;
 import au.com.dius.pact.core.model.messaging.MessagePact;
 import org.junit.Rule;
 import org.junit.Test;
+import software.amazon.awssdk.services.sqs.model.SendMessageRequest;
 import uk.gov.pay.ledger.app.LedgerConfig;
 import uk.gov.pay.ledger.rule.AppWithPostgresAndSqsRule;
 import uk.gov.pay.ledger.rule.SqsTestDocker;
@@ -67,7 +68,11 @@ public class GatewayDoesNotRequire3dsAuthorisationEventQueueConsumerIT {
     public void test() {
         TransactionDao transactionDao = new TransactionDao(appRule.getJdbi(), mock(LedgerConfig.class));
 
-        appRule.getSqsClient().sendMessage(SqsTestDocker.getQueueUrl("event-queue"), new String(currentMessage));
+        SendMessageRequest messageRequest = SendMessageRequest.builder()
+                .queueUrl(SqsTestDocker.getQueueUrl("event-queue"))
+                .messageBody(new String(currentMessage))
+                .build();
+        appRule.getSqsClient().sendMessage(messageRequest);
 
         await().atMost(1, TimeUnit.SECONDS).until(
                 () -> transactionDao.findTransactionByExternalId(externalId).isPresent()

--- a/src/test/java/uk/gov/pay/ledger/pact/event/GatewayRequires3dsAuthorisationEventQueueConsumerIT.java
+++ b/src/test/java/uk/gov/pay/ledger/pact/event/GatewayRequires3dsAuthorisationEventQueueConsumerIT.java
@@ -7,6 +7,7 @@ import au.com.dius.pact.core.model.annotations.Pact;
 import au.com.dius.pact.core.model.messaging.MessagePact;
 import org.junit.Rule;
 import org.junit.Test;
+import software.amazon.awssdk.services.sqs.model.SendMessageRequest;
 import uk.gov.pay.ledger.app.LedgerConfig;
 import uk.gov.pay.ledger.rule.AppWithPostgresAndSqsRule;
 import uk.gov.pay.ledger.rule.SqsTestDocker;
@@ -67,7 +68,11 @@ public class GatewayRequires3dsAuthorisationEventQueueConsumerIT {
     public void test() {
         TransactionDao transactionDao = new TransactionDao(appRule.getJdbi(), mock(LedgerConfig.class));
 
-        appRule.getSqsClient().sendMessage(SqsTestDocker.getQueueUrl("event-queue"), new String(currentMessage));
+        SendMessageRequest messageRequest = SendMessageRequest.builder()
+                .queueUrl(SqsTestDocker.getQueueUrl("event-queue"))
+                .messageBody(new String(currentMessage))
+                .build();
+        appRule.getSqsClient().sendMessage(messageRequest);
 
         await().atMost(1, TimeUnit.SECONDS).until(
                 () -> transactionDao.findTransactionByExternalId(externalId).isPresent()

--- a/src/test/java/uk/gov/pay/ledger/pact/event/PaymentCreatedEventQueueConsumerIT.java
+++ b/src/test/java/uk/gov/pay/ledger/pact/event/PaymentCreatedEventQueueConsumerIT.java
@@ -7,8 +7,8 @@ import au.com.dius.pact.core.model.annotations.Pact;
 import au.com.dius.pact.core.model.messaging.MessagePact;
 import org.junit.Rule;
 import org.junit.Test;
+import software.amazon.awssdk.services.sqs.model.SendMessageRequest;
 import uk.gov.pay.ledger.app.LedgerConfig;
-import uk.gov.pay.ledger.event.dao.EventDao;
 import uk.gov.pay.ledger.rule.AppWithPostgresAndSqsRule;
 import uk.gov.pay.ledger.rule.SqsTestDocker;
 import uk.gov.pay.ledger.transaction.dao.TransactionDao;
@@ -66,10 +66,13 @@ public class PaymentCreatedEventQueueConsumerIT {
     @Test
     @PactVerification({"connector"})
     public void test() {
-        appRule.getSqsClient().sendMessage(SqsTestDocker.getQueueUrl("event-queue"), new String(currentMessage));
+        SendMessageRequest messageRequest = SendMessageRequest.builder()
+                .queueUrl(SqsTestDocker.getQueueUrl("event-queue"))
+                .messageBody(new String(currentMessage))
+                .build();
+        appRule.getSqsClient().sendMessage(messageRequest);
 
         TransactionDao transactionDao = new TransactionDao(appRule.getJdbi(), mock(LedgerConfig.class));
-        EventDao eventDao = appRule.getJdbi().onDemand(EventDao.class);
 
         await().atMost(1, TimeUnit.SECONDS).until(
                 () -> transactionDao.findTransactionByExternalIdAndGatewayAccountId(externalId, gatewayAccountId).isPresent()

--- a/src/test/java/uk/gov/pay/ledger/pact/event/PaymentDetailsEnteredEventQueueConsumerIT.java
+++ b/src/test/java/uk/gov/pay/ledger/pact/event/PaymentDetailsEnteredEventQueueConsumerIT.java
@@ -7,6 +7,7 @@ import au.com.dius.pact.core.model.annotations.Pact;
 import au.com.dius.pact.core.model.messaging.MessagePact;
 import org.junit.Rule;
 import org.junit.Test;
+import software.amazon.awssdk.services.sqs.model.SendMessageRequest;
 import uk.gov.pay.ledger.app.LedgerConfig;
 import uk.gov.pay.ledger.rule.AppWithPostgresAndSqsRule;
 import uk.gov.pay.ledger.rule.SqsTestDocker;
@@ -68,7 +69,11 @@ public class PaymentDetailsEnteredEventQueueConsumerIT {
         TransactionDao transactionDao = new TransactionDao(appRule.getJdbi(), mock(LedgerConfig.class));
         setupTransaction(transactionDao);
 
-        appRule.getSqsClient().sendMessage(SqsTestDocker.getQueueUrl("event-queue"), new String(currentMessage));
+        SendMessageRequest messageRequest = SendMessageRequest.builder()
+                .queueUrl(SqsTestDocker.getQueueUrl("event-queue"))
+                .messageBody(new String(currentMessage))
+                .build();
+        appRule.getSqsClient().sendMessage(messageRequest);
 
         await().atMost(1, TimeUnit.SECONDS).until(
                 () -> transactionDao.findTransactionByExternalId(externalId).isPresent()

--- a/src/test/java/uk/gov/pay/ledger/pact/event/PaymentDetailsSubmittedByAPIEventQueueConsumerIT.java
+++ b/src/test/java/uk/gov/pay/ledger/pact/event/PaymentDetailsSubmittedByAPIEventQueueConsumerIT.java
@@ -7,6 +7,7 @@ import au.com.dius.pact.core.model.annotations.Pact;
 import au.com.dius.pact.core.model.messaging.MessagePact;
 import org.junit.Rule;
 import org.junit.Test;
+import software.amazon.awssdk.services.sqs.model.SendMessageRequest;
 import uk.gov.pay.ledger.app.LedgerConfig;
 import uk.gov.pay.ledger.rule.AppWithPostgresAndSqsRule;
 import uk.gov.pay.ledger.rule.SqsTestDocker;
@@ -67,8 +68,11 @@ public class PaymentDetailsSubmittedByAPIEventQueueConsumerIT {
     public void test() {
         TransactionDao transactionDao = new TransactionDao(appRule.getJdbi(), mock(LedgerConfig.class));
         setupTransaction(transactionDao);
-
-        appRule.getSqsClient().sendMessage(SqsTestDocker.getQueueUrl("event-queue"), new String(currentMessage));
+        SendMessageRequest messageRequest = SendMessageRequest.builder()
+                .queueUrl(SqsTestDocker.getQueueUrl("event-queue"))
+                .messageBody(new String(currentMessage))
+                .build();
+        appRule.getSqsClient().sendMessage(messageRequest);
 
         await().atMost(1, TimeUnit.SECONDS).until(
                 () -> transactionDao.findTransactionByExternalId(externalId).isPresent()

--- a/src/test/java/uk/gov/pay/ledger/pact/event/PaymentIncludedInPayoutEventQueueConsumerIT.java
+++ b/src/test/java/uk/gov/pay/ledger/pact/event/PaymentIncludedInPayoutEventQueueConsumerIT.java
@@ -8,6 +8,7 @@ import au.com.dius.pact.core.model.messaging.MessagePact;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import software.amazon.awssdk.services.sqs.model.SendMessageRequest;
 import uk.gov.pay.ledger.app.LedgerConfig;
 import uk.gov.pay.ledger.event.dao.EventDao;
 import uk.gov.pay.ledger.rule.AppWithPostgresAndSqsRule;
@@ -70,7 +71,11 @@ public class PaymentIncludedInPayoutEventQueueConsumerIT {
     @Test
     @PactVerification({"connector"})
     public void test() {
-        appRule.getSqsClient().sendMessage(SqsTestDocker.getQueueUrl("event-queue"), new String(currentMessage));
+        SendMessageRequest messageRequest = SendMessageRequest.builder()
+                .queueUrl(SqsTestDocker.getQueueUrl("event-queue"))
+                .messageBody(new String(currentMessage))
+                .build();
+        appRule.getSqsClient().sendMessage(messageRequest);
 
         TransactionDao transactionDao = new TransactionDao(appRule.getJdbi(), mock(LedgerConfig.class));
         EventDao eventDao = appRule.getJdbi().onDemand(EventDao.class);

--- a/src/test/java/uk/gov/pay/ledger/pact/event/PaymentNotificationCreatedEventQueueConsumerIT.java
+++ b/src/test/java/uk/gov/pay/ledger/pact/event/PaymentNotificationCreatedEventQueueConsumerIT.java
@@ -7,6 +7,7 @@ import au.com.dius.pact.core.model.annotations.Pact;
 import au.com.dius.pact.core.model.messaging.MessagePact;
 import org.junit.Rule;
 import org.junit.Test;
+import software.amazon.awssdk.services.sqs.model.SendMessageRequest;
 import uk.gov.pay.ledger.app.LedgerConfig;
 import uk.gov.pay.ledger.event.dao.EventDao;
 import uk.gov.pay.ledger.rule.AppWithPostgresAndSqsRule;
@@ -68,7 +69,11 @@ public class PaymentNotificationCreatedEventQueueConsumerIT {
     @Test
     @PactVerification({"connector"})
     public void test() {
-        appRule.getSqsClient().sendMessage(SqsTestDocker.getQueueUrl("event-queue"), new String(currentMessage));
+        SendMessageRequest messageRequest = SendMessageRequest.builder()
+                .queueUrl(SqsTestDocker.getQueueUrl("event-queue"))
+                .messageBody(new String(currentMessage))
+                .build();
+        appRule.getSqsClient().sendMessage(messageRequest);
 
         TransactionDao transactionDao = new TransactionDao(appRule.getJdbi(), mock(LedgerConfig.class));
         EventDao eventDao = appRule.getJdbi().onDemand(EventDao.class);

--- a/src/test/java/uk/gov/pay/ledger/pact/event/PayoutCreatedEventQueueConsumerIT.java
+++ b/src/test/java/uk/gov/pay/ledger/pact/event/PayoutCreatedEventQueueConsumerIT.java
@@ -8,6 +8,7 @@ import au.com.dius.pact.core.model.messaging.MessagePact;
 import com.google.gson.Gson;
 import org.junit.Rule;
 import org.junit.Test;
+import software.amazon.awssdk.services.sqs.model.SendMessageRequest;
 import uk.gov.pay.ledger.payout.dao.PayoutDao;
 import uk.gov.pay.ledger.payout.entity.PayoutEntity;
 import uk.gov.pay.ledger.rule.AppWithPostgresAndSqsRule;
@@ -59,7 +60,11 @@ public class PayoutCreatedEventQueueConsumerIT {
     @Test
     @PactVerification({"connector"})
     public void test() {
-        appRule.getSqsClient().sendMessage(SqsTestDocker.getQueueUrl("event-queue"), new String(currentMessage));
+        SendMessageRequest messageRequest = SendMessageRequest.builder()
+                .queueUrl(SqsTestDocker.getQueueUrl("event-queue"))
+                .messageBody(new String(currentMessage))
+                .build();
+        appRule.getSqsClient().sendMessage(messageRequest);
 
         PayoutDao payoutDao = new PayoutDao(appRule.getJdbi());
 

--- a/src/test/java/uk/gov/pay/ledger/pact/event/PayoutFailedEventQueueConsumerIT.java
+++ b/src/test/java/uk/gov/pay/ledger/pact/event/PayoutFailedEventQueueConsumerIT.java
@@ -8,6 +8,7 @@ import au.com.dius.pact.core.model.messaging.MessagePact;
 import com.google.gson.Gson;
 import org.junit.Rule;
 import org.junit.Test;
+import software.amazon.awssdk.services.sqs.model.SendMessageRequest;
 import uk.gov.pay.ledger.payout.dao.PayoutDao;
 import uk.gov.pay.ledger.payout.entity.PayoutEntity;
 import uk.gov.pay.ledger.rule.AppWithPostgresAndSqsRule;
@@ -62,7 +63,11 @@ public class PayoutFailedEventQueueConsumerIT {
     @Test
     @PactVerification({"connector"})
     public void test() {
-        appRule.getSqsClient().sendMessage(SqsTestDocker.getQueueUrl("event-queue"), new String(currentMessage));
+        SendMessageRequest messageRequest = SendMessageRequest.builder()
+                .queueUrl(SqsTestDocker.getQueueUrl("event-queue"))
+                .messageBody(new String(currentMessage))
+                .build();
+        appRule.getSqsClient().sendMessage(messageRequest);
         PayoutDao payoutDao = new PayoutDao(appRule.getJdbi());
 
         await().atMost(1, TimeUnit.SECONDS).until(

--- a/src/test/java/uk/gov/pay/ledger/pact/event/PayoutPaidEventQueueConsumerIT.java
+++ b/src/test/java/uk/gov/pay/ledger/pact/event/PayoutPaidEventQueueConsumerIT.java
@@ -8,6 +8,7 @@ import au.com.dius.pact.core.model.messaging.MessagePact;
 import com.google.gson.Gson;
 import org.junit.Rule;
 import org.junit.Test;
+import software.amazon.awssdk.services.sqs.model.SendMessageRequest;
 import uk.gov.pay.ledger.payout.dao.PayoutDao;
 import uk.gov.pay.ledger.payout.entity.PayoutEntity;
 import uk.gov.pay.ledger.rule.AppWithPostgresAndSqsRule;
@@ -62,7 +63,11 @@ public class PayoutPaidEventQueueConsumerIT {
     @Test
     @PactVerification({"connector"})
     public void test() {
-        appRule.getSqsClient().sendMessage(SqsTestDocker.getQueueUrl("event-queue"), new String(currentMessage));
+        SendMessageRequest messageRequest = SendMessageRequest.builder()
+                .queueUrl(SqsTestDocker.getQueueUrl("event-queue"))
+                .messageBody(new String(currentMessage))
+                .build();
+        appRule.getSqsClient().sendMessage(messageRequest);
         PayoutDao payoutDao = new PayoutDao(appRule.getJdbi());
 
         await().atMost(1, TimeUnit.SECONDS).until(

--- a/src/test/java/uk/gov/pay/ledger/pact/event/PayoutUpdatedEventQueueConsumerIT.java
+++ b/src/test/java/uk/gov/pay/ledger/pact/event/PayoutUpdatedEventQueueConsumerIT.java
@@ -8,6 +8,7 @@ import au.com.dius.pact.core.model.messaging.MessagePact;
 import com.google.gson.Gson;
 import org.junit.Rule;
 import org.junit.Test;
+import software.amazon.awssdk.services.sqs.model.SendMessageRequest;
 import uk.gov.pay.ledger.payout.dao.PayoutDao;
 import uk.gov.pay.ledger.payout.entity.PayoutEntity;
 import uk.gov.pay.ledger.rule.AppWithPostgresAndSqsRule;
@@ -62,7 +63,11 @@ public class PayoutUpdatedEventQueueConsumerIT {
     @Test
     @PactVerification({"connector"})
     public void test() {
-        appRule.getSqsClient().sendMessage(SqsTestDocker.getQueueUrl("event-queue"), new String(currentMessage));
+        SendMessageRequest messageRequest = SendMessageRequest.builder()
+                .queueUrl(SqsTestDocker.getQueueUrl("event-queue"))
+                .messageBody(new String(currentMessage))
+                .build();
+        appRule.getSqsClient().sendMessage(messageRequest);
         PayoutDao payoutDao = new PayoutDao(appRule.getJdbi());
 
         await().atMost(1, TimeUnit.SECONDS).until(

--- a/src/test/java/uk/gov/pay/ledger/pact/event/RefundCreatedByUserEventQueueConsumerIT.java
+++ b/src/test/java/uk/gov/pay/ledger/pact/event/RefundCreatedByUserEventQueueConsumerIT.java
@@ -9,6 +9,7 @@ import com.google.gson.Gson;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import software.amazon.awssdk.services.sqs.model.SendMessageRequest;
 import uk.gov.pay.ledger.app.LedgerConfig;
 import uk.gov.pay.ledger.event.model.ResourceType;
 import uk.gov.pay.ledger.rule.AppWithPostgresAndSqsRule;
@@ -75,8 +76,11 @@ public class RefundCreatedByUserEventQueueConsumerIT {
                 .withExternalId(refundFixture.getParentResourceExternalId())
                 .withTransactionType("PAYMENT")
                 .insert(appRule.getJdbi());
-
-        appRule.getSqsClient().sendMessage(SqsTestDocker.getQueueUrl("event-queue"), new String(currentMessage));
+        SendMessageRequest messageRequest = SendMessageRequest.builder()
+                .queueUrl(SqsTestDocker.getQueueUrl("event-queue"))
+                .messageBody(new String(currentMessage))
+                .build();
+        appRule.getSqsClient().sendMessage(messageRequest);
         TransactionDao transactionDao = new TransactionDao(appRule.getJdbi(), mock(LedgerConfig.class));
 
         await().atMost(1, TimeUnit.SECONDS).until(

--- a/src/test/java/uk/gov/pay/ledger/pact/event/RefundIncludedInPayoutEventQueueConsumerIT.java
+++ b/src/test/java/uk/gov/pay/ledger/pact/event/RefundIncludedInPayoutEventQueueConsumerIT.java
@@ -8,6 +8,7 @@ import au.com.dius.pact.core.model.messaging.MessagePact;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import software.amazon.awssdk.services.sqs.model.SendMessageRequest;
 import uk.gov.pay.ledger.app.LedgerConfig;
 import uk.gov.pay.ledger.event.dao.EventDao;
 import uk.gov.pay.ledger.rule.AppWithPostgresAndSqsRule;
@@ -84,7 +85,11 @@ public class RefundIncludedInPayoutEventQueueConsumerIT {
                 .withParentExternalId(parentExternalId)
                 .insert(appRule.getJdbi());
 
-        appRule.getSqsClient().sendMessage(SqsTestDocker.getQueueUrl("event-queue"), new String(currentMessage));
+        SendMessageRequest messageRequest = SendMessageRequest.builder()
+                .queueUrl(SqsTestDocker.getQueueUrl("event-queue"))
+                .messageBody(new String(currentMessage))
+                .build();
+        appRule.getSqsClient().sendMessage(messageRequest);
 
         TransactionDao transactionDao = new TransactionDao(appRule.getJdbi(), mock(LedgerConfig.class));
         EventDao eventDao = appRule.getJdbi().onDemand(EventDao.class);

--- a/src/test/java/uk/gov/pay/ledger/pact/event/RefundSubmittedEventQueueConsumerIT.java
+++ b/src/test/java/uk/gov/pay/ledger/pact/event/RefundSubmittedEventQueueConsumerIT.java
@@ -8,6 +8,7 @@ import au.com.dius.pact.core.model.messaging.MessagePact;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import software.amazon.awssdk.services.sqs.model.SendMessageRequest;
 import uk.gov.pay.ledger.app.LedgerConfig;
 import uk.gov.pay.ledger.event.model.ResourceType;
 import uk.gov.pay.ledger.rule.AppWithPostgresAndSqsRule;
@@ -69,7 +70,11 @@ public class RefundSubmittedEventQueueConsumerIT {
                 .withExternalId(refundFixture.getParentResourceExternalId())
                 .insert(appRule.getJdbi());
 
-        appRule.getSqsClient().sendMessage(SqsTestDocker.getQueueUrl("event-queue"), new String(currentMessage));
+        SendMessageRequest messageRequest = SendMessageRequest.builder()
+                .queueUrl(SqsTestDocker.getQueueUrl("event-queue"))
+                .messageBody(new String(currentMessage))
+                .build();
+        appRule.getSqsClient().sendMessage(messageRequest);
         TransactionDao transactionDao = new TransactionDao(appRule.getJdbi(), mock(LedgerConfig.class));
 
         await().atMost(1, TimeUnit.SECONDS).until(

--- a/src/test/java/uk/gov/pay/ledger/pact/event/RefundSucceededEventQueueConsumerIT.java
+++ b/src/test/java/uk/gov/pay/ledger/pact/event/RefundSucceededEventQueueConsumerIT.java
@@ -9,6 +9,7 @@ import au.com.dius.pact.core.model.messaging.MessagePact;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import software.amazon.awssdk.services.sqs.model.SendMessageRequest;
 import uk.gov.pay.ledger.app.LedgerConfig;
 import uk.gov.pay.ledger.event.model.ResourceType;
 import uk.gov.pay.ledger.rule.AppWithPostgresAndSqsRule;
@@ -75,7 +76,11 @@ public class RefundSucceededEventQueueConsumerIT {
                 .withTransactionType("PAYMENT")
                 .insert(appRule.getJdbi());
 
-        appRule.getSqsClient().sendMessage(SqsTestDocker.getQueueUrl("event-queue"), new String(currentMessage));
+        SendMessageRequest messageRequest = SendMessageRequest.builder()
+                .queueUrl(SqsTestDocker.getQueueUrl("event-queue"))
+                .messageBody(new String(currentMessage))
+                .build();
+        appRule.getSqsClient().sendMessage(messageRequest);
         TransactionDao transactionDao = new TransactionDao(appRule.getJdbi(), mock(LedgerConfig.class));
 
         await().atMost(1, TimeUnit.SECONDS).until(

--- a/src/test/java/uk/gov/pay/ledger/pact/event/Requested3dsExemptionQueueConsumerIT.java
+++ b/src/test/java/uk/gov/pay/ledger/pact/event/Requested3dsExemptionQueueConsumerIT.java
@@ -7,6 +7,7 @@ import au.com.dius.pact.core.model.annotations.Pact;
 import au.com.dius.pact.core.model.messaging.MessagePact;
 import org.junit.Rule;
 import org.junit.Test;
+import software.amazon.awssdk.services.sqs.model.SendMessageRequest;
 import uk.gov.pay.ledger.app.LedgerConfig;
 import uk.gov.pay.ledger.rule.AppWithPostgresAndSqsRule;
 import uk.gov.pay.ledger.rule.SqsTestDocker;
@@ -66,7 +67,11 @@ public class Requested3dsExemptionQueueConsumerIT {
     public void test() {
         TransactionDao transactionDao = new TransactionDao(appRule.getJdbi(), mock(LedgerConfig.class));
 
-        appRule.getSqsClient().sendMessage(SqsTestDocker.getQueueUrl("event-queue"), new String(currentMessage));
+        SendMessageRequest messageRequest = SendMessageRequest.builder()
+                .queueUrl(SqsTestDocker.getQueueUrl("event-queue"))
+                .messageBody(new String(currentMessage))
+                .build();
+        appRule.getSqsClient().sendMessage(messageRequest);
 
         await().atMost(1, TimeUnit.SECONDS).until(
                 () -> transactionDao.findTransactionByExternalId(externalId).isPresent()

--- a/src/test/java/uk/gov/pay/ledger/pact/event/StatusCorrectedToCapturedToMatchGatewayStatusEventQueueConsumerIT.java
+++ b/src/test/java/uk/gov/pay/ledger/pact/event/StatusCorrectedToCapturedToMatchGatewayStatusEventQueueConsumerIT.java
@@ -9,6 +9,7 @@ import au.com.dius.pact.core.model.messaging.MessagePact;
 import com.google.gson.Gson;
 import org.junit.Rule;
 import org.junit.Test;
+import software.amazon.awssdk.services.sqs.model.SendMessageRequest;
 import uk.gov.pay.ledger.app.LedgerConfig;
 import uk.gov.pay.ledger.event.dao.EventDao;
 import uk.gov.pay.ledger.event.entity.EventEntity;
@@ -70,7 +71,11 @@ public class StatusCorrectedToCapturedToMatchGatewayStatusEventQueueConsumerIT {
     @Test
     @PactVerification({"connector"})
     public void test() {
-        appRule.getSqsClient().sendMessage(SqsTestDocker.getQueueUrl("event-queue"), new String(currentMessage));
+        SendMessageRequest messageRequest = SendMessageRequest.builder()
+                .queueUrl(SqsTestDocker.getQueueUrl("event-queue"))
+                .messageBody(new String(currentMessage))
+                .build();
+        appRule.getSqsClient().sendMessage(messageRequest);
 
         TransactionDao transactionDao = new TransactionDao(appRule.getJdbi(), mock(LedgerConfig.class));
         EventDao eventDao = appRule.getJdbi().onDemand(EventDao.class);

--- a/src/test/java/uk/gov/pay/ledger/pact/event/UserEmailCollectedEventQueueConsumerIT.java
+++ b/src/test/java/uk/gov/pay/ledger/pact/event/UserEmailCollectedEventQueueConsumerIT.java
@@ -7,6 +7,7 @@ import au.com.dius.pact.core.model.annotations.Pact;
 import au.com.dius.pact.core.model.messaging.MessagePact;
 import org.junit.Rule;
 import org.junit.Test;
+import software.amazon.awssdk.services.sqs.model.SendMessageRequest;
 import uk.gov.pay.ledger.app.LedgerConfig;
 import uk.gov.pay.ledger.rule.AppWithPostgresAndSqsRule;
 import uk.gov.pay.ledger.rule.SqsTestDocker;
@@ -65,7 +66,11 @@ public class UserEmailCollectedEventQueueConsumerIT {
     public void test() {
         TransactionDao transactionDao = new TransactionDao(appRule.getJdbi(), mock(LedgerConfig.class));
 
-        appRule.getSqsClient().sendMessage(SqsTestDocker.getQueueUrl("event-queue"), new String(currentMessage));
+        SendMessageRequest messageRequest = SendMessageRequest.builder()
+                .queueUrl(SqsTestDocker.getQueueUrl("event-queue"))
+                .messageBody(new String(currentMessage))
+                .build();
+        appRule.getSqsClient().sendMessage(messageRequest);
 
         await().atMost(1, TimeUnit.SECONDS).until(
                 () -> transactionDao.findTransactionByExternalId(externalId).isPresent()

--- a/src/test/java/uk/gov/pay/ledger/queue/EventQueueTest.java
+++ b/src/test/java/uk/gov/pay/ledger/queue/EventQueueTest.java
@@ -1,12 +1,12 @@
 package uk.gov.pay.ledger.queue;
 
-import com.amazonaws.services.sqs.model.SendMessageResult;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import software.amazon.awssdk.services.sqs.model.SendMessageResponse;
 import uk.gov.pay.ledger.app.LedgerConfig;
 import uk.gov.pay.ledger.app.config.QueueMessageReceiverConfig;
 import uk.gov.pay.ledger.app.config.SqsConfig;
@@ -50,7 +50,7 @@ class EventQueueTest {
                 "\"example_event_details_field\": \"and its value\"" +
                 "}" +
         "}";
-        SendMessageResult messageResult = mock(SendMessageResult.class);
+        SendMessageResponse messageResult = mock(SendMessageResponse.class);
 
         List<QueueMessage> messages = List.of(
                 QueueMessage.of(messageResult, validJsonMessage)

--- a/src/test/java/uk/gov/pay/ledger/queue/sqs/EventQueueIT.java
+++ b/src/test/java/uk/gov/pay/ledger/queue/sqs/EventQueueIT.java
@@ -1,11 +1,11 @@
 package uk.gov.pay.ledger.queue.sqs;
 
-import com.amazonaws.services.sqs.AmazonSQS;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import software.amazon.awssdk.services.sqs.SqsClient;
 import uk.gov.pay.ledger.app.LedgerConfig;
 import uk.gov.pay.ledger.app.config.QueueMessageReceiverConfig;
 import uk.gov.pay.ledger.app.config.SqsConfig;
@@ -30,7 +30,7 @@ public class EventQueueIT {
 
     @RegisterExtension
     public static AppWithPostgresAndSqsExtension rule = new AppWithPostgresAndSqsExtension();
-    private AmazonSQS client;
+    private SqsClient client;
 
     @BeforeEach
     public void setUp() {

--- a/src/test/java/uk/gov/pay/ledger/rule/AppWithPostgresAndSqsRule.java
+++ b/src/test/java/uk/gov/pay/ledger/rule/AppWithPostgresAndSqsRule.java
@@ -1,6 +1,5 @@
 package uk.gov.pay.ledger.rule;
 
-import com.amazonaws.services.sqs.AmazonSQS;
 import io.dropwizard.testing.ConfigOverride;
 import io.dropwizard.testing.junit.DropwizardAppRule;
 import org.jdbi.v3.core.Jdbi;
@@ -9,6 +8,7 @@ import org.junit.rules.ExternalResource;
 import org.junit.rules.RuleChain;
 import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
+import software.amazon.awssdk.services.sqs.SqsClient;
 import uk.gov.pay.ledger.app.LedgerApp;
 import uk.gov.pay.ledger.app.LedgerConfig;
 
@@ -25,13 +25,13 @@ import static uk.gov.pay.ledger.rule.PostgresTestDocker.getOrCreate;
 public class AppWithPostgresAndSqsRule extends ExternalResource {
     private static String CONFIG_PATH = resourceFilePath("config/test-config.yaml");
     private final Jdbi jdbi;
-    private AmazonSQS sqsClient;
+    private SqsClient sqsClient;
     private DropwizardAppRule<LedgerConfig> appRule;
 
     public AppWithPostgresAndSqsRule(ConfigOverride... configOverrides) {
         getOrCreate();
 
-        sqsClient = SqsTestDocker.initialise("event-queue");
+        sqsClient = SqsTestDocker.initialise(List.of("event-queue"));
 
         ConfigOverride[] newConfigOverrides = overrideDatabaseConfig(configOverrides);
         newConfigOverrides = overrideSqsConfig(newConfigOverrides);
@@ -82,7 +82,7 @@ public class AppWithPostgresAndSqsRule extends ExternalResource {
         return jdbi;
     }
 
-    public AmazonSQS getSqsClient() {
+    public SqsClient getSqsClient() {
         return sqsClient;
     }
 }

--- a/src/test/java/uk/gov/pay/ledger/rule/SqsTestDocker.java
+++ b/src/test/java/uk/gov/pay/ledger/rule/SqsTestDocker.java
@@ -1,24 +1,27 @@
 package uk.gov.pay.ledger.rule;
 
-import com.amazonaws.auth.AWSStaticCredentialsProvider;
-import com.amazonaws.auth.BasicAWSCredentials;
-import com.amazonaws.client.builder.AwsClientBuilder;
-import com.amazonaws.services.sqs.AmazonSQS;
-import com.amazonaws.services.sqs.AmazonSQSClientBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.wait.strategy.Wait;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.sqs.SqsClient;
+import software.amazon.awssdk.services.sqs.model.CreateQueueRequest;
+
+import java.net.URI;
+import java.util.List;
 
 public class SqsTestDocker {
     private static final Logger logger = LoggerFactory.getLogger(SqsTestDocker.class);
 
     private static GenericContainer<?> sqsContainer;
 
-    public static AmazonSQS initialise(String... queues) {
+    public static SqsClient initialise(List<String> queueNames) {
         try {
             createContainer();
-            return createQueues(queues);
+            return createQueues(queueNames);
         } catch (Exception e) {
             logger.error("Exception initialising SQS Container - {}", e.getMessage());
             throw new RuntimeException(e);
@@ -42,13 +45,16 @@ public class SqsTestDocker {
         sqsContainer = null;
     }
 
-    private static AmazonSQS createQueues(String... queues) {
-        AmazonSQS amazonSQS = getSqsClient();
-        if (queues != null) {
-            for (String queue : queues) {
-                amazonSQS.createQueue(queue);
-            }
-        }
+    private static SqsClient createQueues(List<String> queueNames) {
+        SqsClient amazonSQS = getSqsClient();
+
+        queueNames.forEach(queueName -> {
+            CreateQueueRequest createQueueRequest = CreateQueueRequest.builder()
+                    .queueName(queueName)
+                    .build();
+
+            amazonSQS.createQueue(createQueueRequest);
+        });
 
         return amazonSQS;
     }
@@ -61,18 +67,14 @@ public class SqsTestDocker {
         return "http://localhost:" + sqsContainer.getMappedPort(9324);
     }
 
-    private static AmazonSQS getSqsClient() {
+    private static SqsClient getSqsClient() {
         // random credentials required by AWS SDK to build SQS client
-        BasicAWSCredentials awsCreds = new BasicAWSCredentials("x", "x");
+        AwsBasicCredentials awsCreds = AwsBasicCredentials.create("x", "x");
 
-        return AmazonSQSClientBuilder.standard()
-                .withCredentials(new AWSStaticCredentialsProvider(awsCreds))
-                .withEndpointConfiguration(
-                        new AwsClientBuilder.EndpointConfiguration(
-                                getEndpoint(),
-                                "region-1"
-                        ))
-                .withRequestHandlers()
+        return SqsClient.builder()
+                .credentialsProvider(StaticCredentialsProvider.create(awsCreds))
+                .endpointOverride(URI.create(getEndpoint()))
+                .region(Region.of("region-1"))
                 .build();
     }
 }

--- a/src/test/java/uk/gov/pay/ledger/util/fixture/QueueDisputeEventFixture.java
+++ b/src/test/java/uk/gov/pay/ledger/util/fixture/QueueDisputeEventFixture.java
@@ -1,9 +1,9 @@
 package uk.gov.pay.ledger.util.fixture;
 
 import au.com.dius.pact.consumer.dsl.PactDslJsonBody;
-import com.amazonaws.services.sqs.AmazonSQS;
 import com.google.common.collect.ImmutableMap;
 import com.google.gson.GsonBuilder;
+import software.amazon.awssdk.services.sqs.SqsClient;
 import uk.gov.pay.ledger.event.entity.EventEntity;
 import uk.gov.pay.ledger.event.model.ResourceType;
 
@@ -103,7 +103,7 @@ public class QueueDisputeEventFixture implements QueueFixture<QueueDisputeEventF
     }
 
     @Override
-    public QueueDisputeEventFixture insert(AmazonSQS sqsClient) {
+    public QueueDisputeEventFixture insert(SqsClient sqsClient) {
         this.sqsMessageId = QueueEventFixtureUtil.insert(sqsClient, eventType, eventDate, serviceId, live, resourceExternalId,
                 parentResourceExternalId, resourceType, eventData);
         return this;

--- a/src/test/java/uk/gov/pay/ledger/util/fixture/QueueFixture.java
+++ b/src/test/java/uk/gov/pay/ledger/util/fixture/QueueFixture.java
@@ -1,9 +1,9 @@
 package uk.gov.pay.ledger.util.fixture;
 
-import com.amazonaws.services.sqs.AmazonSQS;
+import software.amazon.awssdk.services.sqs.SqsClient;
 
 public interface QueueFixture<F, E> {
-    F insert(AmazonSQS sqsClient);
+    F insert(SqsClient sqsClient);
 
     E toEntity();
 }

--- a/src/test/java/uk/gov/pay/ledger/util/fixture/QueuePaymentEventFixture.java
+++ b/src/test/java/uk/gov/pay/ledger/util/fixture/QueuePaymentEventFixture.java
@@ -1,11 +1,11 @@
 package uk.gov.pay.ledger.util.fixture;
 
 import au.com.dius.pact.consumer.dsl.PactDslJsonBody;
-import com.amazonaws.services.sqs.AmazonSQS;
 import com.google.common.collect.ImmutableMap;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonObject;
 import org.apache.commons.lang3.StringUtils;
+import software.amazon.awssdk.services.sqs.SqsClient;
 import uk.gov.pay.ledger.event.entity.EventEntity;
 import uk.gov.pay.ledger.event.model.ResourceType;
 import uk.gov.service.payments.commons.model.Source;
@@ -291,7 +291,7 @@ public class QueuePaymentEventFixture implements QueueFixture<QueuePaymentEventF
     }
 
     @Override
-    public QueuePaymentEventFixture insert(AmazonSQS sqsClient) {
+    public QueuePaymentEventFixture insert(SqsClient sqsClient) {
         this.sqsMessageId = QueueEventFixtureUtil.insert(sqsClient, eventType, eventDate, serviceId, live, resourceExternalId,
                 parentResourceExternalId, resourceType, eventData);
         return this;

--- a/src/test/java/uk/gov/pay/ledger/util/fixture/QueuePayoutEventFixture.java
+++ b/src/test/java/uk/gov/pay/ledger/util/fixture/QueuePayoutEventFixture.java
@@ -1,9 +1,9 @@
 package uk.gov.pay.ledger.util.fixture;
 
 import au.com.dius.pact.consumer.dsl.PactDslJsonBody;
-import com.amazonaws.services.sqs.AmazonSQS;
 import com.google.common.collect.ImmutableMap;
 import com.google.gson.GsonBuilder;
+import software.amazon.awssdk.services.sqs.SqsClient;
 import uk.gov.pay.ledger.event.entity.EventEntity;
 import uk.gov.pay.ledger.event.model.ResourceType;
 
@@ -92,7 +92,7 @@ public class QueuePayoutEventFixture implements QueueFixture<QueuePayoutEventFix
     }
 
     @Override
-    public QueuePayoutEventFixture insert(AmazonSQS sqsClient) {
+    public QueuePayoutEventFixture insert(SqsClient sqsClient) {
         this.sqsMessageId = QueueEventFixtureUtil.insert(sqsClient, eventType, eventDate, serviceId, live, resourceExternalId,
                 EMPTY, resourceType, eventData);
         return this;

--- a/src/test/java/uk/gov/pay/ledger/util/fixture/QueueRefundEventFixture.java
+++ b/src/test/java/uk/gov/pay/ledger/util/fixture/QueueRefundEventFixture.java
@@ -1,9 +1,9 @@
 package uk.gov.pay.ledger.util.fixture;
 
 import au.com.dius.pact.consumer.dsl.PactDslJsonBody;
-import com.amazonaws.services.sqs.AmazonSQS;
 import com.google.common.collect.ImmutableMap;
 import com.google.gson.GsonBuilder;
+import software.amazon.awssdk.services.sqs.SqsClient;
 import uk.gov.pay.ledger.event.entity.EventEntity;
 import uk.gov.pay.ledger.event.model.ResourceType;
 
@@ -139,7 +139,7 @@ public class QueueRefundEventFixture implements QueueFixture<QueueRefundEventFix
     }
 
     @Override
-    public QueueRefundEventFixture insert(AmazonSQS sqsClient) {
+    public QueueRefundEventFixture insert(SqsClient sqsClient) {
         this.sqsMessageId = QueueEventFixtureUtil.insert(sqsClient, eventType, eventDate, null, true, resourceExternalId,
                 parentResourceExternalId, resourceType, eventData);
         return this;


### PR DESCRIPTION
The AWS SDK for Java 1.x is in maintenance mode, effective July 31, 2024.
The AWS SDK for Java 1.x will no longer receive updates for new or existing services.
We need to upgrade pay-ledger to use the AWS SDK version 2 for SQS operations. This will involve updating dependencies, refactoring code to accommodate changes in the SDK, and ensuring the new SDK's methods and patterns are followed. 