### PR TITLE
PP-15351 Override dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,6 +23,20 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-bom</artifactId>
+                <version>12.1.9</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson</groupId>
+                <artifactId>jackson-bom</artifactId>
+                <version>2.21.3</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
                 <groupId>io.dropwizard</groupId>
                 <artifactId>dropwizard-dependencies</artifactId>
                 <version>5.0.1</version>


### PR DESCRIPTION
## WHAT
- Overrides Jetty and Jackson dependencies due to vulnerable transitive dependencies, and the Dropwizard release with the latest versions of these libraries may take a while.
- Added BOM instead of overriding specific vulnerable dependencies to ensure all modules in the group are aligned to the overridden version.


```
➜  pay-ledger git:(pp_15351_override_dependencies) mvn dependency:tree | grep "jetty-"
[INFO] |  |  \- org.eclipse.jetty:jetty-io:jar:12.1.8:compile
[INFO] |  |  \- org.eclipse.jetty:jetty-http:jar:12.1.8:compile
[INFO] |  +- org.eclipse.jetty:jetty-security:jar:12.1.8:compile
[INFO] |  +- org.eclipse.jetty:jetty-server:jar:12.1.8:compile
[INFO] |  +- org.eclipse.jetty.ee10:jetty-ee10-servlet:jar:12.1.5:compile
[INFO] |  |  \- org.eclipse.jetty:jetty-session:jar:12.1.8:compile
[INFO] |  +- org.eclipse.jetty:jetty-util:jar:12.1.8:compile
[INFO] |  +- org.eclipse.jetty.toolchain.setuid:jetty-setuid-jna:jar:2.0.3:compile
```


```
➜  pay-ledger git:(pp_15351_override_dependencies) mvn dependency:tree | grep "fasterxml"
[INFO] |  |  +- com.fasterxml.jackson.datatype:jackson-datatype-guava:jar:2.21.3:compile
[INFO] |  |  +- com.fasterxml.jackson.datatype:jackson-datatype-jdk8:jar:2.21.3:compile
[INFO] |  |  +- com.fasterxml.jackson.module:jackson-module-parameter-names:jar:2.21.3:compile
[INFO] |  |  \- com.fasterxml.jackson.module:jackson-module-blackbird:jar:2.21.3:compile
[INFO] |  |  +- com.fasterxml:classmate:jar:1.7.3:compile
[INFO] |  |  +- com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:jar:2.21.3:compile
[INFO] |  +- com.fasterxml.jackson.core:jackson-annotations:jar:2.21:compile
[INFO] |  +- com.fasterxml.jackson.core:jackson-databind:jar:2.21.3:compile
[INFO] +- com.fasterxml.jackson.datatype:jackson-datatype-jsr310:jar:2.21.3:compile
[INFO] +- com.fasterxml.jackson.core:jackson-core:jar:2.21.3:compile
[INFO] +- com.fasterxml.jackson.dataformat:jackson-dataformat-csv:jar:2.21.3:compile
[INFO] |  +- com.fasterxml.jackson.jakarta.rs:jackson-jakarta-rs-json-provider:jar:2.21.3:compile
[INFO] |  |  +- com.fasterxml.jackson.jakarta.rs:jackson-jakarta-rs-base:jar:2.21.3:compile
[INFO] |  |  \- com.fasterxml.jackson.module:jackson-module-jakarta-xmlbind-annotations:jar:2.21.3:compile
```