### PR TITLE
PP-13991 refactor config to use dropwizard-sentry 4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -182,11 +182,6 @@
             <version>2.13.1</version>
         </dependency>
         <dependency>
-            <groupId>org.dhatim</groupId>
-            <artifactId>dropwizard-sentry</artifactId>
-            <version>2.1.6</version>
-        </dependency>
-        <dependency>
             <groupId>io.swagger.core.v3</groupId>
             <artifactId>swagger-annotations</artifactId>
             <version>${swagger.version}</version>

--- a/src/main/resources/config/config.yaml
+++ b/src/main/resources/config/config.yaml
@@ -59,7 +59,7 @@ logging:
       customFields:
         container: "ledger"
         environment: ${ENVIRONMENT}
-    - type: pay-dropwizard-4-sentry
+    - type: sentry
       threshold: ERROR
       dsn: ${SENTRY_DSN:-https://example.com@dummy/1}
       environment: ${ENVIRONMENT}


### PR DESCRIPTION
We can migrate to 4.x now we use Dropwizard 4, which would allow us to remove some custom code.