### PR TITLE
PP-14434 add rcp reason to a pact test

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -150,7 +150,7 @@
         "filename": "src/test/java/uk/gov/pay/ledger/pact/ContractTest.java",
         "hashed_secret": "fa143a7a660dac99bd4755c518d72306ad2df9d1",
         "is_verified": false,
-        "line_number": 817
+        "line_number": 818
       }
     ],
     "src/test/java/uk/gov/pay/ledger/rule/PostgresTestDocker.java": [
@@ -163,5 +163,5 @@
       }
     ]
   },
-  "generated_at": "2025-10-01T13:48:53Z"
+  "generated_at": "2025-10-02T15:20:58Z"
 }

--- a/src/test/java/uk/gov/pay/ledger/pact/ContractTest.java
+++ b/src/test/java/uk/gov/pay/ledger/pact/ContractTest.java
@@ -687,6 +687,7 @@ public abstract class ContractTest {
                 .withGatewayAccountId(accountId)
                 .withAgreementId(agreementId)
                 .withAuthorisationMode(AuthorisationMode.AGREEMENT)
+                .withAgreementPaymentType("recurring")
                 .withDefaultTransactionDetails()
                 .insert(app.getJdbi());
         TransactionFixture.aTransactionFixture()


### PR DESCRIPTION
Update an existing Pact test between connector and ledger to verify the agreement_payment_type property.