### PR TITLE
PP-14434 return rcp reason property in payment response

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -125,14 +125,14 @@
         "filename": "openapi/ledger_spec.yaml",
         "hashed_secret": "9baeb3f7db14ddab5d172149762035c0c022d76d",
         "is_verified": false,
-        "line_number": 1682
+        "line_number": 1685
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/ledger_spec.yaml",
         "hashed_secret": "920734ed7628ef47739eed5571412e2c8271790f",
         "is_verified": false,
-        "line_number": 1758
+        "line_number": 1761
       }
     ],
     "src/main/java/uk/gov/pay/ledger/event/model/Event.java": [
@@ -163,5 +163,5 @@
       }
     ]
   },
-  "generated_at": "2025-04-10T15:31:10Z"
+  "generated_at": "2025-10-01T13:48:53Z"
 }

--- a/openapi/ledger_spec.yaml
+++ b/openapi/ledger_spec.yaml
@@ -1654,6 +1654,9 @@ components:
       properties:
         agreement_id:
           type: string
+        agreement_payment_type:
+          type: string
+          example: recurring
         amount:
           type: integer
           format: int64

--- a/src/main/java/uk/gov/pay/ledger/transaction/model/Payment.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/model/Payment.java
@@ -52,6 +52,7 @@ public class Payment extends Transaction {
     private String agreementId;
     private Boolean disputed;
     private Boolean canRetry;
+    private String agreementPaymentType;
 
     public Payment() {
 
@@ -89,6 +90,7 @@ public class Payment extends Transaction {
         this.agreementId = builder.agreementId;
         this.disputed = builder.disputed;
         this.canRetry = builder.canRetry;
+        this.agreementPaymentType = builder.agreementPaymentType;
     }
 
     @Override
@@ -222,6 +224,10 @@ public class Payment extends Transaction {
         return canRetry;
     }
 
+    public String getAgreementPaymentType() {
+        return agreementPaymentType;
+    }
+
     public static class Builder {
         public String serviceId;
         private Long id;
@@ -259,6 +265,7 @@ public class Payment extends Transaction {
         private String agreementId;
         private Boolean disputed;
         public Boolean canRetry;
+        public  String agreementPaymentType;
 
         public Builder() {
         }
@@ -444,6 +451,11 @@ public class Payment extends Transaction {
 
         public Builder withCanRetry(Boolean canRetry) {
             this.canRetry = canRetry;
+            return this;
+        }
+
+        public Builder withAgreementPaymentType(String agreementPaymentType) {
+            this.agreementPaymentType = agreementPaymentType;
             return this;
         }
     }

--- a/src/main/java/uk/gov/pay/ledger/transaction/model/TransactionFactory.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/model/TransactionFactory.java
@@ -140,6 +140,7 @@ public class TransactionFactory {
                     .withAgreementId(entity.getAgreementId())
                     .withDisputed(safeGetAsBoolean(transactionDetails, "disputed", false))
                     .withCanRetry(safeGetAsBoolean(transactionDetails, "can_retry", null))
+                    .withAgreementPaymentType(safeGetAsString(transactionDetails, "agreement_payment_type"))
                     .build();
         } catch (IOException e) {
             LOGGER.error("Error during the parsing transaction entity data [{}] [errorMessage={}]", entity.getExternalId(), e.getMessage());

--- a/src/main/java/uk/gov/pay/ledger/transaction/search/model/TransactionView.java
+++ b/src/main/java/uk/gov/pay/ledger/transaction/search/model/TransactionView.java
@@ -99,6 +99,8 @@ public class TransactionView {
     private String reason;
     private String agreementId;
     private Boolean disputed;
+    @Schema(example = "recurring")
+    private String agreementPaymentType;
 
     public TransactionView(Builder builder) {
         this.id = builder.id;
@@ -142,6 +144,7 @@ public class TransactionView {
         this.reason = builder.reason;
         this.agreementId = builder.agreementId;
         this.disputed = builder.disputed;
+        this.agreementPaymentType = builder.agreementPaymentType;
     }
 
     public TransactionView() {
@@ -186,10 +189,12 @@ public class TransactionView {
                     .withGatewayPayoutId(payment.getGatewayPayoutId())
                     .withAuthorisationMode(payment.getAuthorisationMode())
                     .withAgreementId(payment.getAgreementId())
-                    .withDisputed(payment.getDisputed());
+                    .withDisputed(payment.getDisputed())
+                    .withAgreementPaymentType(payment.getAgreementPaymentType());
             if (payment.getState() != null) {
                 paymentBuilder = paymentBuilder.withState(ExternalTransactionState.from(payment.getState(), statusVersion, payment.getCanRetry()));
             }
+            
             return paymentBuilder.build();
         }
 
@@ -438,6 +443,10 @@ public class TransactionView {
         return disputed;
     }
 
+    public String getAgreementPaymentType() {
+        return agreementPaymentType;
+    }
+
     public static class Builder {
         private Long id;
         private String gatewayAccountId;
@@ -481,6 +490,7 @@ public class TransactionView {
         private String reason;
         private String agreementId;
         private Boolean disputed;
+        private String agreementPaymentType;
 
         public Builder() {
         }
@@ -691,6 +701,11 @@ public class TransactionView {
 
         public Builder withDisputed(Boolean disputed) {
             this.disputed = disputed;
+            return this;
+        }
+        
+        public Builder withAgreementPaymentType(String agreementPaymentType) {
+            this.agreementPaymentType = agreementPaymentType;
             return this;
         }
     }

--- a/src/test/java/uk/gov/pay/ledger/transaction/resource/TransactionResourceIT.java
+++ b/src/test/java/uk/gov/pay/ledger/transaction/resource/TransactionResourceIT.java
@@ -940,7 +940,7 @@ public class TransactionResourceIT {
                 .body("exemption.outcome.result", is(EXEMPTION_HONOURED.toString()));
     }
 
-        @Test
+    @Test
     public void shouldGetTransactionWithCorporateExemptionRejected() {
         transactionFixture = createTransactionFixtureWithExemption(Exemption3ds.EXEMPTION_REJECTED, Exemption3dsRequested.CORPORATE);
         transactionFixture.insert(rule.getJdbi());
@@ -970,5 +970,23 @@ public class TransactionResourceIT {
                 .body("exemption.requested", is(Boolean.TRUE))
                 .body("exemption.type", is(Exemption3dsRequested.CORPORATE.toString()))
                 .body("exemption.outcome.result", is(EXEMPTION_OUT_OF_SCOPE.toString()));
+    }
+
+    @Test
+    public void shouldGetTransactionWithRecurringPaymentReason() {
+        TransactionFixture transactionFixture = aTransactionFixture()
+                .withTransactionType("PAYMENT")
+                .withAgreementPaymentType("instalment")
+                .withDefaultTransactionDetails()
+                .insert(rule.getJdbi());
+
+        given().port(port)
+                .contentType(JSON)
+                .accept(JSON)
+                .get("/v1/transaction/" + transactionFixture.getExternalId() + "?account_id=" + transactionFixture.getGatewayAccountId())
+                .then()
+                .statusCode(Response.Status.OK.getStatusCode())
+                .contentType(JSON)
+                .body("agreement_payment_type", is("instalment"));
     }
 }

--- a/src/test/java/uk/gov/pay/ledger/util/fixture/TransactionFixture.java
+++ b/src/test/java/uk/gov/pay/ledger/util/fixture/TransactionFixture.java
@@ -87,6 +87,7 @@ public class TransactionFixture implements DbFixture<TransactionFixture, Transac
     private Boolean disputed;
     private AuthorisationMode authorisationMode = AuthorisationMode.WEB;
     private Boolean canRetry;
+    private String agreementPaymentType;
 
     private TransactionFixture() {
     }
@@ -385,6 +386,11 @@ public class TransactionFixture implements DbFixture<TransactionFixture, Transac
         return this;
     }
 
+    public TransactionFixture withAgreementPaymentType(String agreementPaymentType) {
+        this.agreementPaymentType = agreementPaymentType;
+        return this;
+    }
+
     @Override
     public TransactionFixture insert(Jdbi jdbi) {
         jdbi.withHandle(h ->
@@ -542,6 +548,9 @@ public class TransactionFixture implements DbFixture<TransactionFixture, Transac
         );
         Optional.ofNullable(canRetry).ifPresent(
                 canRetry -> transactionDetails.addProperty("can_retry", canRetry)
+        );
+        Optional.ofNullable(agreementPaymentType).ifPresent(
+                agreementPaymentType -> transactionDetails.addProperty("agreement_payment_type", agreementPaymentType)
         );
         return transactionDetails;
     }


### PR DESCRIPTION
If `agreemnt_payment_type` exists in payment details, Ledger returns reason property in payment response objects